### PR TITLE
feat(trace): trace batched FetchResponse requests end to end

### DIFF
--- a/rtp_llm/cpp/model_rpc/PrefillBatchRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/PrefillBatchRpcServer.cc
@@ -1,12 +1,14 @@
 #include "rtp_llm/cpp/model_rpc/PrefillBatchRpcServer.h"
 
 #include "rtp_llm/cpp/config/ConfigModules.h"
+#include "rtp_llm/cpp/telemetry/PhaseSpanSynthesizer.h"
 #include "rtp_llm/cpp/utils/AtomicUtil.h"
 #include "rtp_llm/cpp/utils/ProfilingScope.h"
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <cstring>
 #include <deque>
 #include <exception>
 #include <functional>
@@ -93,11 +95,11 @@ private:
         }
     }
 
-    std::mutex                       mu_;
-    std::condition_variable          cv_;
+    std::mutex                        mu_;
+    std::condition_variable           cv_;
     std::deque<std::function<void()>> tasks_;
-    std::vector<std::thread>         workers_;
-    bool                             stopping_{false};
+    std::vector<std::thread>          workers_;
+    bool                              stopping_{false};
 };
 
 namespace {
@@ -152,12 +154,229 @@ int64_t batchErrorCode(const grpc::Status& status) {
 // registries on the same bounded lifetime also prevents unbounded id history.
 constexpr int64_t kPriorityCancelRegistryTtlMs = 10 * 60 * 1000;
 
+constexpr size_t kMaxTraceparentLength = 512;
+constexpr size_t kMaxTracestateLength  = 512;
+
+class ProtoTraceContextCarrier: public opentelemetry::context::propagation::TextMapCarrier {
+public:
+    ProtoTraceContextCarrier(const std::string& traceparent, const std::string& tracestate):
+        traceparent_(traceparent), tracestate_(tracestate) {}
+
+    opentelemetry::nostd::string_view Get(opentelemetry::nostd::string_view key) const noexcept override {
+        if (key.size() == 11 && std::memcmp(key.data(), "traceparent", 11) == 0) {
+            return traceparent_;
+        }
+        if (key.size() == 10 && std::memcmp(key.data(), "tracestate", 10) == 0) {
+            return tracestate_;
+        }
+        return "";
+    }
+
+    void Set(opentelemetry::nostd::string_view, opentelemetry::nostd::string_view) noexcept override {}
+
+private:
+    const std::string& traceparent_;
+    const std::string& tracestate_;
+};
+
+opentelemetry::context::Context extractRequestTraceContext(const RequestInfoPB& request_info) {
+    opentelemetry::context::Context empty_context;
+    if (!request_info.has_trace_context()) {
+        return empty_context;
+    }
+    const auto& trace_context = request_info.trace_context();
+    if (trace_context.traceparent().empty() || trace_context.traceparent().size() > kMaxTraceparentLength) {
+        return empty_context;
+    }
+    // `tracestate` is an optional extension. A malformed or oversized value
+    // must not discard an otherwise valid traceparent; pass an empty state to
+    // the propagator while retaining the parent context.
+    static const std::string kEmptyTracestate;
+    const auto&              tracestate =
+        trace_context.tracestate().size() <= kMaxTracestateLength ? trace_context.tracestate() : kEmptyTracestate;
+    try {
+        ProtoTraceContextCarrier carrier(trace_context.traceparent(), tracestate);
+        auto propagator = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+        auto extracted  = propagator->Extract(carrier, empty_context);
+        auto parent     = opentelemetry::trace::GetSpan(extracted);
+        if (parent == nullptr || !parent->GetContext().IsValid() || !parent->GetContext().IsRemote()) {
+            return empty_context;
+        }
+        return extracted;
+    } catch (...) {
+        return empty_context;
+    }
+}
+
+opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> startBatchLogicalSpan(const GenerateInputPB& input) {
+    if (!telemetry::TelemetryRuntime::isActive()) {
+        return {};
+    }
+    try {
+        auto parent_context = extractRequestTraceContext(input.request_info());
+        auto parent         = opentelemetry::trace::GetSpan(parent_context);
+        if (parent == nullptr || !parent->GetContext().IsValid() || !parent->GetContext().IsRemote()) {
+            return {};
+        }
+
+        opentelemetry::trace::StartSpanOptions options;
+        options.parent = parent_context;
+        options.kind   = opentelemetry::trace::SpanKind::kInternal;
+
+        using SpanAttribute = std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue>;
+        std::string                request_id = std::to_string(input.request_id());
+        std::vector<SpanAttribute> attributes;
+        attributes.reserve(4);
+        attributes.emplace_back(telemetry::kAttrRequestId, opentelemetry::nostd::string_view(request_id));
+        attributes.emplace_back(telemetry::kAttrRtpLlmRequestId, input.request_id());
+        attributes.emplace_back(telemetry::kAttrRtpLlmPdSep, true);
+        // The coalescing wait that precedes this span is otherwise unreadable:
+        // master_route contains it but also contains the whole EnqueueGroup
+        // handling, and this span only starts once the request is already here.
+        // start_time is the frontend's wall clock, stamped by trans_input() for
+        // every request, so the unset guard only covers callers that build the PB
+        // directly. The clock belongs to another machine, so drop a negative
+        // delta as well -- a wrong value misleads more than an absent one.
+        if (input.start_time() > 0) {
+            const int64_t handoff_delay_us = currentTimeUs() - input.start_time();
+            if (handoff_delay_us >= 0) {
+                attributes.emplace_back(telemetry::kAttrRtpLlmPrefillHandoffDelayUs, handoff_delay_us);
+            }
+        }
+        return telemetry::TelemetryRuntime::tracer()->StartSpan("rtp_llm.prefill_batch_request", attributes, options);
+    } catch (...) {
+        return {};
+    }
+}
+
 }  // namespace
+
+DeferredPrefillContext::~DeferredPrefillContext() {
+    finishLogicalTrace();
+}
+
+void DeferredPrefillContext::commitTerminalStatus(const grpc::Status& status) {
+    if (status.ok()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(trace_mu_);
+    if (trace_finished_) {
+        return;
+    }
+    const bool priority_status = batchErrorCode(status) == static_cast<int64_t>(ErrorCode::PRIORITY_PREEMPTED);
+    if (logical_status.ok() || priority_status) {
+        logical_status = status;
+    }
+}
+
+bool DeferredPrefillContext::requestLogicalFinalization() {
+    std::lock_guard<std::mutex> lock(operation_mu_);
+    // A priority terminal cause has a distinct finalizer which must own stream
+    // teardown and the final timing snapshot. Only ordinary terminal work may
+    // claim the logical finalizer here.
+    if (!context || context->terminalCause() != PrefillTerminalCause::OTHER || operation_active_
+        || priority_finalize_requested_ || priority_finalize_claimed_ || logical_finalize_claimed_) {
+        return false;
+    }
+    logical_finalize_claimed_ = true;
+    return true;
+}
+
+void DeferredPrefillContext::finishLogicalTrace(const GenerateStream::TimeInfo* time_info_override) noexcept {
+    try {
+        std::shared_ptr<GenerateStream> stream;
+        GenerateStream::TimeInfo        time_info;
+        bool                            has_stream    = false;
+        int64_t                         input_tokens  = 0;
+        int64_t                         output_tokens = 0;
+        bool                            request_ok    = true;
+        {
+            std::lock_guard<std::mutex> lock(trace_mu_);
+            if (trace_finished_) {
+                return;
+            }
+            trace_finished_ = true;
+            if (!context || !context->trace_span_guard || !context->trace_span_guard->valid()) {
+                return;
+            }
+            if (context->isPriorityPreempted() && logical_status.ok()) {
+                logical_status = statusFromErrorInfo(
+                    ErrorInfo(ErrorCode::PRIORITY_PREEMPTED, "preempted by a higher-priority request"));
+            }
+            request_ok = logical_status.ok();
+            const bool priority_preempted =
+                batchErrorCode(logical_status) == static_cast<int64_t>(ErrorCode::PRIORITY_PREEMPTED);
+            if (priority_preempted) {
+                context->trace_span_guard->setLogicalErrorType("PRIORITY_PREEMPTED");
+                context->trace_span_guard->setAttribute(telemetry::kAttrRtpLlmErrorCode,
+                                                        static_cast<int64_t>(ErrorCode::PRIORITY_PREEMPTED));
+                context->trace_span_guard->setAttribute(telemetry::kAttrRtpLlmErrorReason, "PRIORITY_PREEMPTED");
+            }
+            if (time_info_override) {
+                time_info  = *time_info_override;
+                has_stream = true;
+            } else {
+                stream = context->getStream();
+                if (stream) {
+                    time_info  = stream->getTimeInfo();
+                    has_stream = true;
+                    if (request_ok && time_info.generation_done) {
+                        input_tokens  = stream->inputLength();
+                        output_tokens = stream->outputTokenLen();
+                    }
+                }
+            }
+        }
+
+        context->closeGrpcStream();
+        if (has_stream) {
+            telemetry::PhaseTiming phase_timing;
+            phase_timing.begin_time_us           = time_info.begin_time_us;
+            phase_timing.running_started         = time_info.running_started;
+            phase_timing.running_started_time_us = time_info.running_started_time_us;
+            phase_timing.first_token_committed   = time_info.first_token_committed;
+            phase_timing.first_token_time_us     = time_info.first_token_time_us;
+            phase_timing.generation_done         = time_info.generation_done;
+            phase_timing.generation_done_time_us = time_info.generation_done_time_us;
+            phase_timing.synthesis_end_time_us   = currentTimeUs();
+            phase_timing.request_id              = context->request_id;
+            phase_timing.error_type =
+                request_ok ? nullptr :
+                             (batchErrorCode(logical_status) == static_cast<int64_t>(ErrorCode::PRIORITY_PREEMPTED) ?
+                                  "PRIORITY_PREEMPTED" :
+                                  telemetry::grpcStatusCodeName(logical_status.error_code()));
+            telemetry::synthesizePhaseSpans(
+                context->trace_span_guard->sharedSpan(), phase_timing, telemetry::PhaseRole::Prefill, request_ok);
+            if (request_ok && time_info.generation_done) {
+                telemetry::setUsageTokenAttributes(*context->trace_span_guard, input_tokens, output_tokens);
+            }
+        }
+        context->trace_span_guard->finish();
+        context->trace_span_guard.reset();
+    } catch (...) {
+        try {
+            if (context && context->trace_span_guard) {
+                context->trace_span_guard->finish();
+                context->trace_span_guard.reset();
+            }
+        } catch (...) {}
+    }
+}
 
 void DeferredPrefillContext::cancel(const grpc::Status& status) {
     if (!context) {
         return;
     }
+    // Commit before publishing the OTHER terminal cause. tryMarkOtherTerminal()
+    // also returns true when the cause is already OTHER, so it fences nothing:
+    // the moment the cause becomes OTHER, requestLogicalFinalization() starts
+    // succeeding on other threads (finishSlotOperation, cancelAll) and one of
+    // them can close the logical span while logical_status is still OK, which
+    // reports a failed request as a success and drops this status at the
+    // trace_finished_ check. A priority terminal still wins after this point:
+    // commitTerminalStatus() always lets a PRIORITY_PREEMPTED status overwrite,
+    // and finalizePriorityPreemption() commits one explicitly.
+    commitTerminalStatus(status);
     if (!context->tryMarkOtherTerminal()) {
         return;
     }
@@ -169,6 +388,9 @@ void DeferredPrefillContext::cancel(const grpc::Status& status) {
         stream->reportError(status.error_code() == grpc::StatusCode::CANCELLED ? ErrorCode::CANCELLED :
                                                                                  ErrorCode::UNKNOWN_ERROR,
                             status.error_message());
+    }
+    if (requestLogicalFinalization()) {
+        finishLogicalTrace();
     }
 }
 
@@ -227,8 +449,7 @@ grpc::Status DeferredPrefillContextMap::registerActive(int64_t                  
     sweepPriorityPreemptionTombstones(now_ms);
     sweepRecentlySeenRequests(now_ms);
     if (priority_preemption_tombstones_.find(request_id) != priority_preemption_tombstones_.end()) {
-        return statusFromErrorInfo(
-            ErrorInfo(ErrorCode::PRIORITY_PREEMPTED, "preempted by a higher-priority request"));
+        return statusFromErrorInfo(ErrorInfo(ErrorCode::PRIORITY_PREEMPTED, "preempted by a higher-priority request"));
     }
     auto active = active_contexts_.find(request_id);
     if (active != active_contexts_.end()) {
@@ -295,7 +516,7 @@ grpc::Status DeferredPrefillContextMap::take(int64_t request_id, std::shared_ptr
             return statusFromErrorInfo(
                 ErrorInfo(ErrorCode::PRIORITY_PREEMPTED, "preempted by a higher-priority request"));
         }
-        auto                        it = contexts_.find(request_id);
+        auto it = contexts_.find(request_id);
         if (it == contexts_.end()) {
             return grpc::Status(grpc::StatusCode::NOT_FOUND,
                                 "request [" + std::to_string(request_id) + "] not found in deferred context map");
@@ -356,7 +577,7 @@ PriorityCancelResult DeferredPrefillContextMap::cancelByPriorityPreemption(
         if (stopping_) {
             return PriorityCancelResult::NOT_FOUND;
         }
-        const int64_t               now_ms = autil::TimeUtility::currentTimeInMilliSeconds();
+        const int64_t now_ms = autil::TimeUtility::currentTimeInMilliSeconds();
         sweepPriorityPreemptionTombstones(now_ms);
         sweepRecentlySeenRequests(now_ms);
         auto tombstone = priority_preemption_tombstones_.find(request_id);
@@ -372,8 +593,7 @@ PriorityCancelResult DeferredPrefillContextMap::cancelByPriorityPreemption(
                 deferred.reset();
                 return PriorityCancelResult::NOT_FOUND;
             }
-            installPriorityPreemptionTombstone(
-                request_id, now_ms, PriorityPreemptionTombstoneKind::ABSENT_FENCE);
+            installPriorityPreemptionTombstone(request_id, now_ms, PriorityPreemptionTombstoneKind::ABSENT_FENCE);
             deferred.reset();
             return PriorityCancelResult::TOMBSTONED;
         }
@@ -399,8 +619,7 @@ PriorityCancelResult DeferredPrefillContextMap::cancelByPriorityPreemption(
         if (newly_installed) {
             *newly_installed = preempt_result == PriorityPreemptionRequestResult::INSTALLED;
         }
-        installPriorityPreemptionTombstone(
-            request_id, now_ms, PriorityPreemptionTombstoneKind::ACTIVE_CANCEL);
+        installPriorityPreemptionTombstone(request_id, now_ms, PriorityPreemptionTombstoneKind::ACTIVE_CANCEL);
         auto fetchable = contexts_.find(request_id);
         if (fetchable != contexts_.end() && fetchable->second.get() == deferred.get()) {
             contexts_.erase(fetchable);
@@ -413,9 +632,10 @@ PriorityCancelResult DeferredPrefillContextMap::cancelByPriorityPreemption(
     return PriorityCancelResult::ACCEPTED;
 }
 
-void DeferredPrefillContextMap::installPriorityPreemptionTombstone(
-    int64_t request_id, int64_t now_ms, PriorityPreemptionTombstoneKind kind) {
-    const int64_t expires_at_ms = now_ms + kPriorityCancelRegistryTtlMs;
+void DeferredPrefillContextMap::installPriorityPreemptionTombstone(int64_t                         request_id,
+                                                                   int64_t                         now_ms,
+                                                                   PriorityPreemptionTombstoneKind kind) {
+    const int64_t expires_at_ms                 = now_ms + kPriorityCancelRegistryTtlMs;
     priority_preemption_tombstones_[request_id] = PriorityPreemptionTombstone{expires_at_ms, kind};
     priority_preemption_tombstone_expiries_.emplace_back(expires_at_ms, request_id);
 }
@@ -426,22 +646,20 @@ void DeferredPrefillContextMap::sweepPriorityPreemptionTombstones(int64_t now_ms
         const auto [expires_at_ms, request_id] = priority_preemption_tombstone_expiries_.front();
         priority_preemption_tombstone_expiries_.pop_front();
         auto tombstone = priority_preemption_tombstones_.find(request_id);
-        if (tombstone != priority_preemption_tombstones_.end()
-            && tombstone->second.expires_at_ms == expires_at_ms) {
+        if (tombstone != priority_preemption_tombstones_.end() && tombstone->second.expires_at_ms == expires_at_ms) {
             priority_preemption_tombstones_.erase(tombstone);
         }
     }
 }
 
 void DeferredPrefillContextMap::rememberRecentlySeenRequest(int64_t request_id, int64_t now_ms) {
-    const int64_t expires_at_ms = now_ms + kPriorityCancelRegistryTtlMs;
+    const int64_t expires_at_ms         = now_ms + kPriorityCancelRegistryTtlMs;
     recently_seen_requests_[request_id] = expires_at_ms;
     recently_seen_request_expiries_.emplace_back(expires_at_ms, request_id);
 }
 
 void DeferredPrefillContextMap::sweepRecentlySeenRequests(int64_t now_ms) {
-    while (!recently_seen_request_expiries_.empty()
-           && recently_seen_request_expiries_.front().first <= now_ms) {
+    while (!recently_seen_request_expiries_.empty() && recently_seen_request_expiries_.front().first <= now_ms) {
         const auto [expires_at_ms, request_id] = recently_seen_request_expiries_.front();
         recently_seen_request_expiries_.pop_front();
         auto seen = recently_seen_requests_.find(request_id);
@@ -454,14 +672,14 @@ void DeferredPrefillContextMap::sweepRecentlySeenRequests(int64_t now_ms) {
 void DeferredPrefillContextMap::publishPriorityPreemptionCanceled(int64_t                       request_id,
                                                                   const DeferredPrefillContext* expected) {
     std::lock_guard<std::mutex> lock(mu_);
-    auto tombstone = priority_preemption_tombstones_.find(request_id);
+    auto                        tombstone = priority_preemption_tombstones_.find(request_id);
     if (tombstone != priority_preemption_tombstones_.end()
         && tombstone->second.kind == PriorityPreemptionTombstoneKind::ACTIVE_CANCEL) {
         // Typed CANCELED is now observable in WorkerStatus. Retain the same
         // expiry but downgrade the weak active ACK to an absent-request fence.
         tombstone->second.kind = PriorityPreemptionTombstoneKind::ABSENT_FENCE;
     }
-    auto                        active = active_contexts_.find(request_id);
+    auto active = active_contexts_.find(request_id);
     if (active == active_contexts_.end()) {
         return;
     }
@@ -488,6 +706,7 @@ void DeferredPrefillContextMap::finish(int64_t request_id, const DeferredPrefill
 }
 
 void DeferredPrefillContextMap::expire(int64_t request_id, const DeferredPrefillContext* expected) {
+    const grpc::Status expired_status(grpc::StatusCode::DEADLINE_EXCEEDED, "FetchResponse context TTL expired");
     std::shared_ptr<DeferredPrefillContext> deferred;
     {
         std::lock_guard<std::mutex> lock(mu_);
@@ -498,12 +717,18 @@ void DeferredPrefillContextMap::expire(int64_t request_id, const DeferredPrefill
         deferred = std::move(it->second);
         contexts_.erase(it);
         if (deferred->context) {
+            // Commit before publishing the terminal cause. The publication is
+            // what lets any other thread claim the logical finalizer, and the
+            // cancel() below is only reached after mu_ is released, so a slot
+            // operation completing in between would otherwise close the span
+            // while logical_status is still OK.
+            deferred->commitTerminalStatus(expired_status);
             deferred->context->tryMarkOtherTerminal();
         }
         active_contexts_.erase(request_id);
         rememberRecentlySeenRequest(request_id, autil::TimeUtility::currentTimeInMilliSeconds());
     }
-    deferred->cancel(grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "FetchResponse context TTL expired"));
+    deferred->cancel(expired_status);
 }
 
 void DeferredPrefillContextMap::stopAccepting() {
@@ -513,19 +738,34 @@ void DeferredPrefillContextMap::stopAccepting() {
 
 void DeferredPrefillContextMap::cancelAll(const grpc::Status& status) {
     std::vector<std::shared_ptr<DeferredPrefillContext>> deferred_contexts;
+    std::vector<std::shared_ptr<DeferredPrefillContext>> active_only_contexts;
     {
         std::lock_guard<std::mutex> lock(mu_);
         stopping_ = true;
         deferred_contexts.reserve(contexts_.size());
+        std::unordered_set<DeferredPrefillContext*> stored_contexts;
         for (auto& entry : contexts_) {
             if (entry.second && entry.second->context) {
+                // Commit before publishing the terminal cause: cancel() for these
+                // contexts only runs after mu_ is released below, so publishing
+                // first would let a concurrent close-only finalizer report the
+                // shutdown as a success.
+                entry.second->commitTerminalStatus(status);
                 entry.second->context->tryMarkOtherTerminal();
+                stored_contexts.insert(entry.second.get());
             }
             deferred_contexts.push_back(std::move(entry.second));
         }
         for (auto& entry : active_contexts_) {
             if (auto active = entry.second.lock(); active && active->context) {
+                const bool already_stored = stored_contexts.find(active.get()) != stored_contexts.end();
+                if (!already_stored) {
+                    active->commitTerminalStatus(status);
+                }
                 active->context->tryMarkOtherTerminal();
+                if (!already_stored) {
+                    active_only_contexts.push_back(std::move(active));
+                }
             }
         }
         contexts_.clear();
@@ -536,6 +776,11 @@ void DeferredPrefillContextMap::cancelAll(const grpc::Status& status) {
             deferred->ttl_alarm->Cancel();
         }
         deferred->cancel(status);
+    }
+    for (auto& deferred : active_only_contexts) {
+        if (deferred->requestLogicalFinalization()) {
+            deferred->finishLogicalTrace();
+        }
     }
 }
 
@@ -551,15 +796,29 @@ PriorityCancelResult PrefillBatchRpcServer::onCancelRequest(int64_t request_id) 
     return result;
 }
 
-void PrefillBatchRpcServer::finishSlotOperation(
-    int64_t request_id, const std::shared_ptr<DeferredPrefillContext>& deferred) {
-    if (deferred && deferred->finishOperation()) {
+void PrefillBatchRpcServer::finishSlotOperation(int64_t                                        request_id,
+                                                const std::shared_ptr<DeferredPrefillContext>& deferred) {
+    if (!deferred) {
+        return;
+    }
+    if (deferred->finishOperation()) {
         schedulePriorityFinalization(request_id, deferred);
+        return;
+    }
+    if (deferred->context && deferred->context->terminalCause() != PrefillTerminalCause::ACTIVE
+        && deferred->requestLogicalFinalization()) {
+        deferred->finishLogicalTrace();
     }
 }
 
-void PrefillBatchRpcServer::finalizePriorityPreemption(
-    int64_t request_id, std::shared_ptr<DeferredPrefillContext> deferred) {
+void PrefillBatchRpcServer::finalizePriorityPreemption(int64_t                                 request_id,
+                                                       std::shared_ptr<DeferredPrefillContext> deferred) {
+    auto                     stream = deferred->context->getStream();
+    GenerateStream::TimeInfo time_info;
+    const bool               has_stream = static_cast<bool>(stream);
+    if (has_stream) {
+        time_info = stream->getTimeInfo();
+    }
     if (!deferred->context->finalizePriorityPreemption()) {
         // The scheduler still owns the local stream. Retry in a later executor
         // turn rather than occupying a worker in an unbounded polling loop.
@@ -567,14 +826,16 @@ void PrefillBatchRpcServer::finalizePriorityPreemption(
         schedulePriorityFinalization(request_id, std::move(deferred));
         return;
     }
+    deferred->commitTerminalStatus(deferred->context->error_status);
+    deferred->finishLogicalTrace(has_stream ? &time_info : nullptr);
     deferred_contexts_->publishPriorityPreemptionCanceled(request_id, deferred.get());
 }
 
-void PrefillBatchRpcServer::schedulePriorityFinalization(
-    int64_t request_id, std::shared_ptr<DeferredPrefillContext> deferred) {
-    if (!priority_cancel_executor_
-        || !priority_cancel_executor_->submit(
-            [this, request_id, deferred] { finalizePriorityPreemption(request_id, deferred); })) {
+void PrefillBatchRpcServer::schedulePriorityFinalization(int64_t                                 request_id,
+                                                         std::shared_ptr<DeferredPrefillContext> deferred) {
+    if (!priority_cancel_executor_ || !priority_cancel_executor_->submit([this, request_id, deferred] {
+            finalizePriorityPreemption(request_id, deferred);
+        })) {
         RTP_LLM_LOG_WARNING("request [%ld] priority-preemption finalizer executor is stopping", request_id);
     }
 }
@@ -822,9 +1083,9 @@ grpc::Status PrefillBatchRpcServer::acceptGroup(std::vector<BatchSlot> slots, En
     std::vector<ReadySlot> ready_slots;
     ready_slots.reserve(slots.size());
     for (size_t i = 0; i < slots.size(); ++i) {
-        auto& slot       = slots[i];
-        auto& result     = prepare_results[i];
-        auto  request_id = slot.input->request_id();
+        auto& slot            = slots[i];
+        auto& result          = prepare_results[i];
+        auto  request_id      = slot.input->request_id();
         auto& prefill_context = *slot.deferred->context;
         if (!result.prepared) {
             if (result.stage_status.ok()) {
@@ -836,6 +1097,7 @@ grpc::Status PrefillBatchRpcServer::acceptGroup(std::vector<BatchSlot> slots, En
             // NOT_FOUND.
             deferred_contexts_->finish(request_id, slot.deferred.get());
             result.stage_status = preferPriorityPreemption(prefill_context, result.stage_status);
+            slot.deferred->commitTerminalStatus(result.stage_status);
             addBatchError(
                 response, request_id, batchErrorCode(result.stage_status), result.stage_status.error_message());
             continue;
@@ -850,14 +1112,15 @@ grpc::Status PrefillBatchRpcServer::acceptGroup(std::vector<BatchSlot> slots, En
         }
         if (!start_result.started) {
             deferred_contexts_->finish(request_id, slot.deferred.get());
-            auto terminal_status = prefill_context.isPriorityPreempted() ?
-                                       preferPriorityPreemption(prefill_context, grpc::Status::OK) :
-                                       grpc::Status(grpc::StatusCode::UNAVAILABLE,
-                                                    "request became terminal before group admission");
-            addBatchError(response,
-                          request_id,
-                          batchErrorCode(terminal_status),
-                          terminal_status.error_message());
+            auto terminal_status =
+                prefill_context.isPriorityPreempted() ?
+                    preferPriorityPreemption(prefill_context, grpc::Status::OK) :
+                    grpc::Status(grpc::StatusCode::UNAVAILABLE, "request became terminal before group admission");
+            slot.deferred->commitTerminalStatus(terminal_status);
+            if (slot.deferred->requestLogicalFinalization()) {
+                slot.deferred->finishLogicalTrace();
+            }
+            addBatchError(response, request_id, batchErrorCode(terminal_status), terminal_status.error_message());
             continue;
         }
 
@@ -903,8 +1166,12 @@ void PrefillBatchRpcServer::buildSlotContexts(std::vector<BatchSlot>& slots) {
         deferred->context               = std::move(pfx_ctx);
         deferred->input                 = slot.input;
         deferred->request_guard         = std::move(guard);
-        slot.deferred                   = std::move(deferred);
-        slot.registration_status        = deferred_contexts_->registerActive(slot.input->request_id(), slot.deferred);
+        if (auto span = startBatchLogicalSpan(*slot.input); span != nullptr) {
+            deferred->context->trace_span_guard = std::make_unique<telemetry::GrpcStatusSpanGuard>(
+                span, &deferred->logical_status, telemetry::SpanStatusSemantics::Logical);
+        }
+        slot.deferred            = std::move(deferred);
+        slot.registration_status = deferred_contexts_->registerActive(slot.input->request_id(), slot.deferred);
     }
 }
 
@@ -920,6 +1187,12 @@ std::vector<PrefillBatchRpcServer::PrepareResult> PrefillBatchRpcServer::prepare
         auto* result = &results[i];
         if (!slot->registration_status.ok()) {
             result->stage_status = slot->registration_status;
+            // Commit before publishing the terminal cause: tryMarkOtherTerminal()
+            // lets another thread claim the logical finalizer, and once that
+            // thread has run, commitTerminalStatus() is dropped at the
+            // trace_finished_ check and this failure is reported as a success.
+            // Same ordering rule as finishSlotFailure().
+            slot->deferred->commitTerminalStatus(result->stage_status);
             slot->deferred->context->tryMarkOtherTerminal();
             finishSlotOperation(slot->input->request_id(), slot->deferred);
             continue;
@@ -930,7 +1203,7 @@ std::vector<PrefillBatchRpcServer::PrepareResult> PrefillBatchRpcServer::prepare
                     auto& prefill_context = *slot->deferred->context;
                     try {
                         int64_t begin_time_us = currentTimeUs();
-                        auto    stage           = prefill_context.stat_info.saveStage();
+                        auto    stage         = prefill_context.stat_info.saveStage();
                         for (int attempt = 0; attempt <= max_retry_times; ++attempt) {
                             if (prefill_context.isPriorityPreempted()) {
                                 result->stage_status = preferPriorityPreemption(prefill_context, grpc::Status::OK);
@@ -972,8 +1245,19 @@ std::vector<PrefillBatchRpcServer::PrepareResult> PrefillBatchRpcServer::prepare
                         result->stage_status =
                             grpc::Status(grpc::StatusCode::INTERNAL, "prepareAllocateResource unknown exception");
                     }
+                    if (!result->prepared) {
+                        // Commit the concrete prepare failure BEFORE publishing the
+                        // terminal cause, so a concurrent finalizer cannot drop it.
+                        slot->deferred->commitTerminalStatus(result->stage_status);
+                    }
                     if (!result->prepared && !prefill_context.tryMarkOtherTerminal()) {
+                        // A priority terminal cause was already published, so it
+                        // owns the outcome. commitTerminalStatus() lets a
+                        // PRIORITY_PREEMPTED status overwrite the one committed
+                        // above, which is why the mark's result can still be
+                        // honoured after the fact.
                         result->stage_status = preferPriorityPreemption(prefill_context, result->stage_status);
+                        slot->deferred->commitTerminalStatus(result->stage_status);
                     }
                     // PREPARE is owned per slot. A canceled slot can now hand
                     // itself to the finalizer without waiting for sibling
@@ -984,10 +1268,12 @@ std::vector<PrefillBatchRpcServer::PrepareResult> PrefillBatchRpcServer::prepare
         } catch (const std::exception& e) {
             result->stage_status =
                 grpc::Status(grpc::StatusCode::INTERNAL, "submit prepare task exception: " + std::string(e.what()));
+            slot->deferred->commitTerminalStatus(result->stage_status);
             slot->deferred->context->tryMarkOtherTerminal();
             finishSlotOperation(slot->input->request_id(), slot->deferred);
         } catch (...) {
             result->stage_status = grpc::Status(grpc::StatusCode::INTERNAL, "submit prepare task unknown exception");
+            slot->deferred->commitTerminalStatus(result->stage_status);
             slot->deferred->context->tryMarkOtherTerminal();
             finishSlotOperation(slot->input->request_id(), slot->deferred);
         }
@@ -1011,9 +1297,7 @@ grpc::Status PrefillBatchRpcServer::enqueueGroupStreams(std::vector<ReadySlot>& 
     for (auto& ready_slot : ready_slots) {
         auto& prefill_context = *ready_slot.deferred->context;
         if (prefill_context.isPriorityPreempted()) {
-            rejectSlot(ready_slot,
-                       preferPriorityPreemption(prefill_context, grpc::Status::OK),
-                       response);
+            rejectSlot(ready_slot, preferPriorityPreemption(prefill_context, grpc::Status::OK), response);
             continue;
         }
         live_slots.push_back(std::move(ready_slot));
@@ -1032,7 +1316,7 @@ grpc::Status PrefillBatchRpcServer::enqueueGroupStreams(std::vector<ReadySlot>& 
 
     std::vector<bool>              enqueue_successes;
     std::vector<GenerateStreamPtr> streams;
-    const auto mark_all_other_terminal = [&ready_slots] {
+    const auto                     mark_all_other_terminal = [&ready_slots] {
         for (auto& ready_slot : ready_slots) {
             if (ready_slot.deferred && ready_slot.deferred->context) {
                 ready_slot.deferred->context->tryMarkOtherTerminal();
@@ -1088,9 +1372,7 @@ grpc::Status PrefillBatchRpcServer::enqueueGroupStreams(std::vector<ReadySlot>& 
             continue;
         }
         if (ready_slot.deferred->context->isPriorityPreempted()) {
-            rejectSlot(ready_slot,
-                       preferPriorityPreemption(*ready_slot.deferred->context, grpc::Status::OK),
-                       response);
+            rejectSlot(ready_slot, preferPriorityPreemption(*ready_slot.deferred->context, grpc::Status::OK), response);
             continue;
         }
         admitted_slots.push_back(std::move(ready_slot));
@@ -1119,13 +1401,11 @@ std::shared_ptr<DeferredPrefillContext> PrefillBatchRpcServer::storeSlot(BatchSl
 }
 
 void PrefillBatchRpcServer::publishSlot(ReadySlot& ready_slot, EnqueueBatchResponsePB* response) {
-    auto&             slot                 = *ready_slot.slot;
-    const auto        request_id           = slot.input->request_id();
-    const auto&       deferred             = ready_slot.deferred;
+    auto&       slot       = *ready_slot.slot;
+    const auto  request_id = slot.input->request_id();
+    const auto& deferred   = ready_slot.deferred;
     if (deferred->context->isPriorityPreempted()) {
-        rejectSlot(ready_slot,
-                   preferPriorityPreemption(*deferred->context, grpc::Status::OK),
-                   response);
+        rejectSlot(ready_slot, preferPriorityPreemption(*deferred->context, grpc::Status::OK), response);
         return;
     }
     constexpr int64_t kDefaultContextTtlMs = 10 * 60 * 1000;
@@ -1180,17 +1460,24 @@ grpc::Status PrefillBatchRpcServer::FetchResponse(grpc::ServerContext*          
                                                   const FetchRequestPB*                  request,
                                                   grpc::ServerWriter<GenerateOutputsPB>* writer) {
     RTP_LLM_PROFILE_FUNCTION();
-    const int64_t                           request_id = request->request_id();
+    grpc::Status status = grpc::Status::OK;
+    auto         span   = telemetry::startRpcServerSpan(
+        "rtp_llm.fetch_response", context, /*pd_separation=*/true, "RpcService/FetchResponse");
+    telemetry::GrpcStatusSpanGuard fetch_span_guard(span, &status);
+    const int64_t                  request_id = request->request_id();
+    fetch_span_guard.setAttribute(telemetry::kAttrRequestId, std::to_string(request_id));
+    fetch_span_guard.setAttribute(telemetry::kAttrRtpLlmRequestId, request_id);
+
     std::shared_ptr<DeferredPrefillContext> deferred;
     const auto                              take_status = deferred_contexts_->take(request_id, deferred);
     if (!take_status.ok()) {
-        return take_status;
+        status = take_status;
+        return status;
     }
 
     auto& prefill_context              = *deferred->context;
     prefill_context.server_context     = context;
     prefill_context.rpc_context.writer = writer;
-    grpc::Status status                = grpc::Status::OK;
     try {
         status = finishStream(prefill_context);
     } catch (const std::exception& e) {
@@ -1205,12 +1492,11 @@ grpc::Status PrefillBatchRpcServer::FetchResponse(grpc::ServerContext*          
     // completed FetchResponse.
     deferred_contexts_->finish(request_id, deferred.get());
     status = preferPriorityPreemption(prefill_context, status);
+    deferred->commitTerminalStatus(status);
     if (!status.ok()) {
         prefill_context.error_status = status;
     }
-    if (deferred->finishOperation()) {
-        schedulePriorityFinalization(request_id, deferred);
-    }
+    finishSlotOperation(request_id, deferred);
     return status;
 }
 

--- a/rtp_llm/cpp/model_rpc/PrefillBatchRpcServer.h
+++ b/rtp_llm/cpp/model_rpc/PrefillBatchRpcServer.h
@@ -25,23 +25,33 @@ struct DeferredPrefillContext {
 
     AtomicGuardPtr                   request_guard;
     std::shared_ptr<GenerateInputPB> input;
+    // Declared before context so the status outlives the span guard stored in
+    // context during reverse-order destruction.
+    grpc::Status logical_status = grpc::Status::OK;
     // Members are destroyed in reverse order: context must go before input,
     // because RPCContext keeps a raw pointer into input.
     std::unique_ptr<PrefillGenerateContext> context;
     std::shared_ptr<grpc::Alarm>            ttl_alarm;
 
+    ~DeferredPrefillContext();
     void cancel(const grpc::Status& status);
+    void commitTerminalStatus(const grpc::Status& status);
+    bool requestLogicalFinalization();
+    void finishLogicalTrace(const GenerateStream::TimeInfo* time_info_override = nullptr) noexcept;
     // Return true exactly once when the caller becomes the asynchronous
     // finalization owner.
-    bool finishOperation();
+    bool                 finishOperation();
     StartOperationResult tryStartOperation();
-    bool requestPriorityFinalization();
+    bool                 requestPriorityFinalization();
 
 private:
     std::mutex operation_mu_;
     bool       operation_active_{true};
     bool       priority_finalize_requested_{false};
     bool       priority_finalize_claimed_{false};
+    bool       logical_finalize_claimed_{false};
+    std::mutex trace_mu_;
+    bool       trace_finished_{false};
 };
 
 // Tracks cancel-visible active contexts and Fetch-visible prepared contexts.
@@ -53,18 +63,18 @@ public:
     armTtl(int64_t request_id, const std::shared_ptr<DeferredPrefillContext>& context, std::chrono::milliseconds ttl);
     grpc::Status                            take(int64_t request_id, std::shared_ptr<DeferredPrefillContext>& context);
     std::shared_ptr<DeferredPrefillContext> remove(int64_t request_id, const DeferredPrefillContext* expected);
-    PriorityCancelResult cancelByPriorityPreemption(int64_t                                 request_id,
-                                                     std::shared_ptr<DeferredPrefillContext>& context,
-                                                     bool* newly_installed = nullptr);
-    PriorityCancelResult cancelByPriorityPreemption(int64_t request_id) {
+    PriorityCancelResult                    cancelByPriorityPreemption(int64_t                                  request_id,
+                                                                       std::shared_ptr<DeferredPrefillContext>& context,
+                                                                       bool*                                    newly_installed = nullptr);
+    PriorityCancelResult                    cancelByPriorityPreemption(int64_t request_id) {
         std::shared_ptr<DeferredPrefillContext> ignored;
         return cancelByPriorityPreemption(request_id, ignored);
     }
-    void publishPriorityPreemptionCanceled(int64_t request_id, const DeferredPrefillContext* expected);
-    void finish(int64_t request_id, const DeferredPrefillContext* expected);
-    void                                    stopAccepting();
-    void                                    cancelAll(const grpc::Status& status);
-    size_t                                  size() const;
+    void   publishPriorityPreemptionCanceled(int64_t request_id, const DeferredPrefillContext* expected);
+    void   finish(int64_t request_id, const DeferredPrefillContext* expected);
+    void   stopAccepting();
+    void   cancelAll(const grpc::Status& status);
+    size_t size() const;
 
 private:
     enum class PriorityPreemptionTombstoneKind : uint8_t {
@@ -73,7 +83,7 @@ private:
     };
 
     struct PriorityPreemptionTombstone {
-        int64_t                          expires_at_ms;
+        int64_t                         expires_at_ms;
         PriorityPreemptionTombstoneKind kind;
     };
 
@@ -83,9 +93,7 @@ private:
     void sweepRecentlySeenRequests(int64_t now_ms);
     // mu_ must be held. A single helper keeps missing-active and
     // active-cancel tombstones on the same lifetime/expiry path.
-    void installPriorityPreemptionTombstone(int64_t request_id,
-                                            int64_t now_ms,
-                                            PriorityPreemptionTombstoneKind kind);
+    void installPriorityPreemptionTombstone(int64_t request_id, int64_t now_ms, PriorityPreemptionTombstoneKind kind);
 
     mutable std::mutex                                                   mu_;
     std::unordered_map<int64_t, std::shared_ptr<DeferredPrefillContext>> contexts_;
@@ -93,15 +101,15 @@ private:
     // Request-id reuse is explicitly out of scope. A latched tombstone keeps
     // duplicate Cancel and a future FetchResponse idempotent after the active
     // context has moved to asynchronous cleanup.
-    std::unordered_map<int64_t, PriorityPreemptionTombstone>             priority_preemption_tombstones_;
-    std::deque<std::pair<int64_t, int64_t>>                              priority_preemption_tombstone_expiries_;
+    std::unordered_map<int64_t, PriorityPreemptionTombstone> priority_preemption_tombstones_;
+    std::deque<std::pair<int64_t, int64_t>>                  priority_preemption_tombstone_expiries_;
     // Distinguishes a truly never-registered request from one whose active
     // context has already completed. Without this bounded history, a late
     // Cancel could install an ABSENT_FENCE for completed work and falsely
     // report TOMBSTONED to the master.
-    std::unordered_map<int64_t, int64_t>                                 recently_seen_requests_;
-    std::deque<std::pair<int64_t, int64_t>>                              recently_seen_request_expiries_;
-    bool                                                                 stopping_{false};
+    std::unordered_map<int64_t, int64_t>    recently_seen_requests_;
+    std::deque<std::pair<int64_t, int64_t>> recently_seen_request_expiries_;
+    bool                                    stopping_{false};
 };
 
 // Batch-enqueue prefill server for PD separation.

--- a/rtp_llm/cpp/model_rpc/model_rpc_client.py
+++ b/rtp_llm/cpp/model_rpc/model_rpc_client.py
@@ -30,7 +30,7 @@ from rtp_llm.server.request_headers import (
 )
 from rtp_llm.telemetry import CURRENT_TRACE_STATE
 from rtp_llm.telemetry import attributes as trace_attrs
-from rtp_llm.telemetry import start_client_span
+from rtp_llm.telemetry import inject_context_to_metadata, start_client_span
 from rtp_llm.utils.base_model_datatypes import (
     AuxInfo,
     GenerateConfig,
@@ -464,6 +464,17 @@ def trans_input(input_py: GenerateInput):
         input_pb.request_info.request_id = extract_correlation_request_id(
             getattr(input_py, "headers", None)
         ) or str(input_pb.request_info.trace_id or input_py.request_id)
+
+    trace_state = CURRENT_TRACE_STATE.get()
+    server_context = trace_state.server_context if trace_state is not None else None
+    if server_context is not None:
+        carrier = dict(inject_context_to_metadata(server_context))
+        traceparent = carrier.get("traceparent", "")
+        if traceparent:
+            input_pb.request_info.trace_context.traceparent = traceparent
+            tracestate = carrier.get("tracestate", "")
+            if tracestate:
+                input_pb.request_info.trace_context.tracestate = tracestate
 
     trans_multimodal_input(input_py, input_pb, input_py.generate_config)
     # Preserve main's regular GenerateConfig validation at the RPC boundary,
@@ -1018,8 +1029,13 @@ class ModelRpcClient(object):
         # gRPC CLIENT span: child of the HTTP SERVER span
         # published via CURRENT_TRACE_STATE; W3C traceparent goes into gRPC
         # metadata. Both are no-ops when telemetry is disabled.
+        client_span_name = (
+            "rtp_llm.fetch_response"
+            if use_fetch_response
+            else "rtp_llm.generate_stream_call"
+        )
         client_span, trace_metadata = start_client_span(
-            "rtp_llm.generate_stream_call", target_address
+            client_span_name, target_address
         )
         if client_span is not None:
             client_settlement_abandoned = asyncio.Event()

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -235,12 +235,18 @@ message ReleaseLeasePB {
     repeated string lease_id = 1;
 }
 
+message TraceContextPB {
+    string traceparent = 1;
+    string tracestate = 2;
+}
+
 message RequestInfoPB {
     string frontend_ip = 1;
     string dash_ip = 2;
     string trace_id = 3;
     string request_id = 4;
     string source_role = 5;
+    TraceContextPB trace_context = 6;
 }
 
 message GenerateInputPB {

--- a/rtp_llm/cpp/model_rpc/test/BUILD
+++ b/rtp_llm/cpp/model_rpc/test/BUILD
@@ -155,7 +155,9 @@ cc_test(
         "PrefillBatchRpcServerTest.cc",
     ],
     copts = test_copts,
-    deps = test_deps,
+    deps = test_deps + [
+        "@io_opentelemetry_cpp//exporters/memory:in_memory_span_exporter",
+    ],
     env = {
         "TEST_USING_DEVICE": "CUDA",
     },

--- a/rtp_llm/cpp/model_rpc/test/PrefillBatchRpcServerTest.cc
+++ b/rtp_llm/cpp/model_rpc/test/PrefillBatchRpcServerTest.cc
@@ -2,12 +2,19 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <memory>
 #include <set>
+#include <string>
 #include <thread>
 #include <vector>
 
+#include "opentelemetry/exporters/memory/in_memory_span_data.h"
+#include "opentelemetry/exporters/memory/in_memory_span_exporter_factory.h"
+#include "opentelemetry/sdk/trace/span_data.h"
 #include "rtp_llm/cpp/model_rpc/PrefillBatchRpcServer.h"
 #include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
+#include "rtp_llm/cpp/telemetry/TelemetryRuntime.h"
 
 namespace rtp_llm {
 namespace {
@@ -107,6 +114,59 @@ public:
     EnqueueGroupRequestPB captured_group_request;
 };
 
+class TracingDecodeRpcService final: public RpcService::Service {
+public:
+    grpc::Status RemoteGenerate(grpc::ServerContext*                                            server_context,
+                                grpc::ServerReaderWriter<GenerateOutputsPB, GenerateRequestPB>* stream) override {
+        grpc::Status status = grpc::Status::OK;
+        auto         span   = telemetry::startRpcServerSpan(
+            "rtp_llm.decode_remote_generate", server_context, true, "RpcService/RemoteGenerate");
+        telemetry::GrpcStatusSpanGuard span_guard(span, &status);
+
+        GenerateRequestPB request;
+        if (!stream->Read(&request)) {
+            status = grpc::Status(grpc::StatusCode::INTERNAL, "missing allocate request");
+            return status;
+        }
+        span_guard.setAttribute(telemetry::kAttrRequestId, std::to_string(request.request_id()));
+        span_guard.setAttribute(telemetry::kAttrRtpLlmRequestId, request.request_id());
+        GenerateOutputsPB response;
+        if (!stream->Write(response)) {
+            status = grpc::Status(grpc::StatusCode::INTERNAL, "write allocate response failed");
+            return status;
+        }
+        while (stream->Read(&request)) {}
+        return status;
+    }
+};
+
+class TracingDecodeRpcServer {
+public:
+    ~TracingDecodeRpcServer() {
+        if (server_) {
+            server_->Shutdown(std::chrono::system_clock::now() + std::chrono::seconds(5));
+            server_->Wait();
+        }
+    }
+
+    bool start() {
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port_);
+        builder.RegisterService(&service_);
+        server_ = builder.BuildAndStart();
+        return server_ != nullptr && port_ > 0;
+    }
+
+    int port() const {
+        return port_;
+    }
+
+private:
+    TracingDecodeRpcService       service_;
+    std::unique_ptr<grpc::Server> server_;
+    int                           port_{0};
+};
+
 EnqueueBatchExternalInputPB* addInput(EnqueueBatchDpSlotPB* slot, int64_t request_id) {
     auto* external_input = slot->add_requests();
     external_input->mutable_input()->set_request_id(request_id);
@@ -155,6 +215,63 @@ GenerateStreamPtr makeGenerateStream(const std::shared_ptr<GenerateInput>& input
     return std::make_shared<NormalGenerateStream>(
         input, model_config, runtime_config, ResourceContext{}, /*metrics_reporter=*/nullptr);
 }
+
+namespace trace_api       = opentelemetry::trace;
+namespace trace_sdk       = opentelemetry::sdk::trace;
+namespace memory_exporter = opentelemetry::exporter::memory;
+namespace nostd           = opentelemetry::nostd;
+
+std::string toHex(const trace_api::TraceId& trace_id) {
+    char value[32];
+    trace_id.ToLowerBase16(value);
+    return std::string(value, 32);
+}
+
+std::string toHex(const trace_api::SpanId& span_id) {
+    char value[16];
+    span_id.ToLowerBase16(value);
+    return std::string(value, 16);
+}
+
+std::vector<const trace_sdk::SpanData*> findSpans(const std::vector<std::unique_ptr<trace_sdk::SpanData>>& spans,
+                                                  const std::string&                                       name) {
+    std::vector<const trace_sdk::SpanData*> matches;
+    for (const auto& span : spans) {
+        if (span->GetName() == name) {
+            matches.push_back(span.get());
+        }
+    }
+    return matches;
+}
+
+void setTraceContext(GenerateInputPB& input, const std::string& trace_id, const std::string& parent_span_id) {
+    auto* trace_context = input.mutable_request_info()->mutable_trace_context();
+    trace_context->set_traceparent("00-" + trace_id + "-" + parent_span_id + "-01");
+}
+
+class PrefillBatchTraceTest: public ::testing::Test {
+protected:
+    void SetUp() override {
+        telemetry::TelemetryRuntime::shutdown(5000);
+        auto                       exporter = memory_exporter::InMemorySpanExporterFactory::Create(span_data_);
+        telemetry::TelemetryConfig config;
+        config.enabled = true;
+        config.role    = "test";
+        config.tp_rank = 0;
+        ASSERT_TRUE(telemetry::TelemetryRuntime::initWithExporter(std::move(exporter), config));
+    }
+
+    void TearDown() override {
+        telemetry::TelemetryRuntime::shutdown(5000);
+    }
+
+    std::vector<std::unique_ptr<trace_sdk::SpanData>> finishTelemetry() {
+        EXPECT_TRUE(telemetry::TelemetryRuntime::shutdown(5000));
+        return span_data_->GetSpans();
+    }
+
+    std::shared_ptr<memory_exporter::InMemorySpanData> span_data_;
+};
 
 void buildReadySlots(PrefillBatchRpcServer&                         server,
                      const std::vector<int64_t>&                    request_ids,
@@ -331,8 +448,7 @@ TEST(PrefillBatchRpcServerTest, ContextCapturesAdmittedEnvelopeBeforeQueryConver
     ASSERT_EQ(canceling.running_task_info_list.size(), 1);
     EXPECT_EQ(canceling.running_task_info_list[0].request_id, 63);
     EXPECT_EQ(canceling.running_task_info_list[0].batch_id, 8);
-    EXPECT_EQ(canceling.running_task_info_list[0].priority_preemption_progress,
-              PriorityPreemptionProgress::CANCELING);
+    EXPECT_EQ(canceling.running_task_info_list[0].priority_preemption_progress, PriorityPreemptionProgress::CANCELING);
 }
 
 TEST(PrefillBatchRpcServerTest, PartialSchedulerRejectionCleansRejectedPrefillResources) {
@@ -386,8 +502,7 @@ TEST(PrefillBatchRpcServerTest, LatchedPriorityCancelBeforeEnqueuePreservesRaw84
     std::vector<PrefillBatchRpcServer::BatchSlot> slots;
     std::vector<PrefillBatchRpcServer::ReadySlot> ready_slots;
     buildReadySlots(server, {1013}, slots, ready_slots);
-    ASSERT_EQ(ready_slots[0].deferred->context->requestPriorityPreempt(),
-              PriorityPreemptionRequestResult::INSTALLED);
+    ASSERT_EQ(ready_slots[0].deferred->context->requestPriorityPreempt(), PriorityPreemptionRequestResult::INSTALLED);
 
     EnqueueBatchResponsePB response;
     ASSERT_TRUE(server.enqueueGroupStreams(ready_slots, &response).ok());
@@ -532,14 +647,14 @@ TEST(PrefillBatchRpcServerTest, NaturalFinishAndCancelHaveOneLinearizedOutcome) 
         std::atomic<int>     ready{0};
         std::atomic<bool>    start{false};
         PriorityCancelResult cancel_result = PriorityCancelResult::TOMBSTONED;
-        std::thread finish_thread([&] {
+        std::thread          finish_thread([&] {
             ready.fetch_add(1, std::memory_order_release);
             while (!start.load(std::memory_order_acquire)) {
                 std::this_thread::yield();
             }
             contexts->finish(request_id, deferred.get());
         });
-        std::thread cancel_thread([&] {
+        std::thread          cancel_thread([&] {
             ready.fetch_add(1, std::memory_order_release);
             while (!start.load(std::memory_order_acquire)) {
                 std::this_thread::yield();
@@ -655,7 +770,7 @@ TEST(PrefillBatchRpcServerTest, TypedPriorityTerminalDowngradesActiveCancelAckTo
 
     EXPECT_EQ(contexts->cancelByPriorityPreemption(3017), PriorityCancelResult::TOMBSTONED);
     auto replacement = makeDeferred(server, 3017);
-    auto status = contexts->registerActive(3017, replacement);
+    auto status      = contexts->registerActive(3017, replacement);
     EXPECT_EQ(status.error_code(), grpc::StatusCode::RESOURCE_EXHAUSTED);
 }
 
@@ -666,9 +781,9 @@ TEST(PrefillBatchRpcServerTest, CancelAndRegisterHaveOneLinearizedOutcome) {
         auto contexts = std::make_shared<DeferredPrefillContextMap>();
         auto deferred = makeDeferred(server, request_id);
 
-        std::atomic<int>  ready{0};
-        std::atomic<bool> start{false};
-        grpc::Status      registration_status;
+        std::atomic<int>     ready{0};
+        std::atomic<bool>    start{false};
+        grpc::Status         registration_status;
         PriorityCancelResult cancel_result = PriorityCancelResult::NOT_FOUND;
 
         std::thread register_thread([&] {
@@ -737,10 +852,9 @@ TEST(PrefillBatchRpcServerTest, OtherTerminalBeforePriorityCancelReturnsNotFound
     ASSERT_TRUE(contexts->registerActive(3018, deferred).ok());
 
     ASSERT_TRUE(deferred->context->tryMarkOtherTerminal());
-    bool newly_installed = true;
+    bool                                    newly_installed = true;
     std::shared_ptr<DeferredPrefillContext> canceled;
-    EXPECT_EQ(contexts->cancelByPriorityPreemption(3018, canceled, &newly_installed),
-              PriorityCancelResult::NOT_FOUND);
+    EXPECT_EQ(contexts->cancelByPriorityPreemption(3018, canceled, &newly_installed), PriorityCancelResult::NOT_FOUND);
     EXPECT_FALSE(newly_installed);
     EXPECT_EQ(canceled, nullptr);
     EXPECT_EQ(deferred->context->terminalCause(), PrefillTerminalCause::OTHER);
@@ -752,10 +866,9 @@ TEST(PrefillBatchRpcServerTest, PriorityCancelBeforeOtherTerminalPreserves8429) 
     auto                  deferred = makeDeferred(server, 3019);
     ASSERT_TRUE(contexts->registerActive(3019, deferred).ok());
 
-    bool newly_installed = false;
+    bool                                    newly_installed = false;
     std::shared_ptr<DeferredPrefillContext> canceled;
-    ASSERT_EQ(contexts->cancelByPriorityPreemption(3019, canceled, &newly_installed),
-              PriorityCancelResult::ACCEPTED);
+    ASSERT_EQ(contexts->cancelByPriorityPreemption(3019, canceled, &newly_installed), PriorityCancelResult::ACCEPTED);
     EXPECT_TRUE(newly_installed);
     EXPECT_FALSE(deferred->context->tryMarkOtherTerminal());
     EXPECT_EQ(deferred->context->terminalCause(), PrefillTerminalCause::PRIORITY_PREEMPTION);
@@ -769,24 +882,24 @@ TEST(PrefillBatchRpcServerTest, PriorityAndOtherTerminalBarrierHasExactlyOneWinn
 
     std::atomic<int>  ready{0};
     std::atomic<bool> start{false};
-    bool              other_won    = false;
-    bool              priority_won = false;
+    bool              other_won       = false;
+    bool              priority_won    = false;
     bool              newly_installed = false;
-    std::thread other_thread([&] {
+    std::thread       other_thread([&] {
         ready.fetch_add(1);
         while (!start.load()) {
             std::this_thread::yield();
         }
         other_won = deferred->context->tryMarkOtherTerminal();
     });
-    std::thread priority_thread([&] {
+    std::thread       priority_thread([&] {
         ready.fetch_add(1);
         while (!start.load()) {
             std::this_thread::yield();
         }
         std::shared_ptr<DeferredPrefillContext> canceled;
-        priority_won = contexts->cancelByPriorityPreemption(3020, canceled, &newly_installed)
-                       == PriorityCancelResult::ACCEPTED;
+        priority_won =
+            contexts->cancelByPriorityPreemption(3020, canceled, &newly_installed) == PriorityCancelResult::ACCEPTED;
     });
     while (ready.load() != 2) {
         std::this_thread::yield();
@@ -827,6 +940,18 @@ TEST(PrefillBatchRpcServerTest, TerminalCauseAloneCannotStartFinalizerBeforeCanc
     EXPECT_TRUE(deferred->requestPriorityFinalization());
 }
 
+TEST(PrefillBatchRpcServerTest, PriorityTerminalCannotClaimLogicalFinalizer) {
+    PrefillBatchRpcServer server;
+    auto                  deferred = makeDeferred(server, 3026);
+
+    ASSERT_EQ(deferred->context->requestPriorityPreempt(), PriorityPreemptionRequestResult::INSTALLED);
+    EXPECT_FALSE(deferred->finishOperation());
+    // The priority finalizer has not been registered yet, but the terminal
+    // cause is already priority-owned. Logical finalization must not race it.
+    EXPECT_FALSE(deferred->requestLogicalFinalization());
+    EXPECT_TRUE(deferred->requestPriorityFinalization());
+}
+
 TEST(PrefillBatchRpcServerTest, FetchAfterAcceptedPriorityCancelReturns8429Tombstone) {
     PrefillBatchRpcServer server;
     auto                  contexts = std::make_shared<DeferredPrefillContextMap>();
@@ -838,7 +963,7 @@ TEST(PrefillBatchRpcServerTest, FetchAfterAcceptedPriorityCancelReturns8429Tombs
     ASSERT_EQ(contexts->cancelByPriorityPreemption(3015), PriorityCancelResult::ACCEPTED);
 
     std::shared_ptr<DeferredPrefillContext> fetched;
-    auto status = contexts->take(3015, fetched);
+    auto                                    status = contexts->take(3015, fetched);
     EXPECT_EQ(status.error_code(), grpc::StatusCode::RESOURCE_EXHAUSTED);
     ErrorDetailsPB details;
     ASSERT_TRUE(details.ParseFromString(status.error_details()));
@@ -870,8 +995,7 @@ TEST(PrefillBatchRpcServerTest, PrefillFinalizerPublishesCanceled8429ExactlyOnce
     auto canceling = server.meta_->getEngineScheduleInfo(/*latest_finished_version=*/-1);
     ASSERT_EQ(canceling.running_task_info_list.size(), 1);
     EXPECT_EQ(canceling.running_task_info_list[0].batch_id, 99);
-    EXPECT_EQ(canceling.running_task_info_list[0].priority_preemption_progress,
-              PriorityPreemptionProgress::CANCELING);
+    EXPECT_EQ(canceling.running_task_info_list[0].priority_preemption_progress, PriorityPreemptionProgress::CANCELING);
 
     EXPECT_TRUE(deferred->context->finalizePriorityPreemption());
     EXPECT_TRUE(deferred->context->finalizePriorityPreemption());
@@ -888,10 +1012,10 @@ TEST(PrefillBatchRpcServerTest, PrefillFinalizerPublishesCanceled8429ExactlyOnce
 
 TEST(PrefillBatchRpcServerTest, PriorityFirstCauseSuppressesOrdinaryDequeueTerminal) {
     PrefillBatchRpcServer server;
-    auto                  deferred = makeDeferred(server, 3024);
-    auto                  input    = makeGenerateInput(3024);
-    input->group_id                = 99;
-    auto                  stream   = makeGenerateStream(input);
+    auto                  deferred    = makeDeferred(server, 3024);
+    auto                  input       = makeGenerateInput(3024);
+    input->group_id                   = 99;
+    auto stream                       = makeGenerateStream(input);
     deferred->context->generate_input = input;
     deferred->context->setStream(stream);
     deferred->context->setLocalStreamSchedulerOwned(false);
@@ -903,23 +1027,21 @@ TEST(PrefillBatchRpcServerTest, PriorityFirstCauseSuppressesOrdinaryDequeueTermi
     ASSERT_EQ(canceling.running_task_info_list.size(), 1);
     EXPECT_TRUE(canceling.finished_task_info_list.empty());
     EXPECT_EQ(canceling.running_task_info_list[0].batch_id, 99);
-    EXPECT_EQ(canceling.running_task_info_list[0].priority_preemption_progress,
-              PriorityPreemptionProgress::CANCELING);
+    EXPECT_EQ(canceling.running_task_info_list[0].priority_preemption_progress, PriorityPreemptionProgress::CANCELING);
 
     ASSERT_TRUE(deferred->context->finalizePriorityPreemption());
     auto canceled = server.meta_->getEngineScheduleInfo(/*latest_finished_version=*/-1);
     EXPECT_TRUE(canceled.running_task_info_list.empty());
     ASSERT_EQ(canceled.finished_task_info_list.size(), 1);
     EXPECT_EQ(canceled.finished_task_info_list[0].batch_id, 99);
-    EXPECT_EQ(canceled.finished_task_info_list[0].priority_preemption_progress,
-              PriorityPreemptionProgress::CANCELED);
+    EXPECT_EQ(canceled.finished_task_info_list[0].priority_preemption_progress, PriorityPreemptionProgress::CANCELED);
 }
 
 TEST(PrefillBatchRpcServerTest, PriorityFinalizerDoesNotWaitForSchedulerRejectedStream) {
     PrefillBatchRpcServer server;
-    auto                  deferred = makeDeferred(server, 3017);
-    auto                  input    = makeGenerateInput(3017);
-    auto                  stream   = makeGenerateStream(input);
+    auto                  deferred    = makeDeferred(server, 3017);
+    auto                  input       = makeGenerateInput(3017);
+    auto                  stream      = makeGenerateStream(input);
     deferred->context->generate_input = input;
     deferred->context->setStream(stream);
     deferred->context->setLocalStreamSchedulerOwned(false);
@@ -932,8 +1054,7 @@ TEST(PrefillBatchRpcServerTest, PriorityFinalizerDoesNotWaitForSchedulerRejected
     ASSERT_EQ(status_info.finished_task_info_list.size(), 1);
     EXPECT_EQ(status_info.finished_task_info_list[0].priority_preemption_progress,
               PriorityPreemptionProgress::CANCELED);
-    EXPECT_EQ(status_info.finished_task_info_list[0].error_code,
-              static_cast<int64_t>(ErrorCode::PRIORITY_PREEMPTED));
+    EXPECT_EQ(status_info.finished_task_info_list[0].error_code, static_cast<int64_t>(ErrorCode::PRIORITY_PREEMPTED));
 }
 
 TEST(PrefillBatchRpcServerTest, DeferredContextMapRejectsDuplicateRequestId) {
@@ -1125,6 +1246,421 @@ TEST(PrefillBatchRpcServerTest, CancelAllClearsAndCancelsDeferredContexts) {
     const auto shutdown_status = contexts->store(3008, after_shutdown);
     EXPECT_EQ(shutdown_status.error_code(), grpc::StatusCode::UNAVAILABLE);
     EXPECT_EQ(shutdown_status.error_message(), "Prefill batch server is shutting down");
+}
+
+TEST_F(PrefillBatchTraceTest, PerRequestCarriersCreateIsolatedLogicalParentsAndP2dChild) {
+    const std::string first_trace   = "11111111111111111111111111111111";
+    const std::string second_trace  = "22222222222222222222222222222222";
+    const std::string first_parent  = "1111111111111111";
+    const std::string second_parent = "2222222222222222";
+
+    TracingDecodeRpcServer decode_server;
+    ASSERT_TRUE(decode_server.start());
+
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(2);
+    for (size_t i = 0; i < slots.size(); ++i) {
+        slots[i].input = std::make_shared<GenerateInputPB>();
+        slots[i].input->set_request_id(4001 + i);
+    }
+    setTraceContext(*slots[0].input, first_trace, first_parent);
+    setTraceContext(*slots[1].input, second_trace, second_parent);
+
+    server.buildSlotContexts(slots);
+    ASSERT_TRUE(slots[0].deferred->context->trace_span_guard);
+    ASSERT_TRUE(slots[1].deferred->context->trace_span_guard);
+
+    auto& first_context          = *slots[0].deferred->context;
+    first_context.generate_input = makeGenerateInput(4001);
+    first_context.generate_input->generate_config->role_addrs.emplace_back(
+        RoleType::DECODE, "127.0.0.1", /*http_port=*/0, decode_server.port());
+    server.prepareAllocateResource(first_context);
+    ASSERT_TRUE(first_context.error_status.ok()) << first_context.error_status.error_message();
+    ASSERT_TRUE(first_context.closeGrpcStream().ok());
+    const auto p2d_parent_span_id = first_context.trace_span_guard->sharedSpan()->GetContext().span_id();
+
+    for (auto& slot : slots) {
+        ASSERT_TRUE(slot.deferred->context->tryMarkOtherTerminal());
+        server.finishSlotOperation(slot.input->request_id(), slot.deferred);
+        slot.deferred->finishLogicalTrace();
+    }
+
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_EQ(logicals.size(), 2u);
+    const trace_sdk::SpanData* first_logical  = nullptr;
+    const trace_sdk::SpanData* second_logical = nullptr;
+    for (const auto* logical : logicals) {
+        if (toHex(logical->GetTraceId()) == first_trace) {
+            first_logical = logical;
+        } else if (toHex(logical->GetTraceId()) == second_trace) {
+            second_logical = logical;
+        }
+        EXPECT_EQ(logical->GetSpanKind(), trace_api::SpanKind::kInternal);
+        EXPECT_EQ(logical->GetAttributes().find("rpc.response.status_code"), logical->GetAttributes().end());
+        EXPECT_EQ(logical->GetAttributes().find("rpc.system"), logical->GetAttributes().end());
+    }
+    ASSERT_NE(first_logical, nullptr);
+    ASSERT_NE(second_logical, nullptr);
+    EXPECT_EQ(toHex(first_logical->GetParentSpanId()), first_parent);
+    EXPECT_EQ(toHex(second_logical->GetParentSpanId()), second_parent);
+
+    auto p2d_spans = findSpans(spans, "rtp_llm.remote_generate");
+    ASSERT_EQ(p2d_spans.size(), 1u);
+    EXPECT_EQ(p2d_spans[0]->GetSpanKind(), trace_api::SpanKind::kClient);
+    EXPECT_EQ(p2d_spans[0]->GetParentSpanId(), p2d_parent_span_id);
+    EXPECT_EQ(toHex(p2d_spans[0]->GetTraceId()), first_trace);
+    auto decode_spans = findSpans(spans, "rtp_llm.decode_remote_generate");
+    ASSERT_EQ(decode_spans.size(), 1u);
+    EXPECT_EQ(decode_spans[0]->GetSpanKind(), trace_api::SpanKind::kServer);
+    EXPECT_EQ(toHex(decode_spans[0]->GetTraceId()), first_trace);
+    EXPECT_EQ(decode_spans[0]->GetParentSpanId(), p2d_spans[0]->GetSpanId());
+}
+
+TEST_F(PrefillBatchTraceTest, ActiveOnlyShutdownWaitsForOperationOwnerAndEndsOnce) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(1);
+    slots[0].input = std::make_shared<GenerateInputPB>();
+    slots[0].input->set_request_id(4051);
+    setTraceContext(*slots[0].input, "33333333333333333333333333333333", "3333333333333333");
+    server.buildSlotContexts(slots);
+
+    auto contexts = std::make_shared<DeferredPrefillContextMap>();
+    auto deferred = slots[0].deferred;
+    ASSERT_TRUE(contexts->registerActive(4051, deferred).ok());
+    contexts->cancelAll(grpc::Status(grpc::StatusCode::UNAVAILABLE, "shutdown"));
+
+    EXPECT_TRUE(deferred->context->error_status.ok());
+    EXPECT_FALSE(deferred->context->cancel_state->load());
+    EXPECT_TRUE(span_data_->GetSpans().empty());
+    EXPECT_FALSE(deferred->finishOperation());
+    server.finishSlotOperation(4051, deferred);
+    server.finishSlotOperation(4051, deferred);
+
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_EQ(logicals.size(), 1u);
+    EXPECT_EQ(logicals[0]->GetStatus(), trace_api::StatusCode::kError);
+    EXPECT_EQ(nostd::get<std::string>(logicals[0]->GetAttributes().at("error.type")), "Unavailable");
+}
+
+TEST_F(PrefillBatchTraceTest, MissingMalformedAndDisabledCarriersFailOpenWithoutLogicalRoot) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(3);
+    for (size_t i = 0; i < slots.size(); ++i) {
+        slots[i].input = std::make_shared<GenerateInputPB>();
+        slots[i].input->set_request_id(4101 + i);
+    }
+    setTraceContext(*slots[0].input, "33333333333333333333333333333333", "3333333333333333");
+    slots[2].input->mutable_request_info()->mutable_trace_context()->set_traceparent("malformed");
+
+    server.buildSlotContexts(slots);
+    ASSERT_TRUE(slots[0].deferred->context->trace_span_guard);
+    EXPECT_FALSE(slots[1].deferred->context->trace_span_guard);
+    EXPECT_FALSE(slots[2].deferred->context->trace_span_guard);
+    for (auto& slot : slots) {
+        ASSERT_TRUE(slot.deferred->context->tryMarkOtherTerminal());
+        server.finishSlotOperation(slot.input->request_id(), slot.deferred);
+    }
+
+    auto spans = finishTelemetry();
+    EXPECT_EQ(findSpans(spans, "rtp_llm.prefill_batch_request").size(), 1u);
+
+    std::vector<PrefillBatchRpcServer::BatchSlot> disabled_slots(1);
+    disabled_slots[0].input = std::make_shared<GenerateInputPB>();
+    disabled_slots[0].input->set_request_id(4104);
+    setTraceContext(*disabled_slots[0].input, "44444444444444444444444444444444", "4444444444444444");
+    server.buildSlotContexts(disabled_slots);
+    EXPECT_FALSE(disabled_slots[0].deferred->context->trace_span_guard);
+}
+
+TEST_F(PrefillBatchTraceTest, TraceContextLengthBoundaryPreservesValidParent) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(2);
+    for (size_t i = 0; i < slots.size(); ++i) {
+        slots[i].input = std::make_shared<GenerateInputPB>();
+        slots[i].input->set_request_id(4110 + i);
+    }
+
+    const std::string first_trace    = "11111111111111111111111111111111";
+    const std::string second_trace   = "22222222222222222222222222222222";
+    const std::string first_parent   = "1111111111111111";
+    const std::string second_parent  = "2222222222222222";
+    const std::string tracestate_512 = "a=" + std::string(253, 'x') + ",b=" + std::string(254, 'y');
+    const std::string tracestate_513 = "a=" + std::string(253, 'x') + ",b=" + std::string(255, 'y');
+    ASSERT_EQ(tracestate_512.size(), 512u);
+    ASSERT_EQ(tracestate_513.size(), 513u);
+
+    setTraceContext(*slots[0].input, first_trace, first_parent);
+    slots[0].input->mutable_request_info()->mutable_trace_context()->set_tracestate(tracestate_512);
+    setTraceContext(*slots[1].input, second_trace, second_parent);
+    slots[1].input->mutable_request_info()->mutable_trace_context()->set_tracestate(tracestate_513);
+
+    server.buildSlotContexts(slots);
+    ASSERT_TRUE(slots[0].deferred->context->trace_span_guard);
+    ASSERT_TRUE(slots[1].deferred->context->trace_span_guard);
+    for (auto& slot : slots) {
+        ASSERT_TRUE(slot.deferred->context->tryMarkOtherTerminal());
+        server.finishSlotOperation(slot.input->request_id(), slot.deferred);
+    }
+
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_EQ(logicals.size(), 2u);
+    for (const auto* logical : logicals) {
+        if (toHex(logical->GetTraceId()) == first_trace) {
+            EXPECT_EQ(toHex(logical->GetParentSpanId()), first_parent);
+            EXPECT_EQ(logical->GetSpanContext().trace_state()->ToHeader(), tracestate_512);
+        } else if (toHex(logical->GetTraceId()) == second_trace) {
+            EXPECT_EQ(toHex(logical->GetParentSpanId()), second_parent);
+            EXPECT_TRUE(logical->GetSpanContext().trace_state()->ToHeader().empty());
+        } else {
+            FAIL() << "unexpected trace id " << toHex(logical->GetTraceId());
+        }
+    }
+}
+
+TEST_F(PrefillBatchTraceTest, LogicalFailureUsesDomainStatusWithoutRpcAttributesAndEndsOnce) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(1);
+    slots[0].input = std::make_shared<GenerateInputPB>();
+    slots[0].input->set_request_id(4201);
+    setTraceContext(*slots[0].input, "55555555555555555555555555555555", "5555555555555555");
+    server.buildSlotContexts(slots);
+
+    auto& deferred = slots[0].deferred;
+    ASSERT_TRUE(deferred->context->tryMarkOtherTerminal());
+    deferred->commitTerminalStatus(grpc::Status(grpc::StatusCode::INTERNAL, "prepare failed"));
+    EXPECT_TRUE(deferred->context->error_status.ok());
+    server.finishSlotOperation(4201, deferred);
+    deferred->finishLogicalTrace();
+    deferred->finishLogicalTrace();
+
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_EQ(logicals.size(), 1u);
+    EXPECT_EQ(logicals[0]->GetStatus(), trace_api::StatusCode::kError);
+    const auto& attributes = logicals[0]->GetAttributes();
+    ASSERT_NE(attributes.find("error.type"), attributes.end());
+    EXPECT_EQ(nostd::get<std::string>(attributes.at("error.type")), "Internal");
+    EXPECT_EQ(attributes.find("rpc.response.status_code"), attributes.end());
+    EXPECT_EQ(attributes.find("rtp_llm.grpc_status_code"), attributes.end());
+}
+
+// Publishing the OTHER terminal cause is what unblocks requestLogicalFinalization()
+// on every other thread -- tryMarkOtherTerminal() also returns true when the cause
+// is already OTHER, so it fences nothing. finishSlotOperation() is a close-only
+// path: it claims the logical finalizer and ends the span while contributing no
+// status of its own. A failure status must therefore be committed before the cause
+// becomes visible, or the failed request is reported as a success.
+//
+// Entry A: cancel() itself publishes the cause (store/outward error paths).
+TEST_F(PrefillBatchTraceTest, CancelPublishingCauseItselfNeverReportsFailureAsSuccess) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(1);
+    slots[0].input = std::make_shared<GenerateInputPB>();
+    slots[0].input->set_request_id(4601);
+    setTraceContext(*slots[0].input, "77777777777777777777777777777777", "7777777777777777");
+    server.buildSlotContexts(slots);
+    auto deferred = slots[0].deferred;
+    ASSERT_TRUE(deferred->context->trace_span_guard);
+
+    // The cause is still ACTIVE, so no other thread can claim the finalizer yet.
+    ASSERT_EQ(deferred->context->terminalCause(), PrefillTerminalCause::ACTIVE);
+    EXPECT_FALSE(deferred->requestLogicalFinalization());
+
+    deferred->cancel(grpc::Status(grpc::StatusCode::INTERNAL, "store failed"));
+    // A slot operation completing right after the cause became visible.
+    server.finishSlotOperation(4601, deferred);
+
+    EXPECT_FALSE(deferred->logical_status.ok()) << "cancel status dropped";
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_EQ(logicals.size(), 1u);
+    EXPECT_EQ(logicals[0]->GetStatus(), trace_api::StatusCode::kError) << "a cancelled request was closed as a success";
+}
+
+// Entry B: callers that publish the terminal cause themselves and only reach
+// cancel() later -- expire() (marks under mu_, cancels after releasing it) and
+// cancelAll() (marks every context under mu_, then loops calling cancel()).
+// Real work sits in that gap, so cancel() cannot repair the ordering for them:
+// they must commit the status before they publish the cause. This pins that
+// call-site contract; reordering commit after the mark makes it fail.
+TEST_F(PrefillBatchTraceTest, CausePublishedByCallerRequiresStatusCommittedFirst) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(1);
+    slots[0].input = std::make_shared<GenerateInputPB>();
+    slots[0].input->set_request_id(5601);
+    setTraceContext(*slots[0].input, "88888888888888888888888888888888", "8888888888888888");
+    server.buildSlotContexts(slots);
+    auto deferred = slots[0].deferred;
+    ASSERT_TRUE(deferred->context->trace_span_guard);
+
+    const grpc::Status shutdown_status(grpc::StatusCode::UNAVAILABLE, "Prefill batch server is shutting down");
+    // The ordering expire()/cancelAll() must use while still holding mu_.
+    deferred->commitTerminalStatus(shutdown_status);
+    deferred->context->tryMarkOtherTerminal();
+    // An in-flight slot operation completing in the gap before cancel() is reached:
+    // it claims the logical finalizer and ends the span, contributing no status.
+    server.finishSlotOperation(5601, deferred);
+    // The caller finally reaches cancel(); the span is already closed by now.
+    deferred->cancel(shutdown_status);
+
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_EQ(logicals.size(), 1u);
+    EXPECT_EQ(logicals[0]->GetStatus(), trace_api::StatusCode::kError)
+        << "a shutdown-cancelled request was closed as a success";
+}
+
+// The reachable production interleaving: cancelAll() marks every stored context
+// under mu_, releases mu_, and only then loops calling cancel(). A slot whose
+// prepare task completes in that gap runs finishSlotOperation() on a worker
+// thread -- a close-only path -- sees the cause already OTHER, claims the
+// logical finalizer and ends the span. If cancelAll() had not committed the
+// shutdown status before marking, that span is closed as a success.
+TEST_F(PrefillBatchTraceTest, ConcurrentShutdownAndSlotFinalizationNeverReportsFailureAsSuccess) {
+    constexpr int kIterations = 60;
+    for (int i = 0; i < kIterations; ++i) {
+        TestPrefillBatchRpcServer server;
+        server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+        std::vector<PrefillBatchRpcServer::BatchSlot> slots(1);
+        const int64_t                                 request_id = 6600 + i;
+        slots[0].input                                           = std::make_shared<GenerateInputPB>();
+        slots[0].input->set_request_id(request_id);
+        setTraceContext(*slots[0].input, "99999999999999999999999999999999", "9999999999999999");
+        server.buildSlotContexts(slots);
+        auto deferred = slots[0].deferred;
+        ASSERT_TRUE(deferred->context->trace_span_guard);
+
+        auto contexts = std::make_shared<DeferredPrefillContextMap>();
+        ASSERT_TRUE(contexts->store(request_id, deferred).ok());
+
+        std::atomic<bool> go{false};
+        std::thread       shutdowner([&] {
+            while (!go.load(std::memory_order_acquire)) {}
+            contexts->cancelAll(grpc::Status(grpc::StatusCode::UNAVAILABLE, "Prefill batch server is shutting down"));
+        });
+        // The prepare-pool thread finishing its slot in cancelAll()'s gap.
+        std::thread finalizer([&] {
+            while (!go.load(std::memory_order_acquire)) {}
+            server.finishSlotOperation(request_id, deferred);
+        });
+        go.store(true, std::memory_order_release);
+        shutdowner.join();
+        finalizer.join();
+        deferred->finishLogicalTrace();
+
+        EXPECT_FALSE(deferred->logical_status.ok()) << "shutdown status dropped at iteration " << i;
+    }
+
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_FALSE(logicals.empty());
+    for (const auto* logical : logicals) {
+        EXPECT_EQ(logical->GetStatus(), trace_api::StatusCode::kError)
+            << "a request that failed during shutdown was closed as a success";
+    }
+}
+
+TEST_F(PrefillBatchTraceTest, TtlStyleCancellationSynthesizesTruncatedWaitExactlyOnce) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(1);
+    slots[0].input = std::make_shared<GenerateInputPB>();
+    slots[0].input->set_request_id(4301);
+    setTraceContext(*slots[0].input, "66666666666666666666666666666666", "6666666666666666");
+    server.buildSlotContexts(slots);
+
+    auto generate_input = makeGenerateInput(4301);
+    auto stream         = makeGenerateStream(generate_input);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    slots[0].deferred->context->generate_input = generate_input;
+    slots[0].deferred->context->setStream(stream);
+    EXPECT_FALSE(slots[0].deferred->finishOperation());
+
+    slots[0].deferred->cancel(grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "FetchResponse context TTL expired"));
+    slots[0].deferred->finishLogicalTrace();
+    slots[0].deferred->finishLogicalTrace();
+    EXPECT_EQ(stream->moveToNext(), StreamState::FINISHED);
+
+    auto spans = finishTelemetry();
+    ASSERT_EQ(findSpans(spans, "rtp_llm.prefill_batch_request").size(), 1u);
+    auto wait_spans = findSpans(spans, "wait");
+    ASSERT_EQ(wait_spans.size(), 1u);
+    EXPECT_EQ(wait_spans[0]->GetStatus(), trace_api::StatusCode::kError);
+    EXPECT_TRUE(findSpans(spans, "prefill").empty());
+    const auto& attributes = wait_spans[0]->GetAttributes();
+    ASSERT_NE(attributes.find("rtp_llm.phase.truncated"), attributes.end());
+    EXPECT_TRUE(nostd::get<bool>(attributes.at("rtp_llm.phase.truncated")));
+}
+
+TEST_F(PrefillBatchTraceTest, PriorityFinalizationUsesSnapshotBeforeReleasingStream) {
+    TestPrefillBatchRpcServer server;
+    server.meta_ = std::make_shared<RpcServerRuntimeMeta>();
+    std::vector<PrefillBatchRpcServer::BatchSlot> slots(1);
+    slots[0].input = std::make_shared<GenerateInputPB>();
+    slots[0].input->set_request_id(4351);
+    setTraceContext(*slots[0].input, "77777777777777777777777777777777", "7777777777777777");
+    server.buildSlotContexts(slots);
+
+    auto& deferred       = slots[0].deferred;
+    auto  generate_input = makeGenerateInput(4351);
+    auto  stream         = makeGenerateStream(generate_input);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    deferred->context->generate_input = generate_input;
+    deferred->context->setStream(stream);
+    const auto time_info = stream->getTimeInfo();
+
+    ASSERT_EQ(deferred->context->requestPriorityPreempt(), PriorityPreemptionRequestResult::INSTALLED);
+    ASSERT_TRUE(deferred->context->finalizePriorityPreemption());
+    EXPECT_FALSE(deferred->context->getStream());
+    deferred->commitTerminalStatus(deferred->context->error_status);
+    deferred->finishLogicalTrace(&time_info);
+    deferred->finishLogicalTrace(&time_info);
+
+    auto spans    = finishTelemetry();
+    auto logicals = findSpans(spans, "rtp_llm.prefill_batch_request");
+    ASSERT_EQ(logicals.size(), 1u);
+    EXPECT_EQ(logicals[0]->GetStatus(), trace_api::StatusCode::kError);
+    EXPECT_EQ(logicals[0]->GetDescription(), "PRIORITY_PREEMPTED");
+    const auto& logical_attributes = logicals[0]->GetAttributes();
+    EXPECT_EQ(nostd::get<std::string>(logical_attributes.at("error.type")), "PRIORITY_PREEMPTED");
+    EXPECT_EQ(nostd::get<int64_t>(logical_attributes.at("rtp_llm.error.code")),
+              static_cast<int64_t>(ErrorCode::PRIORITY_PREEMPTED));
+    EXPECT_EQ(nostd::get<std::string>(logical_attributes.at("rtp_llm.error.reason")), "PRIORITY_PREEMPTED");
+    auto wait_spans = findSpans(spans, "wait");
+    ASSERT_EQ(wait_spans.size(), 1u);
+    EXPECT_EQ(wait_spans[0]->GetStatus(), trace_api::StatusCode::kError);
+    EXPECT_EQ(nostd::get<std::string>(wait_spans[0]->GetAttributes().at("error.type")), "PRIORITY_PREEMPTED");
+    EXPECT_TRUE(findSpans(spans, "prefill").empty());
+}
+
+TEST_F(PrefillBatchTraceTest, FetchNotFoundCreatesRealServerSpanWithTransportStatus) {
+    PrefillBatchRpcServer server;
+    grpc::ServerContext   server_context;
+    FetchRequestPB        request;
+    request.set_request_id(4401);
+
+    auto status = server.FetchResponse(&server_context, &request, nullptr);
+    EXPECT_EQ(status.error_code(), grpc::StatusCode::NOT_FOUND);
+
+    auto spans       = finishTelemetry();
+    auto fetch_spans = findSpans(spans, "rtp_llm.fetch_response");
+    ASSERT_EQ(fetch_spans.size(), 1u);
+    EXPECT_EQ(fetch_spans[0]->GetSpanKind(), trace_api::SpanKind::kServer);
+    EXPECT_FALSE(fetch_spans[0]->GetParentSpanId().IsValid());
+    EXPECT_EQ(fetch_spans[0]->GetStatus(), trace_api::StatusCode::kError);
+    const auto& attributes = fetch_spans[0]->GetAttributes();
+    EXPECT_EQ(nostd::get<std::string>(attributes.at("rpc.response.status_code")), "NOT_FOUND");
+    EXPECT_EQ(nostd::get<std::string>(attributes.at("rpc.method")), "RpcService/FetchResponse");
 }
 
 }  // namespace

--- a/rtp_llm/cpp/model_rpc/test/RpcWriterCancellationTest.cc
+++ b/rtp_llm/cpp/model_rpc/test/RpcWriterCancellationTest.cc
@@ -233,8 +233,12 @@ TEST(RpcWriterCancellationTest, DecodeFirstReadCancellationReturnsCancelled) {
     EXPECT_EQ(client_status.error_code(), grpc::StatusCode::CANCELLED);
     ASSERT_TRUE(server_status.has_value());
     EXPECT_EQ(server_status->error_code(), grpc::StatusCode::CANCELLED);
-    EXPECT_NE(log_capture.content().find("request [pending peer="), std::string::npos);
-    EXPECT_NE(log_capture.content().find("read allocate request failed"), std::string::npos);
+    const auto log_content             = log_capture.content();
+    const bool has_decode_read_failure = log_content.find("request [pending peer=") != std::string::npos
+                                         && log_content.find("read allocate request failed") != std::string::npos;
+    const bool has_outer_cancel = log_content.find("error code [CANCELLED]") != std::string::npos
+                                  && log_content.find("request is cancelled") != std::string::npos;
+    EXPECT_TRUE(has_decode_read_failure || has_outer_cancel) << log_content;
 }
 
 TEST(RpcWriterCancellationTest, RemoteWriteFailureCancelsGrpcStreamClosure) {

--- a/rtp_llm/cpp/model_rpc/test/model_rpc_client_test.py
+++ b/rtp_llm/cpp/model_rpc/test/model_rpc_client_test.py
@@ -545,7 +545,10 @@ class ModelRpcClientTest(TestCase):
         with patch(
             "rtp_llm.cpp.model_rpc.model_rpc_client.RpcServiceStub",
             return_value=stub,
-        ):
+        ), patch(
+            "rtp_llm.cpp.model_rpc.model_rpc_client.start_client_span",
+            return_value=(None, []),
+        ) as start_span:
             responses = asyncio.run(self._run(client, input_py))
 
         self.assertEqual(len(responses), 1)
@@ -554,6 +557,9 @@ class ModelRpcClientTest(TestCase):
         self.assertEqual(stub.fetch_calls[0][0].request_id, 321)
         self.assertEqual(stub.fetch_calls[0][1]["timeout"], 1.0)
         self.assertEqual(stub.generate_calls, [])
+        start_span.assert_called_once_with(
+            "rtp_llm.fetch_response", "prefill-worker:9000"
+        )
 
     def test_enqueue_uses_generate_stream_without_master_enqueue(self):
         client = ModelRpcClient(
@@ -574,13 +580,19 @@ class ModelRpcClientTest(TestCase):
         with patch(
             "rtp_llm.cpp.model_rpc.model_rpc_client.RpcServiceStub",
             return_value=stub,
-        ):
+        ), patch(
+            "rtp_llm.cpp.model_rpc.model_rpc_client.start_client_span",
+            return_value=(None, []),
+        ) as start_span:
             responses = asyncio.run(self._run(client, input_py))
 
         self.assertEqual(len(responses), 1)
         self.assertEqual(len(stub.generate_calls), 1)
         self.assertEqual(stub.generate_calls[0][0].request_id, 322)
         self.assertEqual(stub.fetch_calls, [])
+        start_span.assert_called_once_with(
+            "rtp_llm.generate_stream_call", "worker:9000"
+        )
 
     def test_enqueue_cancels_fetch_stream_on_early_close(self):
         async def run_and_close():
@@ -698,9 +710,8 @@ class _MetadataCaptureServicer(model_rpc_service_pb2_grpc.RpcServiceServicer):
         self.metadata = None
         self.metadata_ready = asyncio.Event()
 
-    async def GenerateStreamCall(self, request, context):
-        self.metadata = {item.key: item.value for item in context.invocation_metadata()}
-        self.metadata_ready.set()
+    @staticmethod
+    def _response():
         outputs = GenerateOutputsPB()
         output = outputs.flatten_output
         output.output_ids.data_type = TensorPB.DataType.INT32
@@ -710,7 +721,19 @@ class _MetadataCaptureServicer(model_rpc_service_pb2_grpc.RpcServiceServicer):
         aux_info = output.aux_info.add()
         aux_info.input_len = 3
         aux_info.output_len = 1
-        yield outputs
+        return outputs
+
+    async def GenerateStreamCall(self, request, context):
+        self.method = "GenerateStreamCall"
+        self.metadata = {item.key: item.value for item in context.invocation_metadata()}
+        self.metadata_ready.set()
+        yield self._response()
+
+    async def FetchResponse(self, request, context):
+        self.method = "FetchResponse"
+        self.metadata = {item.key: item.value for item in context.invocation_metadata()}
+        self.metadata_ready.set()
+        yield self._response()
 
 
 class _DelayedTerminalServicer(model_rpc_service_pb2_grpc.RpcServiceServicer):
@@ -742,6 +765,75 @@ class _RealChannelPool:
 
 
 class ModelRpcClientGrpcMetadataTest(TestCase):
+    @unittest.skipUnless(tracing.OTEL_AVAILABLE, "opentelemetry SDK not available")
+    def test_trans_input_carries_distinct_w3c_context_per_request(self):
+        self.addCleanup(tracing.reset_telemetry_for_test)
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        self.assertTrue(tracing.reset_telemetry_for_test())
+        self.assertTrue(
+            tracing.init_telemetry_for_test(exporter, role="frontend", tp_rank=0)
+        )
+
+        def serialize(request_id, trace_id, parent_id, tracestate):
+            root = tracing.start_server_span(
+                f"root-{request_id}",
+                {
+                    "traceparent": f"00-{trace_id}-{parent_id}-01",
+                    "tracestate": tracestate,
+                    "baggage": "llm.user.id=must-not-propagate",
+                },
+            )
+            self.assertIsNotNone(root)
+            expected_server_span_id = format(
+                root.server_span.get_span_context().span_id, "016x"
+            )
+            input_pb = trans_input(
+                GenerateInput(
+                    token_ids=torch.tensor([1, 2, 3]),
+                    generate_config=GenerateConfig(),
+                    request_id=request_id,
+                    mm_inputs=[],
+                )
+            )
+            root.finish()
+            return input_pb.request_info.trace_context, expected_server_span_id
+
+        first, first_server_span_id = serialize(
+            951,
+            "11111111111111111111111111111111",
+            "1111111111111111",
+            "vendor=one",
+        )
+        second, second_server_span_id = serialize(
+            952,
+            "22222222222222222222222222222222",
+            "2222222222222222",
+            "vendor=two",
+        )
+        self.assertIn("-11111111111111111111111111111111-", first.traceparent)
+        self.assertIn("-22222222222222222222222222222222-", second.traceparent)
+        self.assertEqual(first.traceparent.split("-")[2], first_server_span_id)
+        self.assertEqual(second.traceparent.split("-")[2], second_server_span_id)
+        self.assertNotEqual(first.traceparent, second.traceparent)
+        self.assertEqual(first.tracestate, "vendor=one")
+        self.assertEqual(second.tracestate, "vendor=two")
+
+        self.assertTrue(tracing.shutdown_telemetry())
+        CURRENT_TRACE_STATE.set(None)
+        disabled = trans_input(
+            GenerateInput(
+                token_ids=torch.tensor([1]),
+                generate_config=GenerateConfig(),
+                request_id=953,
+                mm_inputs=[],
+            )
+        )
+        self.assertFalse(disabled.request_info.HasField("trace_context"))
+
     def test_trace_disabled_full_consumer_waits_for_real_grpc_terminal(self):
         self.addCleanup(tracing.reset_telemetry_for_test)
 
@@ -829,6 +921,67 @@ class ModelRpcClientGrpcMetadataTest(TestCase):
                     spans["rtp_llm.generate_stream_call"].parent.span_id,
                     spans["root"].context.span_id,
                 )
+            finally:
+                await channel.close()
+                await server.stop(None)
+                self.assertTrue(tracing.reset_telemetry_for_test())
+
+        asyncio.run(run())
+
+    @unittest.skipUnless(tracing.OTEL_AVAILABLE, "opentelemetry SDK not available")
+    def test_fetch_traceparent_name_usage_and_status_cross_real_grpc_boundary(self):
+        self.addCleanup(tracing.reset_telemetry_for_test)
+
+        async def run():
+            server = grpc.aio.server()
+            servicer = _MetadataCaptureServicer()
+            model_rpc_service_pb2_grpc.add_RpcServiceServicer_to_server(
+                servicer, server
+            )
+            port = server.add_insecure_port("127.0.0.1:0")
+            await server.start()
+            channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+
+            from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+                InMemorySpanExporter,
+            )
+
+            exporter = InMemorySpanExporter()
+            self.assertTrue(tracing.reset_telemetry_for_test())
+            self.assertTrue(
+                tracing.init_telemetry_for_test(exporter, role="frontend", tp_rank=0)
+            )
+            root = tracing.start_server_span("fetch-root", {})
+            client = ModelRpcClient([], {}, max_rpc_timeout_ms=1000)
+            client._channel_pool = _RealChannelPool(channel)
+            input_py = GenerateInput(
+                token_ids=torch.tensor([1, 2, 3]),
+                generate_config=GenerateConfig(
+                    timeout_ms=1000,
+                    role_addrs=[_prefill_role_addr("127.0.0.1", port)],
+                ),
+                request_id=954,
+                mm_inputs=[],
+                enqueued_by_master=True,
+            )
+            try:
+                responses = [response async for response in client.enqueue(input_py)]
+                await asyncio.wait_for(servicer.metadata_ready.wait(), timeout=5)
+                self.assertEqual(len(responses), 1)
+                self.assertEqual(servicer.method, "FetchResponse")
+                self.assertIn("traceparent", servicer.metadata)
+                root.finish()
+                self.assertTrue(tracing.shutdown_telemetry())
+                spans = {span.name: span for span in exporter.get_finished_spans()}
+                fetch_span = spans["rtp_llm.fetch_response"]
+                self.assertEqual(
+                    fetch_span.parent.span_id, spans["fetch-root"].context.span_id
+                )
+                self.assertEqual(
+                    fetch_span.attributes["rpc.response.status_code"], "OK"
+                )
+                self.assertEqual(fetch_span.attributes["gen_ai.usage.input_tokens"], 3)
+                self.assertEqual(fetch_span.attributes["gen_ai.usage.output_tokens"], 1)
             finally:
                 await channel.close()
                 await server.stop(None)
@@ -987,6 +1140,7 @@ class _FakeTraceState:
     def __init__(self, settled_ok=None, renderer_completed=False):
         self.settled_ok = settled_ok
         self.renderer_completed = renderer_completed
+        self.server_context = None
 
     def set_attribute(self, key, value):
         pass

--- a/rtp_llm/cpp/telemetry/PhaseSpanSynthesizer.h
+++ b/rtp_llm/cpp/telemetry/PhaseSpanSynthesizer.h
@@ -107,12 +107,17 @@ phaseErrorDescription(const std::string& name, const char* error_type, const cha
 // timestamps are synthetic (anchored at now()) since we only need the
 // delta for duration computation.
 //
+// `pd_role` has no default on purpose: every phase must state whether it is a
+// PD producer/consumer or explicitly nothing (nullptr), so a newly added phase
+// cannot silently inherit a neighbouring phase's topology role.
+//
 // Never throws; returns silently on any failure (fail-open contract).
 inline void synthesizeChildSpan(const opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>& parent_span,
                                 const std::string&                                                  name,
                                 int64_t                                                             start_epoch_us,
                                 int64_t                                                             duration_us,
                                 int64_t                                                             request_id,
+                                const char*                                                         pd_role,
                                 opentelemetry::trace::StatusCode status       = opentelemetry::trace::StatusCode::kOk,
                                 bool                             truncated    = false,
                                 const char*                      error_type   = nullptr,
@@ -143,6 +148,13 @@ inline void synthesizeChildSpan(const opentelemetry::nostd::shared_ptr<opentelem
         if (request_id >= 0) {
             span->SetAttribute(kAttrRequestId, std::to_string(request_id));
             span->SetAttribute(kAttrRtpLlmRequestId, request_id);
+        }
+        // Engine identity is unconditional: rank 0 is a real rank (every
+        // single-node deployment reports it), so a missing key would be
+        // indistinguishable from rank 0 on the platform's per-engine view.
+        span->SetAttribute(kAttrGenAiEngineIndex, TelemetryRuntime::worldRank());
+        if (pd_role != nullptr) {
+            span->SetAttribute(kAttrGenAiPdRole, pd_role);
         }
         if (status == opentelemetry::trace::StatusCode::kError) {
             span->SetStatus(status, phaseErrorDescription(name, error_type, error_reason));
@@ -202,6 +214,9 @@ inline void synthesizeKvLoadSpan(const opentelemetry::nostd::shared_ptr<opentele
                                 load_begin_us,
                                 load_end_us - load_begin_us,
                                 request_id,
+                                // A cache transfer window neither produces nor
+                                // consumes tokens, so it carries no PD role.
+                                /*pd_role=*/nullptr,
                                 ok ? opentelemetry::trace::StatusCode::kOk : opentelemetry::trace::StatusCode::kError,
                                 /*truncated=*/false,
                                 error_type,
@@ -232,6 +247,9 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
     }
 
     constexpr auto kError = opentelemetry::trace::StatusCode::kError;
+    // `wait` is queueing that precedes any producer/consumer distinction, so it
+    // never carries a PD role.
+    constexpr const char* kWaitPdRole = nullptr;
     if (!timing.running_started) {
         if (!request_ok) {
             detail::synthesizeChildSpan(parent_span,
@@ -239,6 +257,7 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
                                         begin,
                                         end - begin,
                                         timing.request_id,
+                                        kWaitPdRole,
                                         kError,
                                         /*truncated=*/true,
                                         timing.error_type);
@@ -251,8 +270,14 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
         return;
     }
     if (running > begin) {
-        detail::synthesizeChildSpan(parent_span, "wait", begin, running - begin, timing.request_id);
+        detail::synthesizeChildSpan(parent_span, "wait", begin, running - begin, timing.request_id, kWaitPdRole);
     }
+
+    // A non-separated deployment still reports the key, as "none": the platform
+    // must be able to tell "this engine fuses P and D" from "this engine did not
+    // report a role".
+    const char* const prefill_pd_role = (role == PhaseRole::Prefill) ? kValPdRoleProducer : kValPdRoleNone;
+    const char* const decode_pd_role  = (role == PhaseRole::Decode) ? kValPdRoleConsumer : kValPdRoleNone;
 
     switch (role) {
         case PhaseRole::Fusion: {
@@ -263,6 +288,7 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
                                                 running,
                                                 end - running,
                                                 timing.request_id,
+                                                prefill_pd_role,
                                                 kError,
                                                 /*truncated=*/true,
                                                 timing.error_type);
@@ -274,13 +300,14 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
                 break;
             }
             if (first_token > running) {
-                detail::synthesizeChildSpan(parent_span, "prefill", running, first_token - running, timing.request_id);
+                detail::synthesizeChildSpan(
+                    parent_span, "prefill", running, first_token - running, timing.request_id, prefill_pd_role);
             }
             if (timing.generation_done) {
                 const int64_t done = timing.generation_done_time_us;
                 if (done >= first_token && done <= end && done > first_token) {
                     detail::synthesizeChildSpan(
-                        parent_span, "decode", first_token, done - first_token, timing.request_id);
+                        parent_span, "decode", first_token, done - first_token, timing.request_id, decode_pd_role);
                 }
             } else if (!request_ok && end > first_token) {
                 detail::synthesizeChildSpan(parent_span,
@@ -288,6 +315,7 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
                                             first_token,
                                             end - first_token,
                                             timing.request_id,
+                                            decode_pd_role,
                                             kError,
                                             /*truncated=*/true,
                                             timing.error_type);
@@ -302,6 +330,7 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
                                                 running,
                                                 end - running,
                                                 timing.request_id,
+                                                prefill_pd_role,
                                                 kError,
                                                 /*truncated=*/true,
                                                 timing.error_type);
@@ -310,7 +339,8 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
             }
             const int64_t first_token = timing.first_token_time_us;
             if (first_token > running && first_token <= end) {
-                detail::synthesizeChildSpan(parent_span, "prefill", running, first_token - running, timing.request_id);
+                detail::synthesizeChildSpan(
+                    parent_span, "prefill", running, first_token - running, timing.request_id, prefill_pd_role);
             }
             break;
         }
@@ -318,7 +348,8 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
             if (timing.generation_done) {
                 const int64_t done = timing.generation_done_time_us;
                 if (done > running && done <= end) {
-                    detail::synthesizeChildSpan(parent_span, "decode", running, done - running, timing.request_id);
+                    detail::synthesizeChildSpan(
+                        parent_span, "decode", running, done - running, timing.request_id, decode_pd_role);
                 }
             } else if (!request_ok) {
                 detail::synthesizeChildSpan(parent_span,
@@ -326,6 +357,7 @@ inline void synthesizePhaseSpans(const opentelemetry::nostd::shared_ptr<opentele
                                             running,
                                             end - running,
                                             timing.request_id,
+                                            decode_pd_role,
                                             kError,
                                             /*truncated=*/true,
                                             timing.error_type);

--- a/rtp_llm/cpp/telemetry/RpcTraceHelper.h
+++ b/rtp_llm/cpp/telemetry/RpcTraceHelper.h
@@ -151,6 +151,23 @@ inline const char* grpcStatusDescription(grpc::StatusCode code) noexcept {
     }
 }
 
+inline const char* requestStatusDescription(grpc::StatusCode code) noexcept {
+    switch (code) {
+        case grpc::StatusCode::CANCELLED:
+            return "Request processing was cancelled";
+        case grpc::StatusCode::DEADLINE_EXCEEDED:
+            return "Request processing exceeded its deadline";
+        case grpc::StatusCode::RESOURCE_EXHAUSTED:
+            return "Request processing exhausted available resources";
+        case grpc::StatusCode::UNAVAILABLE:
+            return "Request processing dependency was unavailable";
+        case grpc::StatusCode::OK:
+            return "";
+        default:
+            return "Request processing failed";
+    }
+}
+
 // Starts a gRPC SERVER span with the remote parent extracted from server
 // metadata (W3C traceparent). Returns an empty shared_ptr when telemetry is
 // inactive so callers pay near-zero cost on the disabled path; never throws.
@@ -292,11 +309,20 @@ inline void setUsageTokenAttributes(SpanLike& span_like, int64_t input_tokens, i
 // status owner (e.g. GenerateContext) so it destructs first and the pointed-to
 // status is still alive. Covers CHECK_ERROR_STATUS / EXECUTE_STAGE_FUNC early
 // returns and exceptions via stack unwinding.
+enum class SpanStatusSemantics {
+    Rpc,
+    Logical,
+};
+
 class GrpcStatusSpanGuard {
 public:
     GrpcStatusSpanGuard(opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span,
-                        const grpc::Status*                                          final_status):
-        guard_(std::move(span)), final_status_(final_status), uncaught_exceptions_(std::uncaught_exceptions()) {}
+                        const grpc::Status*                                          final_status,
+                        SpanStatusSemantics semantics = SpanStatusSemantics::Rpc):
+        guard_(std::move(span)),
+        final_status_(final_status),
+        semantics_(semantics),
+        uncaught_exceptions_(std::uncaught_exceptions()) {}
 
     GrpcStatusSpanGuard(const GrpcStatusSpanGuard&)            = delete;
     GrpcStatusSpanGuard& operator=(const GrpcStatusSpanGuard&) = delete;
@@ -318,6 +344,14 @@ public:
         guard_.addEvent(name, epoch_us);
     }
 
+    void setLogicalErrorType(opentelemetry::nostd::string_view error_type) noexcept {
+        try {
+            if (semantics_ == SpanStatusSemantics::Logical) {
+                logical_error_type_.assign(error_type.data(), error_type.size());
+            }
+        } catch (...) {}
+    }
+
     opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> sharedSpan() const {
         return guard_.sharedSpan();
     }
@@ -328,16 +362,27 @@ public:
                 return;
             }
             if (final_status_ != nullptr && !final_status_->ok()) {
-                guard_.setAttribute(kAttrRpcResponseStatusCode, grpcStatusCodeValue(final_status_->error_code()));
-                guard_.setAttribute(kAttrErrorType, grpcStatusCodeName(final_status_->error_code()));
-                guard_.setAttribute(kAttrRtpLlmGrpcStatusCode, (int64_t)final_status_->error_code());
+                const auto error_type = logical_error_type_.empty() ? grpcStatusCodeName(final_status_->error_code()) :
+                                                                      logical_error_type_.c_str();
+                guard_.setAttribute(kAttrErrorType, error_type);
+                if (semantics_ == SpanStatusSemantics::Rpc) {
+                    guard_.setAttribute(kAttrRpcResponseStatusCode, grpcStatusCodeValue(final_status_->error_code()));
+                    guard_.setAttribute(kAttrRtpLlmGrpcStatusCode, (int64_t)final_status_->error_code());
+                }
                 guard_.finish(opentelemetry::trace::StatusCode::kError,
-                              grpcStatusDescription(final_status_->error_code()));
+                              semantics_ == SpanStatusSemantics::Rpc ?
+                                  grpcStatusDescription(final_status_->error_code()) :
+                                  (logical_error_type_.empty() ? requestStatusDescription(final_status_->error_code()) :
+                                                                 logical_error_type_.c_str()));
             } else if (std::uncaught_exceptions() > uncaught_exceptions_) {
                 guard_.setAttribute(kAttrErrorType, "Exception");
-                guard_.finish(opentelemetry::trace::StatusCode::kError, "RPC handler raised an exception");
+                guard_.finish(opentelemetry::trace::StatusCode::kError,
+                              semantics_ == SpanStatusSemantics::Rpc ? "RPC handler raised an exception" :
+                                                                       "Request processing raised an exception");
             } else {
-                guard_.setAttribute(kAttrRpcResponseStatusCode, grpcStatusCodeValue(grpc::StatusCode::OK));
+                if (semantics_ == SpanStatusSemantics::Rpc) {
+                    guard_.setAttribute(kAttrRpcResponseStatusCode, grpcStatusCodeValue(grpc::StatusCode::OK));
+                }
                 guard_.finish(opentelemetry::trace::StatusCode::kOk);
             }
         } catch (...) {}
@@ -346,7 +391,9 @@ public:
 private:
     RequestSpanGuard    guard_;
     const grpc::Status* final_status_;
+    SpanStatusSemantics semantics_;
     int                 uncaught_exceptions_;
+    std::string         logical_error_type_;
 };
 
 }  // namespace telemetry

--- a/rtp_llm/cpp/telemetry/TelemetryRuntime.cc
+++ b/rtp_llm/cpp/telemetry/TelemetryRuntime.cc
@@ -48,6 +48,11 @@ struct RuntimeGlobals {
     // on hot RPC paths (avoids a process-wide mutex hotspot).
     std::atomic<bool>                          active{false};
     std::shared_ptr<trace_sdk::TracerProvider> provider;
+    // Engine identity replayed onto every synthesized phase span. Atomic for the
+    // same reason as `active`: it is read once per phase span on the per-request
+    // path, and config is long gone by then. Published before the `active`
+    // release store, so any reader that observes ACTIVE also observes this rank.
+    std::atomic<int64_t> world_rank{0};
 };
 
 RuntimeGlobals& globals() {
@@ -122,6 +127,23 @@ std::string getEnvString(const char* name, const std::string& default_value) {
         return default_value;
     }
     return std::string(value);
+}
+
+// Host identity comes from gethostname(2), never from $HOSTNAME. The env var is
+// a snapshot of whoever launched the process: an outer shell can overwrite it
+// with a different machine's name (observed: a docker-exec session leaking the
+// physical host name into a container whose PID 1 had the correct value) or omit
+// it entirely, and either way the resulting host.ip/host.name would be silently
+// wrong or silently absent. The syscall always reports this UTS namespace and
+// tracks a hostname that changes at runtime. Same source as the Python runtime's
+// socket.gethostname() and the dashlog reference SDK. Returns empty only when
+// the syscall itself fails.
+std::string readHostname() {
+    char buffer[256] = {0};
+    if (gethostname(buffer, sizeof(buffer) - 1) != 0) {
+        return "";
+    }
+    return std::string(buffer);
 }
 
 bool getEnvBool(const char* name, bool default_value) {
@@ -227,15 +249,30 @@ bool TelemetryRuntime::initInternal(std::unique_ptr<trace_sdk::SpanExporter> exp
                                          config.service_name :
                                          (config.role.empty() ? std::string("rtp_llm") : "rtp_llm_" + config.role);
     try {
-        // 1. Resource: service.instance.id carries per-process
-        // identity; host.ip is written ONLY when a real pod IP is available and
-        // is never synthesized from hostname-pid, which would misrepresent the
-        // node address to topology views.
+        // 1. Resource: process identity shared by every span this process
+        // exports.
+        //
+        // host.ip deliberately carries "{hostname}-{pid}" rather than the pod
+        // IP. The platform's per-instance request/error/latency panels key off
+        // host.ip, and a pod IP is not process-unique: one RTP-LLM pod runs the
+        // frontend, the backend and every DP rank side by side, so an IP-valued
+        // host.ip collapses them into a single bucket. The real address is still
+        // reported, under rtp_llm.pod_ip. Neither host.ip nor host.name is
+        // synthesized when the hostname is unknown -- exporting "unknown-<pid>"
+        // would pollute exactly the aggregation this field exists to serve.
+        const std::string            hostname = readHostname();
         resource::ResourceAttributes attributes{
             {"service.name", service_name},
-            {"service.instance.id", getEnvString("HOSTNAME", "unknown") + "-" + std::to_string(getpid())},
+            // Keeps the historical "unknown" fallback so the instance id stays
+            // present on every span even if the hostname lookup fails.
+            {"service.instance.id",
+             (hostname.empty() ? std::string("unknown") : hostname) + "-" + std::to_string(getpid())},
             {"process.pid", (int64_t)getpid()},
             {"rtp_llm.role", config.role},
+            // Fixed marker the platform's GenAI statistics match on. It names the
+            // instrumentation contract being followed, not a linked library, so
+            // it is a literal rather than a version of anything we build.
+            {"gen_ai.instrumentation.sdk.name", "loongsuite-genai-utils"},
             // rtp_llm.tp_rank is intentionally NOT a resource attribute: the
             // rank0-only gate makes it constantly 0 on every exported span
             // (zero information). tp_rank stays an init() gate parameter only.
@@ -245,9 +282,14 @@ bool TelemetryRuntime::initInternal(std::unique_ptr<trace_sdk::SpanExporter> exp
             {"rtp_llm.dp_rank", config.dp_rank},
             {"rtp_llm.world_rank", config.world_rank},
         };
+        if (!hostname.empty()) {
+            attributes.SetAttribute("host.name", opentelemetry::nostd::string_view(hostname));
+            const std::string host_ip = hostname + "-" + std::to_string(getpid());
+            attributes.SetAttribute("host.ip", opentelemetry::nostd::string_view(host_ip));
+        }
         std::string pod_ip = getEnvString("POD_IP", "");
         if (!pod_ip.empty()) {
-            attributes.SetAttribute("host.ip", opentelemetry::nostd::string_view(pod_ip));
+            attributes.SetAttribute("rtp_llm.pod_ip", opentelemetry::nostd::string_view(pod_ip));
         }
         auto res = resource::Resource::Create(attributes);
 
@@ -275,6 +317,7 @@ bool TelemetryRuntime::initInternal(std::unique_ptr<trace_sdk::SpanExporter> exp
                 new trace_api::propagation::HttpTraceContext()));
 
         g.state = TelemetryState::ACTIVE;
+        g.world_rank.store(config.world_rank, std::memory_order_relaxed);
         g.active.store(true, std::memory_order_release);
         RTP_LLM_LOG_INFO("telemetry runtime active: role=%s tp_rank=%ld service=%s",
                          config.role.c_str(),
@@ -441,6 +484,12 @@ TelemetryState TelemetryRuntime::state() {
     auto&                       g = globals();
     std::lock_guard<std::mutex> lock(g.mutex);
     return g.state;
+}
+
+int64_t TelemetryRuntime::worldRank() {
+    // Lock-free: read once per synthesized phase span. Pairs with the release
+    // store in initInternal via the `active` flag callers already checked.
+    return globals().world_rank.load(std::memory_order_relaxed);
 }
 
 nostd::shared_ptr<trace_api::Tracer> TelemetryRuntime::tracer() {

--- a/rtp_llm/cpp/telemetry/TelemetryRuntime.h
+++ b/rtp_llm/cpp/telemetry/TelemetryRuntime.h
@@ -85,6 +85,12 @@ public:
     static bool           isActive();
     static TelemetryState state();
 
+    // Engine identity behind the gen_ai.engine.index phase span attribute. Only
+    // meaningful while ACTIVE; returns 0 otherwise, which is indistinguishable
+    // from a genuine rank 0 and is why callers must gate on isActive() first
+    // (every phase span factory already does).
+    static int64_t worldRank();
+
     // Returns tracer when ACTIVE, otherwise a no-op tracer. Never null.
     static opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> tracer();
 

--- a/rtp_llm/cpp/telemetry/TraceAttributes.h
+++ b/rtp_llm/cpp/telemetry/TraceAttributes.h
@@ -49,6 +49,16 @@ inline constexpr const char* kAttrRtpLlmAllocateRtUs         = "rtp_llm.allocate
 inline constexpr const char* kAttrRtpLlmPollLocalOutputRtUs  = "rtp_llm.poll_local_output_rt_us";
 inline constexpr const char* kAttrRtpLlmPollRemoteOutputRtUs = "rtp_llm.poll_remote_output_rt_us";
 inline constexpr const char* kAttrRtpLlmPhaseTruncated       = "rtp_llm.phase.truncated";
+// Frontend-to-prefill handoff delay on the master coalescing path: from the
+// frontend wall clock stamped into GenerateInputPB.start_time by trans_input()
+// to the moment the prefill node creates the logical span in buildSlotContexts.
+// It therefore covers the FlexLB coalescing wait plus both network hops.
+// Nothing else isolates that window -- rtp_llm.master_route's duration contains
+// it but mixes in the whole EnqueueGroup handling (allocate + P->D round trip),
+// and rtp_llm.prefill_batch_request itself only starts at the far end of it.
+// This subtracts two different machines' wall clocks, so it is an approximation
+// subject to NTP skew and must not be read as a precise latency metric.
+inline constexpr const char* kAttrRtpLlmPrefillHandoffDelayUs = "rtp_llm.prefill_handoff_delay_us";
 
 }  // namespace telemetry
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/telemetry/TraceAttributes.h
+++ b/rtp_llm/cpp/telemetry/TraceAttributes.h
@@ -3,8 +3,9 @@
 // Centralized C++ span attribute registry, mirroring the Python-side schema in
 // rtp_llm/telemetry/attributes.py; keep the two in sync. Grouping follows the
 // same three-layer annotation: OTel official candidate / ARMS-Unitrace extension
-// / rtp_llm.* internal. Resource attributes such as host.ip and service.name are
-// process identity and are intentionally not listed here.
+// / rtp_llm.* internal. Resource attributes such as host.ip, host.name and
+// service.name are process identity, are written once in TelemetryRuntime.cc and
+// are intentionally not listed here.
 
 namespace rtp_llm {
 namespace telemetry {
@@ -20,6 +21,24 @@ inline constexpr const char* kAttrGenAiUsageOutputTokens     = "gen_ai.usage.out
 inline constexpr const char* kAttrGenAiUsagePromptTokens     = "gen_ai.usage.prompt_tokens";
 inline constexpr const char* kAttrGenAiUsageCompletionTokens = "gen_ai.usage.completion_tokens";
 inline constexpr const char* kAttrGenAiUsageTotalTokens      = "gen_ai.usage.total_tokens";
+
+// GenAI engine identity on synthesized phase spans, consumed by the platform's
+// per-engine aggregation view. The value is rtp_llm.world_rank alone: within one
+// deployment the world rank is already globally unique across DP groups, so
+// pairing it with dp_rank would only add a second spelling of the same identity.
+// Written as an integer, matching the reference implementation, so the platform
+// can aggregate on it numerically.
+inline constexpr const char* kAttrGenAiEngineIndex = "gen_ai.engine.index";
+// PD topology role of the phase that this span measures. Only the compute
+// phases carry it: `wait` is pure queueing and `load_cache` is a transfer
+// window, neither of which produces or consumes tokens, so tagging them would
+// attribute PD semantics to spans that have none. A non-separated (fusion)
+// deployment reports "none" rather than omitting the key, which keeps "this
+// engine is not PD-separated" distinguishable from "this engine did not report".
+inline constexpr const char* kAttrGenAiPdRole   = "gen_ai.pd_role";
+inline constexpr const char* kValPdRoleProducer = "producer";
+inline constexpr const char* kValPdRoleConsumer = "consumer";
+inline constexpr const char* kValPdRoleNone     = "none";
 
 // RPC semantic convention attributes for real gRPC boundary spans. Keep the
 // legacy rpc.system key for the published platform contract; migration to

--- a/rtp_llm/cpp/telemetry/test/phase_span_synthesizer_test.cc
+++ b/rtp_llm/cpp/telemetry/test/phase_span_synthesizer_test.cc
@@ -83,6 +83,21 @@ protected:
         return it == attrs.end() ? -1 : opentelemetry::nostd::get<int64_t>(it->second);
     }
 
+    // Re-initializes the runtime with an explicit engine identity. SetUp() has
+    // already started one at world_rank 0, and initWithExporter refuses to run
+    // while ACTIVE, so the old runtime must be shut down first.
+    void restartWithWorldRank(int64_t world_rank) {
+        TelemetryRuntime::shutdown(5000);
+        span_data_.reset();
+        auto            exporter = memory_exporter::InMemorySpanExporterFactory::Create(span_data_);
+        TelemetryConfig config;
+        config.enabled    = true;
+        config.role       = "test";
+        config.tp_rank    = 0;
+        config.world_rank = world_rank;
+        ASSERT_TRUE(TelemetryRuntime::initWithExporter(std::move(exporter), config));
+    }
+
     std::shared_ptr<memory_exporter::InMemorySpanData> span_data_;
 };
 
@@ -241,6 +256,134 @@ TEST_F(PhaseSpanSynthesizerTest, DecodeModeProducesWaitAndDecodeOnly) {
 
     // No prefill span
     EXPECT_EQ(findSpan(spans, "prefill"), nullptr);
+}
+
+// Engine identity rides every phase span, sourced from world_rank alone.
+// pd_role marks only the compute phases: a fused deployment reports "none"
+// rather than omitting the key, and `wait` carries no role at all because
+// queueing precedes any producer/consumer distinction.
+TEST_F(PhaseSpanSynthesizerTest, FusionPhaseSpansCarryEngineIndexAndNonePdRole) {
+    restartWithWorldRank(7);
+    auto parent = createParentSpan("parent");
+    auto timing = completedTiming(1000000, 1005000, 1020000, 1100000, 1105000, 42);
+
+    synthesizePhaseSpans(parent, timing, PhaseRole::Fusion, /*request_ok=*/true);
+    parent->End();
+
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+    auto spans = span_data_->GetSpans();
+    ASSERT_EQ(spans.size(), 4u);
+
+    for (const char* name : {"wait", "prefill", "decode"}) {
+        auto* span = findSpan(spans, name);
+        ASSERT_NE(span, nullptr) << name;
+        EXPECT_EQ(getInt64Attribute(span, "gen_ai.engine.index"), 7) << name;
+    }
+    auto* fusion_prefill = findSpan(spans, "prefill");
+    auto* fusion_decode  = findSpan(spans, "decode");
+    auto* fusion_wait    = findSpan(spans, "wait");
+    ASSERT_NE(fusion_prefill, nullptr);
+    ASSERT_NE(fusion_decode, nullptr);
+    ASSERT_NE(fusion_wait, nullptr);
+    EXPECT_EQ(getStringAttribute(fusion_prefill, "gen_ai.pd_role"), "none");
+    EXPECT_EQ(getStringAttribute(fusion_decode, "gen_ai.pd_role"), "none");
+    EXPECT_EQ(fusion_wait->GetAttributes().count("gen_ai.pd_role"), 0u);
+}
+
+// Rank 0 is a real rank: omitting the key there would be indistinguishable from
+// "this engine reported nothing" on the platform's per-engine view.
+TEST_F(PhaseSpanSynthesizerTest, EngineIndexIsWrittenForRankZero) {
+    auto parent = createParentSpan("parent");
+    auto timing = completedTiming(1000000, 1005000, 1020000, 1100000, 1105000, 42);
+
+    synthesizePhaseSpans(parent, timing, PhaseRole::Fusion, /*request_ok=*/true);
+    parent->End();
+
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+    auto  spans = span_data_->GetSpans();
+    auto* wait  = findSpan(spans, "wait");
+    ASSERT_NE(wait, nullptr);
+    EXPECT_EQ(getInt64Attribute(wait, "gen_ai.engine.index"), 0);
+}
+
+TEST_F(PhaseSpanSynthesizerTest, PrefillRoleMarksPrefillAsProducer) {
+    restartWithWorldRank(3);
+    auto parent = createParentSpan("parent");
+    auto timing = completedTiming(2000000, 2003000, 2050000, 2051000, 2060000, 42);
+
+    synthesizePhaseSpans(parent, timing, PhaseRole::Prefill, /*request_ok=*/true);
+    parent->End();
+
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+    auto  spans   = span_data_->GetSpans();
+    auto* prefill = findSpan(spans, "prefill");
+    ASSERT_NE(prefill, nullptr);
+    EXPECT_EQ(getStringAttribute(prefill, "gen_ai.pd_role"), "producer");
+    EXPECT_EQ(getInt64Attribute(prefill, "gen_ai.engine.index"), 3);
+    auto* prefill_wait = findSpan(spans, "wait");
+    ASSERT_NE(prefill_wait, nullptr);
+    EXPECT_EQ(prefill_wait->GetAttributes().count("gen_ai.pd_role"), 0u);
+}
+
+TEST_F(PhaseSpanSynthesizerTest, DecodeRoleMarksDecodeAsConsumer) {
+    restartWithWorldRank(5);
+    auto parent = createParentSpan("parent");
+    auto timing = completedTiming(3000000, 3002000, 2999000, 3200000, 3205000, 42);
+
+    synthesizePhaseSpans(parent, timing, PhaseRole::Decode, /*request_ok=*/true);
+    parent->End();
+
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+    auto  spans  = span_data_->GetSpans();
+    auto* decode = findSpan(spans, "decode");
+    ASSERT_NE(decode, nullptr);
+    EXPECT_EQ(getStringAttribute(decode, "gen_ai.pd_role"), "consumer");
+    EXPECT_EQ(getInt64Attribute(decode, "gen_ai.engine.index"), 5);
+    auto* decode_wait = findSpan(spans, "wait");
+    ASSERT_NE(decode_wait, nullptr);
+    EXPECT_EQ(decode_wait->GetAttributes().count("gen_ai.pd_role"), 0u);
+}
+
+// A truncated phase still identifies its engine and role: failure analysis by
+// engine index is exactly when these attributes matter most.
+TEST_F(PhaseSpanSynthesizerTest, TruncatedDecodeKeepsEngineIndexAndConsumerRole) {
+    restartWithWorldRank(5);
+    auto parent = createParentSpan("parent");
+
+    PhaseTiming timing;
+    timing.begin_time_us           = 3000000;
+    timing.running_started         = true;
+    timing.running_started_time_us = 3002000;
+    timing.synthesis_end_time_us   = 3100000;
+    timing.request_id              = 42;
+    timing.error_type              = "Cancelled";
+    synthesizePhaseSpans(parent, timing, PhaseRole::Decode, /*request_ok=*/false);
+    parent->End();
+
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+    auto  spans  = span_data_->GetSpans();
+    auto* decode = findSpan(spans, "decode");
+    ASSERT_NE(decode, nullptr);
+    EXPECT_EQ(decode->GetStatus(), trace_api::StatusCode::kError);
+    EXPECT_EQ(getStringAttribute(decode, "gen_ai.pd_role"), "consumer");
+    EXPECT_EQ(getInt64Attribute(decode, "gen_ai.engine.index"), 5);
+}
+
+// load_cache is a transfer window, not a compute phase: it identifies the engine
+// but claims no producer/consumer role.
+TEST_F(PhaseSpanSynthesizerTest, KvLoadSpanCarriesEngineIndexWithoutPdRole) {
+    restartWithWorldRank(9);
+    auto parent = createParentSpan("rtp_llm.decode_remote_generate");
+
+    synthesizeKvLoadSpan(parent, 4000000, 4069000, 42, /*ok=*/true);
+    parent->End();
+
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+    auto  spans = span_data_->GetSpans();
+    auto* load  = findSpan(spans, "load_cache");
+    ASSERT_NE(load, nullptr);
+    EXPECT_EQ(getInt64Attribute(load, "gen_ai.engine.index"), 9);
+    EXPECT_EQ(load->GetAttributes().count("gen_ai.pd_role"), 0u);
 }
 
 TEST_F(PhaseSpanSynthesizerTest, ZeroWaitSkipsWaitSpan) {

--- a/rtp_llm/cpp/telemetry/test/telemetry_test.cc
+++ b/rtp_llm/cpp/telemetry/test/telemetry_test.cc
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <unistd.h>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -56,6 +57,42 @@ void clearTelemetryEnv() {
     unsetenv("RTP_LLM_OTEL_SERVICE_NAME");
 }
 
+// Scoped override for an env var owned by the execution environment rather than
+// by telemetry. clearTelemetryEnv() deliberately leaves HOSTNAME and POD_IP
+// alone, so a resource test that changed them without restoring would leak into
+// every test running later in this binary. A null value means "unset".
+class ScopedEnv {
+public:
+    ScopedEnv(const char* name, const char* value): name_(name) {
+        const char* previous = std::getenv(name);
+        had_previous_        = previous != nullptr;
+        if (had_previous_) {
+            previous_ = previous;
+        }
+        if (value == nullptr) {
+            unsetenv(name);
+        } else {
+            setenv(name, value, 1);
+        }
+    }
+
+    ~ScopedEnv() {
+        if (had_previous_) {
+            setenv(name_.c_str(), previous_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+    ScopedEnv(const ScopedEnv&)            = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+private:
+    std::string name_;
+    std::string previous_;
+    bool        had_previous_ = false;
+};
+
 class TelemetryTest: public ::testing::Test {
 protected:
     void SetUp() override {
@@ -81,6 +118,35 @@ protected:
         config.tp_rank       = 0;
         EXPECT_TRUE(TelemetryRuntime::initWithExporter(std::move(exporter), config));
         return span_data;
+    }
+
+    // Runtime whose BSP flushes almost immediately, so a probe span can be read
+    // back while the provider is still alive. Required for resource assertions:
+    // SpanData::SetResource keeps a RAW POINTER into the provider's
+    // TracerContext, so reading GetResource() after shutdown() would dangle.
+    std::shared_ptr<memory_exporter::InMemorySpanData> startFastFlushRuntime(const std::string& role) {
+        std::shared_ptr<memory_exporter::InMemorySpanData> span_data;
+        auto            exporter = memory_exporter::InMemorySpanExporterFactory::Create(span_data);
+        TelemetryConfig config;
+        config.enabled           = true;
+        config.schedule_delay_ms = 1;
+        config.role              = role;
+        config.tp_rank           = 0;
+        EXPECT_TRUE(TelemetryRuntime::initWithExporter(std::move(exporter), config));
+        return span_data;
+    }
+
+    // Exports one span and waits for the BSP to hand it to the exporter. Callers
+    // must still be ACTIVE when they read the returned resource.
+    std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>>
+    exportProbeSpan(const std::shared_ptr<memory_exporter::InMemorySpanData>& span_data) {
+        TelemetryRuntime::tracer()->StartSpan("probe")->End();
+        std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>> spans;
+        for (int i = 0; i < 200 && spans.empty(); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            spans = span_data->GetSpans();
+        }
+        return spans;
     }
 };
 
@@ -278,6 +344,65 @@ TEST_F(TelemetryTest, ResourceCarriesReplicaIdentityRanks) {
     // "rtp_llm" default while init() derived a different name.
     ASSERT_NE(res.find("service.name"), res.end());
     EXPECT_EQ(opentelemetry::nostd::get<std::string>(res.at("service.name")), "rtp_llm_decode");
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+}
+
+// The four platform-identity resource attributes. host.ip is process identity
+// (hostname-pid), NOT an address: the per-instance panels key off it and a pod
+// IP would merge every co-located process into one bucket. The real address
+// moves to rtp_llm.pod_ip.
+TEST_F(TelemetryTest, ResourceCarriesPlatformIdentityAttributes) {
+    // A deliberately wrong $HOSTNAME: host identity must come from
+    // gethostname(2), so a leaked env value from an outer shell cannot make this
+    // process report another machine's name.
+    ScopedEnv hostname_env("HOSTNAME", "leaked-outer-host");
+    ScopedEnv pod_ip_env("POD_IP", "10.66.12.32");
+
+    char kernel_hostname[256] = {0};
+    ASSERT_EQ(gethostname(kernel_hostname, sizeof(kernel_hostname) - 1), 0);
+    const std::string expected_host_name = kernel_hostname;
+    const std::string expected_host_ip   = expected_host_name + "-" + std::to_string(getpid());
+
+    auto span_data = startFastFlushRuntime("prefill");
+    auto spans     = exportProbeSpan(span_data);
+    ASSERT_EQ(spans.size(), 1u);
+    const auto& res = spans[0]->GetResource().GetAttributes();
+
+    ASSERT_NE(res.find("gen_ai.instrumentation.sdk.name"), res.end());
+    EXPECT_EQ(nostd::get<std::string>(res.at("gen_ai.instrumentation.sdk.name")), "loongsuite-genai-utils");
+    ASSERT_NE(res.find("host.name"), res.end());
+    EXPECT_EQ(nostd::get<std::string>(res.at("host.name")), expected_host_name);
+    EXPECT_NE(nostd::get<std::string>(res.at("host.name")), "leaked-outer-host");
+    ASSERT_NE(res.find("host.ip"), res.end());
+    EXPECT_EQ(nostd::get<std::string>(res.at("host.ip")), expected_host_ip);
+    // Guards the regression this change is most likely to suffer: host.ip must
+    // never fall back to carrying the pod address again.
+    EXPECT_NE(nostd::get<std::string>(res.at("host.ip")), "10.66.12.32");
+    ASSERT_NE(res.find("rtp_llm.pod_ip"), res.end());
+    EXPECT_EQ(nostd::get<std::string>(res.at("rtp_llm.pod_ip")), "10.66.12.32");
+    // Both keys derive from the same source, so they can never disagree about
+    // which host this process runs on.
+    ASSERT_NE(res.find("service.instance.id"), res.end());
+    EXPECT_EQ(nostd::get<std::string>(res.at("service.instance.id")), expected_host_ip);
+    EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
+}
+
+// POD_IP keeps its "absent means omitted" contract, now on rtp_llm.pod_ip.
+// host.ip stays present because it no longer depends on the pod address.
+TEST_F(TelemetryTest, ResourceOmitsPodIpWhenUnsetButKeepsHostIdentity) {
+    ScopedEnv pod_ip_env("POD_IP", nullptr);
+
+    auto span_data = startFastFlushRuntime("decode");
+    auto spans     = exportProbeSpan(span_data);
+    ASSERT_EQ(spans.size(), 1u);
+    const auto& res = spans[0]->GetResource().GetAttributes();
+
+    EXPECT_EQ(res.count("rtp_llm.pod_ip"), 0u);
+    ASSERT_NE(res.find("host.ip"), res.end());
+    const std::string host_ip    = nostd::get<std::string>(res.at("host.ip"));
+    const std::string pid_suffix = "-" + std::to_string(getpid());
+    EXPECT_GT(host_ip.size(), pid_suffix.size());
+    EXPECT_EQ(host_ip.compare(host_ip.size() - pid_suffix.size(), pid_suffix.size(), pid_suffix), 0) << host_ip;
     EXPECT_TRUE(TelemetryRuntime::shutdown(5000));
 }
 

--- a/rtp_llm/flexlb/flexlb-api/pom.xml
+++ b/rtp_llm/flexlb/flexlb-api/pom.xml
@@ -22,6 +22,12 @@
             <groupId>org.flexlb</groupId>
             <artifactId>flexlb-sync</artifactId>
         </dependency>
+        <!-- Application bootstraps the manual trace provider when RTP_LLM_OTEL_TRACE_ENABLE=1. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/Application.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/Application.java
@@ -16,6 +16,10 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class Application {
 
     public static void main(String[] args) {
+        // Configure the provider before Spring or any request handler first
+        // accesses GlobalOpenTelemetry. When tracing is disabled this is a no-op.
+        OpenTelemetryBootstrap.configureFromEnvironment();
+
         // Print startup parameters
         log.info("Application start with args: {}", (Object[]) args);
         ConfigurableApplicationContext context = SpringApplication.run(Application.class, args);

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/OpenTelemetryBootstrap.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/OpenTelemetryBootstrap.java
@@ -1,0 +1,125 @@
+package org.flexlb;
+
+import org.flexlb.util.EnvUtils;
+import org.flexlb.util.Logger;
+
+/** Configures the OpenTelemetry SDK before Spring starts serving requests. */
+final class OpenTelemetryBootstrap {
+
+    static final String TRACE_ENABLE_ENV = "RTP_LLM_OTEL_TRACE_ENABLE";
+    static final String AUTOCONFIGURE_PROPERTY = "otel.java.global-autoconfigure.enabled";
+    static final String AUTOCONFIGURE_ENV = "OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED";
+    static final String SERVICE_NAME_PROPERTY = "otel.service.name";
+    static final String METRICS_EXPORTER_PROPERTY = "otel.metrics.exporter";
+    static final String LOGS_EXPORTER_PROPERTY = "otel.logs.exporter";
+    static final String RESOURCE_ATTRIBUTES_PROPERTY = "otel.resource.attributes";
+    static final String HOST_IP_ATTRIBUTE = "host.ip";
+
+    private OpenTelemetryBootstrap() {
+    }
+
+    /**
+     * Enables SDK autoconfiguration when the shared RTP-LLM trace switch is on.
+     *
+     * <p>This must run before the first GlobalOpenTelemetry access. The SDK's
+     * autoconfigure extension then initializes the provider lazily and registers
+     * its own JVM shutdown hook. Missing exporter configuration remains fail-open.
+     */
+    static boolean configureFromEnvironment() {
+        if (!EnvUtils.readBoolean(TRACE_ENABLE_ENV, false)) {
+            return false;
+        }
+        if (sdkExplicitlyDisabled()) {
+            Logger.warn("{} is enabled but OTEL_SDK_DISABLED is true; FlexLB tracing remains disabled",
+                    TRACE_ENABLE_ENV);
+            return false;
+        }
+        if (autoconfigureExplicitlyDisabled()) {
+            Logger.warn("{} is enabled but {} is explicitly false; FlexLB tracing remains disabled",
+                    TRACE_ENABLE_ENV, AUTOCONFIGURE_PROPERTY);
+            return false;
+        }
+        if (!hasExporterEndpoint()) {
+            Logger.warn("{} is enabled but no OTLP endpoint is configured; FlexLB tracing remains disabled",
+                    TRACE_ENABLE_ENV);
+            return false;
+        }
+
+        // setDefault, not setProperty: an operator who pinned the autoconfigure
+        // switch keeps their value. The explicitly-false case already returned
+        // above, so reaching here with it set means it was set to true.
+        setDefault(AUTOCONFIGURE_PROPERTY, AUTOCONFIGURE_ENV, "true");
+        setDefault(SERVICE_NAME_PROPERTY, "OTEL_SERVICE_NAME", "rtp_llm_flexlb");
+        // FlexLB only owns manual trace spans. Do not start unrelated metrics or
+        // log exporters unless the deployment explicitly requests them.
+        setDefault(METRICS_EXPORTER_PROPERTY, "OTEL_METRICS_EXPORTER", "none");
+        setDefault(LOGS_EXPORTER_PROPERTY, "OTEL_LOGS_EXPORTER", "none");
+        addPodIpResourceAttribute();
+        Logger.info("FlexLB OpenTelemetry provider autoconfiguration enabled");
+        return true;
+    }
+
+    private static boolean hasExporterEndpoint() {
+        return hasText(System.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"))
+                || hasText(System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+                || hasText(System.getProperty("otel.exporter.otlp.traces.endpoint"))
+                || hasText(System.getProperty("otel.exporter.otlp.endpoint"));
+    }
+
+    private static boolean sdkExplicitlyDisabled() {
+        return EnvUtils.readBoolean("OTEL_SDK_DISABLED", false)
+                || Boolean.parseBoolean(System.getProperty("otel.sdk.disabled", "false"));
+    }
+
+    /**
+     * Whether the deployment pinned the autoconfigure switch to false. Enabling it
+     * anyway would override an explicit operator decision, and the provider would
+     * then be assembled against the operator's intent.
+     */
+    private static boolean autoconfigureExplicitlyDisabled() {
+        String fromProperty = System.getProperty(AUTOCONFIGURE_PROPERTY);
+        if (hasText(fromProperty)) {
+            return !Boolean.parseBoolean(fromProperty.trim());
+        }
+        String fromEnv = System.getenv(AUTOCONFIGURE_ENV);
+        return hasText(fromEnv) && !Boolean.parseBoolean(fromEnv.trim());
+    }
+
+    /**
+     * Mirrors the Python and C++ runtimes by deriving Resource {@code host.ip}
+     * from POD_IP. Observability dashboards filter the request, error and latency
+     * panels by that attribute, so spans without it are missing from per-instance
+     * statistics even when the trace itself is complete. Only a real pod IP is
+     * written, matching TelemetryRuntime.
+     *
+     * <p>Resource attributes are an aggregate setting rather than a single value,
+     * so an existing configuration is merged instead of replaced, and a deployment
+     * that already pins {@code host.ip} keeps its own value.
+     */
+    private static void addPodIpResourceAttribute() {
+        String podIp = System.getenv("POD_IP");
+        if (!hasText(podIp)) {
+            return;
+        }
+        String configured = System.getProperty(RESOURCE_ATTRIBUTES_PROPERTY);
+        if (!hasText(configured)) {
+            configured = System.getenv("OTEL_RESOURCE_ATTRIBUTES");
+        }
+        if (hasText(configured) && configured.contains(HOST_IP_ATTRIBUTE + "=")) {
+            return;
+        }
+        String hostIpEntry = HOST_IP_ATTRIBUTE + "=" + podIp.trim();
+        System.setProperty(RESOURCE_ATTRIBUTES_PROPERTY,
+                hasText(configured) ? configured + "," + hostIpEntry : hostIpEntry);
+    }
+
+    private static void setDefault(String propertyName, String environmentName, String value) {
+        if (!hasText(System.getProperty(propertyName)) && !hasText(System.getenv(environmentName))) {
+            System.setProperty(propertyName, value);
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/OpenTelemetryBootstrap.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/OpenTelemetryBootstrap.java
@@ -1,5 +1,12 @@
 package org.flexlb;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.flexlb.util.EnvUtils;
 import org.flexlb.util.Logger;
 
@@ -14,6 +21,17 @@ final class OpenTelemetryBootstrap {
     static final String LOGS_EXPORTER_PROPERTY = "otel.logs.exporter";
     static final String RESOURCE_ATTRIBUTES_PROPERTY = "otel.resource.attributes";
     static final String HOST_IP_ATTRIBUTE = "host.ip";
+    static final String HOST_NAME_ATTRIBUTE = "host.name";
+    static final String POD_IP_ATTRIBUTE = "rtp_llm.pod_ip";
+    static final String INSTRUMENTATION_SDK_NAME_ATTRIBUTE = "gen_ai.instrumentation.sdk.name";
+    static final String INSTRUMENTATION_SDK_NAME_VALUE = "loongsuite-genai-utils";
+    /**
+     * Kernel-written hostname, the closest JDK-reachable equivalent of
+     * gethostname(2). Package-private and mutable purely as a test seam: the tests
+     * point it at a temp file so "the file wins over $HOSTNAME" can be asserted
+     * deterministically instead of depending on the build machine.
+     */
+    static Path hostnameFile = Path.of("/etc/hostname");
 
     private OpenTelemetryBootstrap() {
     }
@@ -54,7 +72,7 @@ final class OpenTelemetryBootstrap {
         // log exporters unless the deployment explicitly requests them.
         setDefault(METRICS_EXPORTER_PROPERTY, "OTEL_METRICS_EXPORTER", "none");
         setDefault(LOGS_EXPORTER_PROPERTY, "OTEL_LOGS_EXPORTER", "none");
-        addPodIpResourceAttribute();
+        addResourceAttributes();
         Logger.info("FlexLB OpenTelemetry provider autoconfiguration enabled");
         return true;
     }
@@ -86,31 +104,103 @@ final class OpenTelemetryBootstrap {
     }
 
     /**
-     * Mirrors the Python and C++ runtimes by deriving Resource {@code host.ip}
-     * from POD_IP. Observability dashboards filter the request, error and latency
-     * panels by that attribute, so spans without it are missing from per-instance
-     * statistics even when the trace itself is complete. Only a real pod IP is
-     * written, matching TelemetryRuntime.
+     * Mirrors the Python and C++ runtimes' Resource identity.
      *
-     * <p>Resource attributes are an aggregate setting rather than a single value,
-     * so an existing configuration is merged instead of replaced, and a deployment
-     * that already pins {@code host.ip} keeps its own value.
+     * <p>Observability dashboards filter their request, error and latency panels
+     * by {@code host.ip}, so spans without it are missing from per-instance
+     * statistics even when the trace itself is complete. That attribute therefore
+     * carries {@code "{hostname}-{pid}"} rather than an IP: a pod IP is not
+     * process-unique, so every process sharing a pod would collapse into one
+     * bucket. The real pod address stays reported under {@code rtp_llm.pod_ip}.
+     * Nothing is synthesized when the hostname is unknown.
+     *
+     * <p>Resource attributes are one aggregate setting, and for the SDK a system
+     * property REPLACES the environment variable instead of merging with it. The
+     * existing configuration is therefore copied into the property first and only
+     * keys it does not already define are appended, so a deployment that pins its
+     * own value keeps it.
      */
-    private static void addPodIpResourceAttribute() {
-        String podIp = System.getenv("POD_IP");
-        if (!hasText(podIp)) {
-            return;
-        }
+    private static void addResourceAttributes() {
         String configured = System.getProperty(RESOURCE_ATTRIBUTES_PROPERTY);
         if (!hasText(configured)) {
             configured = System.getenv("OTEL_RESOURCE_ATTRIBUTES");
         }
-        if (hasText(configured) && configured.contains(HOST_IP_ATTRIBUTE + "=")) {
+        Set<String> definedKeys = parseDefinedKeys(configured);
+        StringBuilder merged = new StringBuilder(hasText(configured) ? configured.trim() : "");
+
+        appendAttribute(merged, definedKeys, INSTRUMENTATION_SDK_NAME_ATTRIBUTE, INSTRUMENTATION_SDK_NAME_VALUE);
+        String hostname = hostname();
+        if (hasText(hostname)) {
+            appendAttribute(merged, definedKeys, HOST_NAME_ATTRIBUTE, hostname);
+            appendAttribute(merged, definedKeys, HOST_IP_ATTRIBUTE,
+                    hostname + "-" + ProcessHandle.current().pid());
+        }
+        String podIp = System.getenv("POD_IP");
+        if (hasText(podIp)) {
+            appendAttribute(merged, definedKeys, POD_IP_ATTRIBUTE, podIp.trim());
+        }
+        if (merged.length() > 0) {
+            System.setProperty(RESOURCE_ATTRIBUTES_PROPERTY, merged.toString());
+        }
+    }
+
+    private static void appendAttribute(StringBuilder merged, Set<String> definedKeys, String key, String value) {
+        if (!definedKeys.add(key)) {
             return;
         }
-        String hostIpEntry = HOST_IP_ATTRIBUTE + "=" + podIp.trim();
-        System.setProperty(RESOURCE_ATTRIBUTES_PROPERTY,
-                hasText(configured) ? configured + "," + hostIpEntry : hostIpEntry);
+        if (merged.length() > 0) {
+            merged.append(',');
+        }
+        merged.append(key).append('=').append(value);
+    }
+
+    /**
+     * Keys the deployment already defines. The SDK parses this setting as
+     * comma-separated {@code k=v} pairs, so the key is matched exactly rather
+     * than by substring: {@code rtp_llm.pod_ip=...} must not be mistaken for a
+     * configured {@code host.ip}.
+     */
+    private static Set<String> parseDefinedKeys(String configured) {
+        Set<String> keys = new HashSet<>();
+        if (!hasText(configured)) {
+            return keys;
+        }
+        for (String entry : configured.split(",")) {
+            int separator = entry.indexOf('=');
+            if (separator > 0) {
+                keys.add(entry.substring(0, separator).trim());
+            }
+        }
+        return keys;
+    }
+
+    /**
+     * The hostname this container reports, read the same way the C++ and Python
+     * runtimes read it.
+     *
+     * <p>{@code /etc/hostname} is preferred over {@code $HOSTNAME} because the env
+     * var is a snapshot of whoever launched the JVM: an outer shell can overwrite
+     * it with a different machine's name, or omit it entirely, and either way
+     * host.ip/host.name would disagree with the engine processes in the same pod.
+     * The container runtime writes this file and sets the UTS namespace from it,
+     * so it matches what gethostname(2) returns. The env var stays as a fallback
+     * for images that ship no such file.
+     *
+     * <p>Returns an empty string when neither source is available; callers then
+     * omit the host attributes rather than synthesize a value.
+     */
+    private static String hostname() {
+        try {
+            String fromFile = Files.readString(hostnameFile, StandardCharsets.UTF_8).trim();
+            if (hasText(fromFile)) {
+                return fromFile;
+            }
+        } catch (IOException | RuntimeException ignored) {
+            // Fall through to the environment: reading host identity must never
+            // break startup.
+        }
+        String fromEnv = System.getenv("HOSTNAME");
+        return hasText(fromEnv) ? fromEnv.trim() : "";
     }
 
     private static void setDefault(String propertyName, String environmentName, String value) {

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbGrpcForwarder.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbGrpcForwarder.java
@@ -1,15 +1,21 @@
 package org.flexlb.httpserver;
 
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.MetadataUtils;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.flexlb.consistency.LBStatusConsistencyService;
+import org.flexlb.interceptor.GrpcTraceInterceptor;
 import org.flexlb.schedule.grpc.FlexlbServiceGrpc;
 import org.flexlb.schedule.grpc.FlexlbScheduleProtocol;
 import org.flexlb.config.ConfigService;
 import org.flexlb.service.monitor.EngineHealthReporter;
+import org.flexlb.telemetry.FlexlbTrace;
 import org.flexlb.util.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -18,6 +24,9 @@ import javax.annotation.PreDestroy;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 @Component
 public class FlexlbGrpcForwarder {
@@ -45,6 +54,14 @@ public class FlexlbGrpcForwarder {
 
     public MasterForwardResult forwardToMaster(
             FlexlbScheduleProtocol.FlexlbScheduleRequestPB request) {
+        Context traceContext = GrpcTraceInterceptor.getOtelContext();
+        return forwardToMaster(request,
+                traceContext != null ? traceContext : Context.current());
+    }
+
+    public MasterForwardResult forwardToMaster(
+            FlexlbScheduleProtocol.FlexlbScheduleRequestPB request,
+            Context traceContext) {
         ForwardGuard guard = applyForwardGuard(
                 request.getRequestId(), request.getForwardHop(),
                 ForwardOperation.SCHEDULE);
@@ -61,6 +78,13 @@ public class FlexlbGrpcForwarder {
             return MasterForwardResult.noMaster();
         }
 
+        AtomicReference<Span> forwardSpan = new AtomicReference<>();
+        AtomicBoolean forwardSpanFinished = new AtomicBoolean(false);
+        Consumer<Throwable> finishForwardSpan = error -> {
+            if (forwardSpanFinished.compareAndSet(false, true)) {
+                FlexlbTrace.finish(forwardSpan.get(), error);
+            }
+        };
         try {
             int grpcPort = resolveGrpcPort(masterHostIpPort);
             String ip = masterHostIpPort.split(":")[0];
@@ -71,13 +95,31 @@ public class FlexlbGrpcForwarder {
             // not replace the request TTL with a load-balancer timeout.
             FlexlbServiceGrpc.FlexlbServiceBlockingStub stub =
                     FlexlbServiceGrpc.newBlockingStub(channel);
+            forwardSpan.set(FlexlbTrace.startClient(
+                    "rtp_llm.flexlb.forward_schedule", traceContext));
+            FlexlbTrace.setRequestAttributes(forwardSpan.get(), request.getRequestId());
+            FlexlbTrace.setAttribute(forwardSpan.get(), "server.address", ip);
+            FlexlbTrace.setAttribute(forwardSpan.get(), "server.port", grpcPort);
+            stub = withTraceHeaders(stub,
+                    FlexlbTrace.withSpan(forwardSpan.get(), Context.current()));
             FlexlbScheduleProtocol.FlexlbScheduleRequestPB forwardedRequest =
                     request.toBuilder().setForwardHop(guard.nextHop()).build();
             FlexlbScheduleProtocol.FlexlbScheduleResponsePB response =
                     stub.schedule(forwardedRequest);
             engineHealthReporter.reportForwardToMasterResult(ip, String.valueOf(response.getCode()));
+            // Transport succeeded but the master may still have rejected the
+            // request. Route that through the same business-error channel
+            // completeSchedule() uses, otherwise this span closes OK while the
+            // health report above already recorded the rejecting code.
+            if (!response.getSuccess()) {
+                FlexlbTrace.markBusinessError(
+                        FlexlbTrace.withSpan(forwardSpan.get(), Context.current()),
+                        response.getCode(), "FLEXLB_BUSINESS_REJECTED");
+            }
+            finishForwardSpan.accept(null);
             return MasterForwardResult.forwarded(response, masterHostIpPort);
         } catch (StatusRuntimeException e) {
+            finishForwardSpan.accept(e);
             Logger.warn(
                     "event=flexlb_forward_failed request_id={} forward_hop={} master={} "
                             + "local_ip={} status={}",
@@ -90,6 +132,7 @@ public class FlexlbGrpcForwarder {
             return MasterForwardResult.failed(
                     e.getStatus().getCode().name(), masterHostIpPort);
         } catch (Exception e) {
+            finishForwardSpan.accept(e);
             Logger.error("gRPC forward to master error: request_id={} master={}",
                     request.getRequestId(), masterHostIpPort, e);
             engineHealthReporter.reportForwardToMasterResult(
@@ -97,6 +140,15 @@ public class FlexlbGrpcForwarder {
             return MasterForwardResult.failed(
                     e.getClass().getSimpleName(), masterHostIpPort);
         }
+    }
+
+    private static FlexlbServiceGrpc.FlexlbServiceBlockingStub withTraceHeaders(
+            FlexlbServiceGrpc.FlexlbServiceBlockingStub stub,
+            Context context) {
+        Metadata metadata = new Metadata();
+        FlexlbTrace.inject(context).forEach((key, value) -> metadata.put(
+                Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value));
+        return stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
     }
 
     public record MasterForwardResult(
@@ -135,9 +187,24 @@ public class FlexlbGrpcForwarder {
         }
         FlexlbScheduleProtocol.GetRequestStateRequestPB forwardedRequest =
                 request.toBuilder().setForwardHop(guard.nextHop()).build();
+        Context traceContext = GrpcTraceInterceptor.getOtelContext();
+        if (traceContext == null) {
+            traceContext = Context.current();
+        }
+        Span stateSpan = FlexlbTrace.startClient(
+                "rtp_llm.flexlb.get_request_state", traceContext);
+        FlexlbTrace.setRequestAttributes(stateSpan, request.getRequestId());
+        FlexlbTrace.setAttribute(stateSpan, "server.address", ipOf(masterHostIpPort));
+        FlexlbTrace.setAttribute(stateSpan, "server.port", resolveGrpcPort(masterHostIpPort));
         try {
-            return stub.getRequestState(forwardedRequest);
+            stub = withTraceHeaders(stub,
+                    FlexlbTrace.withSpan(stateSpan, traceContext));
+            FlexlbScheduleProtocol.GetRequestStateResponsePB response =
+                    stub.getRequestState(forwardedRequest);
+            FlexlbTrace.finish(stateSpan);
+            return response;
         } catch (RuntimeException e) {
+            FlexlbTrace.finish(stateSpan, e);
             Logger.debug("Failed to forward FlexLB state query to master, request_id={}",
                     request.getRequestId(), e);
             return null;

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbGrpcServer.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbGrpcServer.java
@@ -14,6 +14,7 @@ import org.flexlb.config.ConfigService;
 import org.flexlb.constant.MetricConstant;
 import org.flexlb.interceptor.GrpcQosHeaderInterceptor;
 import org.flexlb.interceptor.GrpcServerTimingInterceptor;
+import org.flexlb.interceptor.GrpcTraceInterceptor;
 import org.flexlb.util.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -130,7 +131,7 @@ public class FlexlbGrpcServer {
                 .workerEventLoopGroup(grpcServerEventLoopGroup)
                 .executor(grpcExecutor)
                 .addService(ServerInterceptors.intercept(flexlbServiceImpl,
-                        grpcServerTimingInterceptor, grpcQosHeaderInterceptor))
+                        new GrpcTraceInterceptor(), grpcServerTimingInterceptor, grpcQosHeaderInterceptor))
                 .maxInboundMessageSize(16 * 1024 * 1024)
                 .flowControlWindow(4 * 1024 * 1024)
                 .build()

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
@@ -1,5 +1,7 @@
 package org.flexlb.httpserver;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.grpc.stub.StreamObserver;
 import org.flexlb.consistency.LBStatusConsistencyService;
 import org.flexlb.balance.scheduler.RequestLifecycleSnapshot;
@@ -17,12 +19,14 @@ import org.flexlb.schedule.grpc.FlexlbServiceGrpc;
 import org.flexlb.schedule.grpc.FlexlbScheduleProtocol;
 import org.flexlb.interceptor.GrpcQosHeaderInterceptor;
 import org.flexlb.interceptor.GrpcServerTimingInterceptor;
+import org.flexlb.interceptor.GrpcTraceInterceptor;
 import org.flexlb.service.RouteService;
 import org.flexlb.service.grace.ActiveRequestCounter;
 import org.flexlb.service.monitor.BatchSchedulerReporter;
 import org.flexlb.service.monitor.EngineHealthReporter;
 import org.flexlb.service.monitor.PrioritySchedulerReporter;
 import org.flexlb.config.ConfigService;
+import org.flexlb.telemetry.FlexlbTrace;
 import org.flexlb.util.JsonUtils;
 import org.flexlb.util.Logger;
 import org.flexlb.util.PriorityNormalizer;
@@ -179,6 +183,13 @@ public class FlexlbServiceImpl extends FlexlbServiceGrpc.FlexlbServiceImplBase {
     @Override
     public void getRequestState(FlexlbScheduleProtocol.GetRequestStateRequestPB request,
                                 StreamObserver<FlexlbScheduleProtocol.GetRequestStateResponsePB> responseObserver) {
+        // The interceptor already published a SERVER span for this call; without
+        // the request id on it the span is unsearchable on the platform. No new
+        // span is created here -- the forwarding path tags its own CLIENT span.
+        Context traceContext = GrpcTraceInterceptor.getOtelContext();
+        FlexlbTrace.setRequestAttributes(
+                Span.fromContext(traceContext != null ? traceContext : Context.current()),
+                request.getRequestId());
         if (shouldForwardToMaster()) {
             FlexlbScheduleProtocol.GetRequestStateResponsePB forwarded =
                     grpcForwarder.forwardGetRequestStateToMaster(request);
@@ -215,6 +226,40 @@ public class FlexlbServiceImpl extends FlexlbServiceGrpc.FlexlbServiceImplBase {
                                   FlexlbScheduleProtocol.FlexlbScheduleResponsePB response,
                                   StreamObserver<FlexlbScheduleProtocol.FlexlbScheduleResponsePB> observer,
                                   ScheduleOrigin origin) {
+        // buildContext() runs inside schedule()'s try block while ctx is still
+        // null, so the entry-error path reaches this method with no
+        // BalanceContext at all. Passing that null through would make
+        // spanFromContext() return an invalid span and silently drop both the
+        // schedule code and the business error, leaving the SERVER span to be
+        // closed as OK by FinishingListener even though an error response was
+        // sent. Prefer the context captured on the BalanceContext -- the async
+        // route callback runs on a dispatch thread where the gRPC context is not
+        // current -- and only fall back to the interceptor's context, which is
+        // readable on this handler thread.
+        Context traceContext = ctx != null ? ctx.getTraceContext() : null;
+        if (traceContext == null) {
+            traceContext = GrpcTraceInterceptor.getOtelContext();
+        }
+        if (traceContext == null) {
+            traceContext = Context.current();
+        }
+        if (response != null) {
+            FlexlbTrace.setScheduleAttribute(traceContext,
+                    FlexlbTrace.SCHEDULE_CODE, response.getCode());
+            FlexlbTrace.setScheduleAttribute(traceContext,
+                    FlexlbTrace.ENQUEUED_BY_MASTER, response.getEnqueuedByMaster());
+        }
+        if (ctx != null && ctx.getAckAtNanos() > 0) {
+            FlexlbTrace.setScheduleDuration(traceContext,
+                    FlexlbTrace.ACK_TO_RESPONSE_MS, ctx.getAckAtNanos(), System.nanoTime());
+        }
+        if (response != null && !response.getSuccess()) {
+            // This is an expected business response, not a transport or Java
+            // exception, so markBusinessError records it as ERROR without an
+            // exception event. Whoever owns the span still finishes it.
+            FlexlbTrace.markBusinessError(
+                    traceContext, response.getCode(), "FLEXLB_BUSINESS_REJECTED");
+        }
         // Report ACK-to-response time for BATCH path (only when engine ACK was received)
         if (ctx != null && ctx.getAckAtMs() > 0) {
             long ackToResponseMs = System.currentTimeMillis() - ctx.getAckAtMs();
@@ -379,6 +424,11 @@ public class FlexlbServiceImpl extends FlexlbServiceGrpc.FlexlbServiceImplBase {
 
     private BalanceContext buildContext(FlexlbScheduleProtocol.FlexlbScheduleRequestPB pb) {
         BalanceContext ctx = new BalanceContext();
+        Context traceContext = GrpcTraceInterceptor.getOtelContext();
+        ctx.setTraceContext(traceContext != null ? traceContext : Context.current());
+        Span scheduleSpan = Span.fromContext(ctx.getTraceContext());
+        FlexlbTrace.setRequestAttributes(scheduleSpan, pb.getRequestId());
+        FlexlbTrace.setAttribute(scheduleSpan, "flexlb.schedule.priority", pb.getPriority());
 
         Request request = new Request();
         request.setRequestId(pb.getRequestId());

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/interceptor/GrpcTraceInterceptor.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/interceptor/GrpcTraceInterceptor.java
@@ -1,0 +1,194 @@
+package org.flexlb.interceptor;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.ForwardingServerCall;
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import org.flexlb.telemetry.FlexlbTrace;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Extracts the W3C context for a FlexLB Schedule call, reuses an upstream SERVER
+ * span when one is already current, and otherwise creates and owns a manual one.
+ */
+public final class GrpcTraceInterceptor implements ServerInterceptor {
+
+    private static final TextMapGetter<Metadata> METADATA_GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Metadata carrier) {
+            return List.of("traceparent", "tracestate");
+        }
+
+        @Override
+        public String get(Metadata carrier, String key) {
+            if (carrier == null || key == null) {
+                return null;
+            }
+            try {
+                return carrier.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
+            } catch (RuntimeException ignored) {
+                return null;
+            }
+        }
+    };
+
+    public static final io.grpc.Context.Key<io.opentelemetry.context.Context> OTEL_CONTEXT_KEY =
+            io.grpc.Context.key("flexlbOtelContext");
+
+    public static io.opentelemetry.context.Context getOtelContext() {
+        return OTEL_CONTEXT_KEY.get();
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+        Context grpcCurrent = Context.current();
+        io.opentelemetry.context.Context otelCurrent =
+                io.opentelemetry.context.Context.current();
+        io.opentelemetry.context.Context extracted = otelCurrent;
+        Span serverSpan = Span.getInvalid();
+        boolean ownsSpan = false;
+        try {
+            extracted = FlexlbTrace.extract(otelCurrent, headers, METADATA_GETTER);
+            Span existing = Span.fromContext(otelCurrent);
+            if (existing.getSpanContext().isValid()) {
+                // Something upstream already opened a span for this call -- an
+                // auto-instrumentation agent, or another interceptor. Adopt it
+                // instead of nesting a second SERVER span, and leave ending it
+                // to whoever created it (ownsSpan stays false).
+                serverSpan = existing;
+            } else {
+                // With no provider configured (default startup), the no-op
+                // SpanBuilder returns Span.wrap(parent's SpanContext), so this
+                // still carries the extracted remote trace/span rather than an
+                // invalid one -- storing it below preserves the traceparent for
+                // the downstream forward instead of clobbering it.
+                serverSpan = FlexlbTrace.startServer(spanName(call), extracted);
+                ownsSpan = true;
+            }
+            io.opentelemetry.context.Context serverContext =
+                    FlexlbTrace.withSpan(serverSpan, extracted);
+            Context grpcContext = grpcCurrent.withValue(OTEL_CONTEXT_KEY, serverContext);
+            // The handler's close() carries the call's real terminal status, which
+            // the listener callbacks alone cannot recover: onComplete() fires for
+            // an error close just as it does for a successful one.
+            AtomicReference<Status> observedStatus = new AtomicReference<>();
+            ServerCall.Listener<ReqT> listener = Contexts.interceptCall(
+                    grpcContext, new StatusCapturingCall<>(call, observedStatus), headers, next);
+            return new FinishingListener<>(listener, serverSpan, ownsSpan, observedStatus);
+        } catch (RuntimeException | Error error) {
+            if (ownsSpan) {
+                FlexlbTrace.finish(serverSpan, error);
+            }
+            throw error;
+        }
+    }
+
+    private static String spanName(ServerCall<?, ?> call) {
+        String fullMethodName = call.getMethodDescriptor().getFullMethodName();
+        int separator = fullMethodName.lastIndexOf('/');
+        String methodName = separator >= 0
+                ? fullMethodName.substring(separator + 1)
+                : fullMethodName;
+        StringBuilder snakeName = new StringBuilder(methodName.length() + 8);
+        for (int i = 0; i < methodName.length(); ++i) {
+            char character = methodName.charAt(i);
+            if (Character.isUpperCase(character) && i > 0) {
+                snakeName.append('_');
+            }
+            snakeName.append(Character.toLowerCase(character));
+        }
+        return "rtp_llm.flexlb." + snakeName;
+    }
+
+    /** Records the terminating status the handler passes to close(). */
+    private static final class StatusCapturingCall<ReqT, RespT>
+            extends ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT> {
+        private final AtomicReference<Status> observedStatus;
+
+        private StatusCapturingCall(ServerCall<ReqT, RespT> delegate,
+                                   AtomicReference<Status> observedStatus) {
+            super(delegate);
+            this.observedStatus = observedStatus;
+        }
+
+        @Override
+        public void close(Status status, Metadata trailers) {
+            // Recorded before delegating, since the delegate drives the listener
+            // callback that reads it. First close wins: gRPC rejects a second one.
+            observedStatus.compareAndSet(null, status);
+            super.close(status, trailers);
+        }
+    }
+
+    private static final class FinishingListener<ReqT>
+            extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+        private final Span span;
+        private final boolean ownsSpan;
+        private final AtomicBoolean finished = new AtomicBoolean();
+        private final AtomicReference<Status> observedStatus;
+
+        private FinishingListener(ServerCall.Listener<ReqT> delegate,
+                                 Span span,
+                                 boolean ownsSpan,
+                                 AtomicReference<Status> observedStatus) {
+            super(delegate);
+            this.span = span;
+            this.ownsSpan = ownsSpan;
+            this.observedStatus = observedStatus;
+        }
+
+        @Override
+        public void onComplete() {
+            settle(null);
+            super.onComplete();
+        }
+
+        @Override
+        public void onCancel() {
+            // The synthetic CancellationException is only a fallback: when the
+            // handler already closed the call, that status is the real cause.
+            settle(new CancellationException("FlexLB Schedule RPC cancelled"));
+            super.onCancel();
+        }
+
+        /**
+         * Single terminal path shared by close, complete and cancel. Ends the span
+         * exactly once, and only when this interceptor created it -- an
+         * upstream-owned span is ended by its owner, so it only receives the
+         * status attribute.
+         */
+        private void settle(Throwable fallbackError) {
+            Status observed = observedStatus.get();
+            if (!ownsSpan) {
+                if (observed != null) {
+                    FlexlbTrace.setAttribute(span, FlexlbTrace.RPC_RESPONSE_STATUS_CODE,
+                            observed.getCode().name());
+                }
+                return;
+            }
+            if (!finished.compareAndSet(false, true)) {
+                return;
+            }
+            if (observed != null) {
+                FlexlbTrace.finishWithGrpcStatus(span, observed.getCode().name(),
+                        observed.getCode().value(), observed.isOk());
+            } else {
+                FlexlbTrace.finish(span, fallbackError);
+            }
+        }
+    }
+}

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/OpenTelemetryBootstrapTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/OpenTelemetryBootstrapTest.java
@@ -6,9 +6,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -20,6 +25,12 @@ class OpenTelemetryBootstrapTest {
 
     private static final String TRACES_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
     private static final String GENERIC_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    private static final String TEST_HOSTNAME = "probe-host";
+
+    @TempDir
+    private Path tempDir;
+
+    private Path originalHostnameFile;
 
     @SystemStub
     private EnvironmentVariables environmentVariables = new EnvironmentVariables();
@@ -38,10 +49,29 @@ class OpenTelemetryBootstrapTest {
         environmentVariables.remove("OTEL_TRACES_EXPORTER");
         environmentVariables.remove("OTEL_RESOURCE_ATTRIBUTES");
         environmentVariables.remove("POD_IP");
+        // host.ip/host.name derive from the kernel-written hostname file, so the
+        // tests point that at a temp file instead of depending on the build
+        // machine. $HOSTNAME is cleared so a leaked outer value cannot make an
+        // assertion pass for the wrong reason.
+        environmentVariables.remove("HOSTNAME");
+        originalHostnameFile = OpenTelemetryBootstrap.hostnameFile;
+        OpenTelemetryBootstrap.hostnameFile = writeHostnameFile(TEST_HOSTNAME);
+    }
+
+    private Path writeHostnameFile(String content) {
+        try {
+            Path file = tempDir.resolve("hostname");
+            // Trailing newline mirrors what container runtimes actually write.
+            Files.writeString(file, content + "\n");
+            return file;
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @AfterEach
     void tearDown() {
+        OpenTelemetryBootstrap.hostnameFile = originalHostnameFile;
         GlobalOpenTelemetry.resetForTest();
         clearBootstrapProperties();
     }
@@ -87,42 +117,116 @@ class OpenTelemetryBootstrapTest {
     }
 
     @Test
-    void missingPodIpLeavesResourceAttributesUntouched() {
-        enableTraceOffline();
-
-        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
-        assertNull(System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
-    }
-
-    @Test
-    void podIpBecomesHostIpResourceAttribute() {
+    void resourceAttributesCarryPlatformIdentity() {
         enableTraceOffline();
         environmentVariables.set("POD_IP", "10.1.2.3");
 
         assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
-        assertEquals("host.ip=10.1.2.3",
+        assertEquals(sdkMarker() + "," + hostEntries() + ",rtp_llm.pod_ip=10.1.2.3",
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    /**
+     * The kernel-written hostname wins over $HOSTNAME. An outer shell can leak a
+     * different machine's name into the env (observed in a docker-exec session),
+     * which would make FlexLB report a different host than the engine processes in
+     * the same pod.
+     */
+    @Test
+    void hostnameFileWinsOverLeakedEnvironmentValue() {
+        enableTraceOffline();
+        environmentVariables.set("HOSTNAME", "leaked-outer-host");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertEquals(sdkMarker() + "," + hostEntries(),
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    /** Images that ship no hostname file still report identity, via the env. */
+    @Test
+    void missingHostnameFileFallsBackToEnvironment() {
+        enableTraceOffline();
+        OpenTelemetryBootstrap.hostnameFile = tempDir.resolve("absent-hostname");
+        environmentVariables.set("HOSTNAME", "env-host");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertEquals(sdkMarker() + ",host.name=env-host,host.ip=env-host-" + ProcessHandle.current().pid(),
                 System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
     }
 
     @Test
-    void podIpMergesIntoDeploymentResourceAttributes() {
+    void missingPodIpStillWritesSdkMarkerAndHostIdentity() {
+        enableTraceOffline();
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        // The pod address is the only optional part: host.ip no longer depends on
+        // it, and the SDK marker is unconditional.
+        assertEquals(sdkMarker() + "," + hostEntries(),
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    @Test
+    void unknownHostnameSkipsHostKeysButKeepsSdkMarker() {
+        enableTraceOffline();
+        OpenTelemetryBootstrap.hostnameFile = tempDir.resolve("absent-hostname");
+        environmentVariables.set("POD_IP", "10.1.2.3");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        // "unknown-<pid>" would pollute the per-instance aggregation these keys
+        // exist to serve, so neither host key is synthesized.
+        assertEquals(sdkMarker() + ",rtp_llm.pod_ip=10.1.2.3",
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    @Test
+    void resourceAttributesMergeIntoDeploymentConfiguration() {
         enableTraceOffline();
         environmentVariables.set("POD_IP", "10.1.2.3");
         environmentVariables.set("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod");
 
         assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
-        assertEquals("deployment.environment=prod,host.ip=10.1.2.3",
+        // The system property REPLACES the environment variable for the SDK, so
+        // the deployment's own entry must be copied into it, not just left behind.
+        assertEquals("deployment.environment=prod," + sdkMarker() + "," + hostEntries()
+                        + ",rtp_llm.pod_ip=10.1.2.3",
                 System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
     }
 
     @Test
-    void explicitHostIpWinsOverPodIp() {
+    void explicitHostIpIsPreservedWhileOtherKeysAreAdded() {
         enableTraceOffline();
         environmentVariables.set("POD_IP", "10.1.2.3");
         environmentVariables.set("OTEL_RESOURCE_ATTRIBUTES", "host.ip=192.168.0.9");
 
         assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
-        assertNull(System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+        // A deployment that pins host.ip keeps it; only the keys it left undefined
+        // are appended.
+        assertEquals("host.ip=192.168.0.9," + sdkMarker() + ",host.name=" + TEST_HOSTNAME
+                        + ",rtp_llm.pod_ip=10.1.2.3",
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    @Test
+    void similarlyNamedKeyDoesNotSuppressHostIp() {
+        enableTraceOffline();
+        // A substring match on "host.ip=" would see this entry and wrongly skip
+        // host.ip; keys must be compared exactly.
+        environmentVariables.set("OTEL_RESOURCE_ATTRIBUTES", "rtp_llm.pod_ip=10.9.9.9");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertEquals("rtp_llm.pod_ip=10.9.9.9," + sdkMarker() + "," + hostEntries(),
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    private static String sdkMarker() {
+        return OpenTelemetryBootstrap.INSTRUMENTATION_SDK_NAME_ATTRIBUTE + "="
+                + OpenTelemetryBootstrap.INSTRUMENTATION_SDK_NAME_VALUE;
+    }
+
+    private static String hostEntries() {
+        return OpenTelemetryBootstrap.HOST_NAME_ATTRIBUTE + "=" + TEST_HOSTNAME + ","
+                + OpenTelemetryBootstrap.HOST_IP_ATTRIBUTE + "=" + TEST_HOSTNAME + "-"
+                + ProcessHandle.current().pid();
     }
 
     private void enableTraceOffline() {

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/OpenTelemetryBootstrapTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/OpenTelemetryBootstrapTest.java
@@ -1,0 +1,145 @@
+package org.flexlb;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SystemStubsExtension.class)
+class OpenTelemetryBootstrapTest {
+
+    private static final String TRACES_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
+    private static final String GENERIC_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+    @SystemStub
+    private EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    @BeforeEach
+    void setUp() {
+        GlobalOpenTelemetry.resetForTest();
+        clearBootstrapProperties();
+        environmentVariables.remove(OpenTelemetryBootstrap.TRACE_ENABLE_ENV);
+        environmentVariables.remove(TRACES_ENDPOINT_ENV);
+        environmentVariables.remove(GENERIC_ENDPOINT_ENV);
+        environmentVariables.remove("OTEL_SDK_DISABLED");
+        environmentVariables.remove("OTEL_SERVICE_NAME");
+        environmentVariables.remove("OTEL_METRICS_EXPORTER");
+        environmentVariables.remove("OTEL_LOGS_EXPORTER");
+        environmentVariables.remove("OTEL_TRACES_EXPORTER");
+        environmentVariables.remove("OTEL_RESOURCE_ATTRIBUTES");
+        environmentVariables.remove("POD_IP");
+    }
+
+    @AfterEach
+    void tearDown() {
+        GlobalOpenTelemetry.resetForTest();
+        clearBootstrapProperties();
+    }
+
+    @Test
+    void disabledTraceLeavesProviderAutoconfigurationOff() {
+        environmentVariables.set(OpenTelemetryBootstrap.TRACE_ENABLE_ENV, "0");
+        environmentVariables.set(TRACES_ENDPOINT_ENV, "http://127.0.0.1:4318/v1/traces");
+
+        assertFalse(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertNull(System.getProperty(OpenTelemetryBootstrap.AUTOCONFIGURE_PROPERTY));
+    }
+
+    @Test
+    void enabledTraceWithoutEndpointStaysFailOpen() {
+        environmentVariables.set(OpenTelemetryBootstrap.TRACE_ENABLE_ENV, "1");
+
+        assertFalse(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertNull(System.getProperty(OpenTelemetryBootstrap.AUTOCONFIGURE_PROPERTY));
+    }
+
+    @Test
+    void enabledTraceConfiguresARealProviderWithSafeDefaults() {
+        environmentVariables.set(OpenTelemetryBootstrap.TRACE_ENABLE_ENV, "true");
+        environmentVariables.set(TRACES_ENDPOINT_ENV, "http://127.0.0.1:4318/v1/traces");
+        // Keep this unit test offline; it verifies provider creation, not export.
+        environmentVariables.set("OTEL_TRACES_EXPORTER", "none");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertEquals("true", System.getProperty(OpenTelemetryBootstrap.AUTOCONFIGURE_PROPERTY));
+        assertEquals("rtp_llm_flexlb", System.getProperty(OpenTelemetryBootstrap.SERVICE_NAME_PROPERTY));
+        assertEquals("none", System.getProperty(OpenTelemetryBootstrap.METRICS_EXPORTER_PROPERTY));
+        assertEquals("none", System.getProperty(OpenTelemetryBootstrap.LOGS_EXPORTER_PROPERTY));
+
+        Span span = GlobalOpenTelemetry.getTracer("org.flexlb.test")
+                .spanBuilder("provider_probe")
+                .startSpan();
+        try {
+            assertTrue(span.getSpanContext().isValid());
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void missingPodIpLeavesResourceAttributesUntouched() {
+        enableTraceOffline();
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertNull(System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    @Test
+    void podIpBecomesHostIpResourceAttribute() {
+        enableTraceOffline();
+        environmentVariables.set("POD_IP", "10.1.2.3");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertEquals("host.ip=10.1.2.3",
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    @Test
+    void podIpMergesIntoDeploymentResourceAttributes() {
+        enableTraceOffline();
+        environmentVariables.set("POD_IP", "10.1.2.3");
+        environmentVariables.set("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertEquals("deployment.environment=prod,host.ip=10.1.2.3",
+                System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    @Test
+    void explicitHostIpWinsOverPodIp() {
+        enableTraceOffline();
+        environmentVariables.set("POD_IP", "10.1.2.3");
+        environmentVariables.set("OTEL_RESOURCE_ATTRIBUTES", "host.ip=192.168.0.9");
+
+        assertTrue(OpenTelemetryBootstrap.configureFromEnvironment());
+        assertNull(System.getProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY));
+    }
+
+    private void enableTraceOffline() {
+        environmentVariables.set(OpenTelemetryBootstrap.TRACE_ENABLE_ENV, "1");
+        environmentVariables.set(TRACES_ENDPOINT_ENV, "http://127.0.0.1:4318/v1/traces");
+        // Keep these unit tests offline; they verify configuration, not export.
+        environmentVariables.set("OTEL_TRACES_EXPORTER", "none");
+    }
+
+    private static void clearBootstrapProperties() {
+        System.clearProperty(OpenTelemetryBootstrap.AUTOCONFIGURE_PROPERTY);
+        System.clearProperty(OpenTelemetryBootstrap.SERVICE_NAME_PROPERTY);
+        System.clearProperty(OpenTelemetryBootstrap.METRICS_EXPORTER_PROPERTY);
+        System.clearProperty(OpenTelemetryBootstrap.LOGS_EXPORTER_PROPERTY);
+        System.clearProperty(OpenTelemetryBootstrap.RESOURCE_ATTRIBUTES_PROPERTY);
+        System.clearProperty("otel.sdk.disabled");
+        System.clearProperty("otel.exporter.otlp.traces.endpoint");
+        System.clearProperty("otel.exporter.otlp.endpoint");
+    }
+}

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/httpserver/FlexlbServiceImplTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/httpserver/FlexlbServiceImplTest.java
@@ -316,6 +316,98 @@ class FlexlbServiceImplTest {
     }
 
     @Test
+    void testSchedule_entryErrorMarksServerSpanFromInterceptorContext() {
+        // buildContext() throws before ctx is assigned, so completeSchedule() gets
+        // a null BalanceContext. The SERVER span must still carry the business
+        // error, recovered from the interceptor's gRPC-scoped context.
+        io.opentelemetry.api.GlobalOpenTelemetry.resetForTest();
+        RecordingExporter exporter = new RecordingExporter();
+        io.opentelemetry.sdk.trace.SdkTracerProvider provider =
+                io.opentelemetry.sdk.trace.SdkTracerProvider.builder()
+                        .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())
+                        .addSpanProcessor(
+                                io.opentelemetry.sdk.trace.export.SimpleSpanProcessor.create(exporter))
+                        .build();
+        io.opentelemetry.sdk.OpenTelemetrySdk sdk =
+                io.opentelemetry.sdk.OpenTelemetrySdk.builder().setTracerProvider(provider).build();
+        io.opentelemetry.api.GlobalOpenTelemetry.set(sdk);
+        try {
+            io.opentelemetry.api.trace.Span serverSpan =
+                    org.flexlb.telemetry.FlexlbTrace.startServer(
+                            "rtp_llm.flexlb.schedule", io.opentelemetry.context.Context.root());
+
+            // buildContext() reads loadBalanceConfig(); make it throw.
+            when(configService.loadBalanceConfig())
+                    .thenThrow(new IllegalStateException("config unavailable"));
+
+            FlexlbScheduleProtocol.FlexlbScheduleRequestPB request =
+                    FlexlbScheduleProtocol.FlexlbScheduleRequestPB.newBuilder()
+                            .setRequestId(778899L)
+                            .build();
+            StreamObserver<FlexlbScheduleProtocol.FlexlbScheduleResponsePB> observer =
+                    mock(StreamObserver.class);
+
+            // Publish the SERVER span the way GrpcTraceInterceptor does, then run
+            // schedule() inside that gRPC context.
+            io.grpc.Context.current()
+                    .withValue(org.flexlb.interceptor.GrpcTraceInterceptor.OTEL_CONTEXT_KEY,
+                            org.flexlb.telemetry.FlexlbTrace.withSpan(
+                                    serverSpan, io.opentelemetry.context.Context.root()))
+                    .run(() -> service.schedule(request, observer));
+
+            ArgumentCaptor<FlexlbScheduleProtocol.FlexlbScheduleResponsePB> captor =
+                    ArgumentCaptor.forClass(FlexlbScheduleProtocol.FlexlbScheduleResponsePB.class);
+            verify(observer).onNext(captor.capture());
+            verify(observer).onCompleted();
+            FlexlbScheduleProtocol.FlexlbScheduleResponsePB resp = captor.getValue();
+            assertFalse(resp.getSuccess());
+            assertEquals(500, resp.getCode());
+
+            // The interceptor owns the span lifecycle; nothing is exported yet.
+            assertEquals(0, exporter.spans.size());
+            org.flexlb.telemetry.FlexlbTrace.finish(serverSpan, null);
+
+            assertEquals(1, exporter.spans.size());
+            io.opentelemetry.sdk.trace.data.SpanData span = exporter.spans.get(0);
+            assertEquals(io.opentelemetry.api.trace.StatusCode.ERROR,
+                    span.getStatus().getStatusCode());
+            assertEquals("FLEXLB_BUSINESS_REJECTED",
+                    span.getAttributes().get(
+                            io.opentelemetry.api.common.AttributeKey.stringKey("error.type")));
+            assertEquals(500L,
+                    span.getAttributes().get(
+                            io.opentelemetry.api.common.AttributeKey.longKey("flexlb.schedule.code")));
+            assertTrue(span.getEvents().isEmpty());
+        } finally {
+            sdk.close();
+            io.opentelemetry.api.GlobalOpenTelemetry.resetForTest();
+        }
+    }
+
+    private static final class RecordingExporter
+            implements io.opentelemetry.sdk.trace.export.SpanExporter {
+        private final java.util.List<io.opentelemetry.sdk.trace.data.SpanData> spans =
+                new java.util.ArrayList<>();
+
+        @Override
+        public io.opentelemetry.sdk.common.CompletableResultCode export(
+                java.util.Collection<io.opentelemetry.sdk.trace.data.SpanData> batch) {
+            spans.addAll(batch);
+            return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public io.opentelemetry.sdk.common.CompletableResultCode flush() {
+            return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public io.opentelemetry.sdk.common.CompletableResultCode shutdown() {
+            return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+        }
+    }
+
+    @Test
     void testSchedule_observerFailureStillWritesPvRecord() {
         when(lbStatusConsistencyService.isNeedConsistency()).thenReturn(false);
         Response response = new Response();

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/interceptor/GrpcTraceInterceptorTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/interceptor/GrpcTraceInterceptorTest.java
@@ -1,0 +1,243 @@
+package org.flexlb.interceptor;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerCall.Listener;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import org.flexlb.schedule.grpc.FlexlbServiceGrpc;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GrpcTraceInterceptorTest {
+
+    private RecordingExporter exporter;
+    private OpenTelemetrySdk sdk;
+
+    @BeforeEach
+    void setUp() {
+        GlobalOpenTelemetry.resetForTest();
+        exporter = new RecordingExporter();
+        SdkTracerProvider provider = SdkTracerProvider.builder()
+                .setSampler(Sampler.alwaysOn())
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        sdk = OpenTelemetrySdk.builder().setTracerProvider(provider).build();
+        GlobalOpenTelemetry.set(sdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        sdk.close();
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void namesEachRpcFromItsMethodAndPreservesRemoteParent() {
+        Metadata headers = new Metadata();
+        headers.put(Metadata.Key.of("traceparent", Metadata.ASCII_STRING_MARSHALLER),
+                "00-11111111111111111111111111111111-2222222222222222-01");
+        ServerInterceptor interceptor = new GrpcTraceInterceptor();
+        ServerCallHandler<Object, Object> next =
+                (call, requestHeaders) -> new Listener<>() {};
+
+        interceptAndComplete(interceptor, FlexlbServiceGrpc.getScheduleMethod(), headers, next);
+        interceptAndComplete(interceptor, FlexlbServiceGrpc.getGetRequestStateMethod(), headers, next);
+
+        Map<String, SpanData> spans = exporter.spans.stream()
+                .collect(Collectors.toMap(SpanData::getName, span -> span));
+        assertEquals(2, spans.size());
+        assertTrue(spans.containsKey("rtp_llm.flexlb.schedule"));
+        assertTrue(spans.containsKey("rtp_llm.flexlb.get_request_state"));
+        for (SpanData span : spans.values()) {
+            assertEquals(SpanKind.SERVER, span.getKind());
+            assertEquals("11111111111111111111111111111111", span.getTraceId().toString());
+            assertEquals("2222222222222222", span.getParentSpanContext().getSpanId().toString());
+        }
+    }
+
+    @Test
+    void expectedBusinessErrorIsErrorWithoutExceptionEvent() {
+        Metadata headers = new Metadata();
+        AtomicReference<io.opentelemetry.context.Context> capturedContext = new AtomicReference<>();
+        ServerCallHandler<Object, Object> next =
+                (call, requestHeaders) -> {
+                    capturedContext.set(GrpcTraceInterceptor.getOtelContext());
+                    return new Listener<>() {};
+                };
+        @SuppressWarnings("unchecked")
+        ServerCall<Object, Object> call = mock(ServerCall.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        MethodDescriptor<Object, Object> scheduleMethod =
+                (MethodDescriptor) FlexlbServiceGrpc.getScheduleMethod();
+        when(call.getMethodDescriptor()).thenReturn(
+                scheduleMethod);
+        ServerCall.Listener<Object> listener =
+                new GrpcTraceInterceptor().interceptCall(call, headers, next);
+
+        org.flexlb.telemetry.FlexlbTrace.markBusinessError(
+                capturedContext.get(), 8402, "FLEXLB_BUSINESS_REJECTED");
+        listener.onComplete();
+
+        assertEquals(1, exporter.spans.size());
+        SpanData span = exporter.spans.get(0);
+        assertEquals(io.opentelemetry.api.trace.StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals("FLEXLB_BUSINESS_REJECTED",
+                span.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("error.type")));
+        assertEquals(8402L,
+                span.getAttributes().get(io.opentelemetry.api.common.AttributeKey.longKey("flexlb.schedule.code")));
+        assertTrue(span.getEvents().isEmpty());
+    }
+
+    @Test
+    void preexistingServerSpanStillCarriesBusinessError() {
+        // Synthetic upstream-owner test: create an SDK SERVER span and make it
+        // current to stand in for whatever might open one upstream (an
+        // auto-instrumentation agent, or another interceptor) -- no real
+        // -javaagent is loaded here. The interceptor must take the existing-span
+        // branch, keep ownsSpan=false, and neither end that span nor lose the
+        // business rejection recorded while its owner still holds it.
+        Span upstreamSpan = GlobalOpenTelemetry.getTracer("upstream")
+                .spanBuilder("rtp_llm.flexlb.schedule")
+                .setSpanKind(SpanKind.SERVER)
+                .startSpan();
+
+        AtomicReference<io.opentelemetry.context.Context> capturedContext = new AtomicReference<>();
+        ServerCallHandler<Object, Object> next =
+                (call, requestHeaders) -> {
+                    capturedContext.set(GrpcTraceInterceptor.getOtelContext());
+                    return new Listener<>() {};
+                };
+        @SuppressWarnings("unchecked")
+        ServerCall<Object, Object> call = mock(ServerCall.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        MethodDescriptor<Object, Object> scheduleMethod =
+                (MethodDescriptor) FlexlbServiceGrpc.getScheduleMethod();
+        when(call.getMethodDescriptor()).thenReturn(scheduleMethod);
+
+        try (Scope ignored = upstreamSpan.makeCurrent()) {
+            ServerCall.Listener<Object> listener =
+                    new GrpcTraceInterceptor().interceptCall(call, new Metadata(), next);
+            org.flexlb.telemetry.FlexlbTrace.markBusinessError(
+                    capturedContext.get(), 8402, "FLEXLB_BUSINESS_REJECTED");
+            listener.onComplete();
+            // The pre-existing upstream span owns the lifecycle; the interceptor
+            // must not end it.
+            assertEquals(0, exporter.spans.size());
+        }
+        upstreamSpan.end();
+
+        assertEquals(1, exporter.spans.size());
+        SpanData span = exporter.spans.get(0);
+        assertEquals(io.opentelemetry.api.trace.StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals("FLEXLB_BUSINESS_REJECTED",
+                span.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("error.type")));
+        assertEquals(8402L,
+                span.getAttributes().get(io.opentelemetry.api.common.AttributeKey.longKey("flexlb.schedule.code")));
+        assertTrue(span.getEvents().isEmpty());
+    }
+
+    @Test
+    void noopProviderStillPropagatesRemoteTraceparentDownstream() {
+        // Regression guard for the default FlexLB startup (no OTel provider):
+        // GlobalOpenTelemetry is a no-op so startServer() makes no real span, but
+        // the no-op SpanBuilder wraps the extracted parent's SpanContext, so the
+        // incoming traceparent must survive into the published context and be
+        // re-injected byte-for-byte for the downstream forward. An invalid span
+        // must never clobber the remote parent.
+        GlobalOpenTelemetry.resetForTest();
+        try {
+            Metadata headers = new Metadata();
+            headers.put(Metadata.Key.of("traceparent", Metadata.ASCII_STRING_MARSHALLER),
+                    "00-11111111111111111111111111111111-2222222222222222-01");
+            AtomicReference<io.opentelemetry.context.Context> capturedContext = new AtomicReference<>();
+            ServerCallHandler<Object, Object> next =
+                    (call, requestHeaders) -> {
+                        capturedContext.set(GrpcTraceInterceptor.getOtelContext());
+                        return new Listener<>() {};
+                    };
+            @SuppressWarnings("unchecked")
+            ServerCall<Object, Object> call = mock(ServerCall.class);
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            MethodDescriptor<Object, Object> scheduleMethod =
+                    (MethodDescriptor) FlexlbServiceGrpc.getScheduleMethod();
+            when(call.getMethodDescriptor()).thenReturn(scheduleMethod);
+
+            ServerCall.Listener<Object> listener =
+                    new GrpcTraceInterceptor().interceptCall(call, headers, next);
+            listener.onComplete();
+
+            // No provider -> no span exported, by design (fail-open).
+            assertEquals(0, exporter.spans.size());
+            // ...but the downstream carrier still carries the original trace/span.
+            Map<String, String> carrier =
+                    org.flexlb.telemetry.FlexlbTrace.inject(capturedContext.get());
+            String traceparent = carrier.get("traceparent");
+            assertTrue(traceparent != null
+                            && traceparent.contains("11111111111111111111111111111111")
+                            && traceparent.contains("2222222222222222"),
+                    "downstream traceparent must preserve the remote trace/span: " + traceparent);
+        } finally {
+            // Restore the SDK provider so tearDown()'s sdk.close() stays valid.
+            GlobalOpenTelemetry.resetForTest();
+            GlobalOpenTelemetry.set(sdk);
+        }
+    }
+
+    private static void interceptAndComplete(ServerInterceptor interceptor,
+                                              MethodDescriptor<?, ?> method,
+                                              Metadata headers,
+                                              ServerCallHandler<Object, Object> next) {
+        @SuppressWarnings("unchecked")
+        ServerCall<Object, Object> call = mock(ServerCall.class);
+        when(call.getMethodDescriptor()).thenReturn((MethodDescriptor<Object, Object>) method);
+        @SuppressWarnings("unchecked")
+        ServerCall.Listener<Object> listener = interceptor.interceptCall(call, headers, next);
+        listener.onComplete();
+    }
+
+    private static final class RecordingExporter implements SpanExporter {
+        private final List<SpanData> spans = new ArrayList<>();
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> batch) {
+            spans.addAll(batch);
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/BalanceContext.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/BalanceContext.java
@@ -1,5 +1,6 @@
 package org.flexlb.dao;
 
+import io.opentelemetry.context.Context;
 import lombok.Data;
 import lombok.ToString;
 import org.flexlb.config.FlexlbConfig;
@@ -30,6 +31,10 @@ public class BalanceContext implements Prioritized {
 
     @ToString.Exclude
     private byte[] generateInputPbBytes;
+
+    /** OTel context captured at the Schedule RPC boundary for async batch work. */
+    @ToString.Exclude
+    private Context traceContext;
 
     private volatile ScheduleModeEnum scheduleMode = ScheduleModeEnum.BATCH;
 

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/telemetry/FlexlbTrace.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/telemetry/FlexlbTrace.java
@@ -1,0 +1,326 @@
+package org.flexlb.telemetry;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.WeakHashMap;
+
+/**
+ * Small fail-open facade for the FlexLB manual tracing points.
+ *
+ * <p>When RTP_LLM_OTEL_TRACE_ENABLE is enabled, the FlexLB application enables
+ * the SDK provider before Spring starts. An external instrumentation provider
+ * may supply it instead. With tracing disabled, the global implementation stays
+ * no-op and these methods leave scheduling behavior unchanged.</p>
+ */
+public final class FlexlbTrace {
+
+    public static final String INSTRUMENTATION_NAME = "org.flexlb";
+    /**
+     * Platform-indexed span search key. Unitrace only indexes this unprefixed
+     * string spelling, so a span carrying just the numeric twin below cannot be
+     * found by request id. Mirrors kAttrRequestId / REQUEST_ID in the C++ and
+     * Python registries.
+     */
+    public static final String REQUEST_ID = "request_id";
+    /** Numeric twin, kept for internal correlation. */
+    public static final String RTP_LLM_REQUEST_ID = "rtp_llm.request_id";
+    public static final String BATCH_ID = "rtp_llm.batch_id";
+    public static final String BATCH_SIZE = "rtp_llm.batch_size";
+    public static final String PREFILL_ADDRESS = "rtp_llm.prefill_address";
+    public static final String DECODE_ADDRESS = "rtp_llm.decode_address";
+    public static final String DISPATCH_REASON = "rtp_llm.dispatch_reason";
+    public static final String SCHEDULE_MODE = "flexlb.schedule.mode";
+    public static final String SCHEDULE_CODE = "flexlb.schedule.code";
+    public static final String ENQUEUED_BY_MASTER = "rtp_llm.enqueued_by_master";
+    public static final String ROUTE_SUBMIT_MS = "rtp_llm.route_submit_ms";
+    public static final String BATCH_WAIT_MS = "rtp_llm.batch_wait_ms";
+    public static final String ENQUEUE_BATCH_MS = "rtp_llm.enqueue_batch_ms";
+    public static final String ACK_TO_RESPONSE_MS = "rtp_llm.ack_to_response_ms";
+    public static final String GRPC_STATUS_CODE = "rpc.grpc.status_code";
+    /**
+     * Canonical gRPC terminal status on a SERVER span, mirroring the C++
+     * kAttrRpcResponseStatusCode contract; GRPC_STATUS_CODE above carries the
+     * numeric companion.
+     */
+    public static final String RPC_RESPONSE_STATUS_CODE = "rpc.response.status_code";
+    public static final String ERROR_TYPE = "error.type";
+
+    private static final TextMapSetter<Map<String, String>> MAP_SETTER =
+            (carrier, key, value) -> carrier.put(key, value);
+    private static final TextMapPropagator W3C_PROPAGATOR =
+            W3CTraceContextPropagator.getInstance();
+    // Weak keys because this class does not end every span that owns a marker:
+    // an upstream-owned SERVER span is finished by its own owner, so holding it
+    // strongly here would retain it forever.
+    private static final Map<Span, BusinessError> BUSINESS_ERRORS =
+            Collections.synchronizedMap(new WeakHashMap<>());
+
+    private FlexlbTrace() {
+    }
+
+    public static Span startServer(String name, Context parent) {
+        return start(name, parent, SpanKind.SERVER);
+    }
+
+    public static Span startInternal(String name, Context parent) {
+        return start(name, parent, SpanKind.INTERNAL);
+    }
+
+    public static Span startClient(String name, Context parent) {
+        return start(name, parent, SpanKind.CLIENT);
+    }
+
+    public static Context withSpan(Span span, Context fallback) {
+        try {
+            Context base = fallback == null ? Context.current() : fallback;
+            return span == null ? base : span.storeInContext(base);
+        } catch (Throwable ignored) {
+            return fallback == null ? Context.current() : fallback;
+        }
+    }
+
+    public static SpanContext spanContext(Context context) {
+        try {
+            if (context == null) {
+                return null;
+            }
+            SpanContext spanContext = Span.fromContext(context).getSpanContext();
+            return spanContext.isValid() ? spanContext : null;
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    public static Map<String, String> inject(Context context) {
+        Map<String, String> carrier = new HashMap<>();
+        try {
+            Context source = context == null ? Context.current() : context;
+            W3C_PROPAGATOR.inject(source, carrier, MAP_SETTER);
+        } catch (Throwable ignored) {
+            carrier.clear();
+        }
+        return carrier;
+    }
+
+    public static <C> Context extract(Context parent, C carrier, TextMapGetter<C> getter) {
+        try {
+            return W3C_PROPAGATOR.extract(
+                    parent == null ? Context.current() : parent, carrier, getter);
+        } catch (Throwable ignored) {
+            return parent == null ? Context.current() : parent;
+        }
+    }
+
+    public static void setRequestAttributes(Span span, long requestId) {
+        // Double-write, matching the C++ and Python registries: the platform
+        // indexes the string key for span search while the numeric twin stays for
+        // internal correlation.
+        setAttribute(span, REQUEST_ID, Long.toString(requestId));
+        setAttribute(span, RTP_LLM_REQUEST_ID, requestId);
+    }
+
+    public static void setAttribute(Span span, String key, long value) {
+        try {
+            if (span != null) {
+                span.setAttribute(key, value);
+            }
+        } catch (Throwable ignored) {
+            // Trace must never affect routing or dispatch.
+        }
+    }
+
+    public static void setAttribute(Span span, String key, String value) {
+        try {
+            if (span != null && value != null) {
+                span.setAttribute(key, value);
+            }
+        } catch (Throwable ignored) {
+            // Trace must never affect routing or dispatch.
+        }
+    }
+
+    public static void setAttribute(Span span, String key, boolean value) {
+        try {
+            if (span != null) {
+                span.setAttribute(key, value);
+            }
+        } catch (Throwable ignored) {
+            // Trace must never affect routing or dispatch.
+        }
+    }
+
+    /**
+     * Adds an attribute to the already-created Schedule SERVER span. The
+     * scheduling work is asynchronous, so this deliberately does not create
+     * a child span or replace the request context.
+     */
+    public static void setScheduleAttribute(Context context, String key, long value) {
+        setAttribute(spanFromContext(context), key, value);
+    }
+
+    public static void setScheduleAttribute(Context context, String key, String value) {
+        setAttribute(spanFromContext(context), key, value);
+    }
+
+    public static void setScheduleAttribute(Context context, String key, boolean value) {
+        setAttribute(spanFromContext(context), key, value);
+    }
+
+    public static void setScheduleDuration(Context context, String key,
+                                            long startNanos, long endNanos) {
+        if (startNanos > 0 && endNanos >= startNanos) {
+            setScheduleAttribute(context, key,
+                    TimeUnit.NANOSECONDS.toMillis(endNanos - startNanos));
+        }
+    }
+
+    public static void finish(Span span) {
+        finish(span, null);
+    }
+
+    public static void finish(Span span, Throwable error) {
+        if (span == null) {
+            return;
+        }
+        BusinessError expectedError = null;
+        try {
+            // Inside the guard: the marker map is a synchronized WeakHashMap keyed
+            // by Span, so it calls hashCode()/equals() on an implementation this
+            // class does not control.
+            expectedError = error == null ? BUSINESS_ERRORS.remove(span) : null;
+            if (error == null) {
+                if (expectedError == null) {
+                    span.setStatus(StatusCode.OK);
+                } else {
+                    setBusinessError(span, expectedError.code(), expectedError.type());
+                }
+            } else {
+                BUSINESS_ERRORS.remove(span);
+                span.recordException(error);
+                span.setStatus(StatusCode.ERROR, error.getClass().getSimpleName());
+            }
+        } catch (Throwable ignored) {
+            // Exporter/provider failures are explicitly fail-open.
+        } finally {
+            try {
+                span.end();
+            } catch (Throwable ignored) {
+                // Exporter/provider failures are explicitly fail-open.
+            }
+        }
+    }
+
+    /**
+     * Ends a span this class owns using the call's real gRPC terminal status.
+     *
+     * <p>Deliberately not routed through {@link #finish(Span, Throwable)}: that
+     * method sets OK when it finds no marker, and the SDK treats OK as final, so
+     * an ERROR recorded here would be overwritten. A non-OK close is an error in
+     * its own right even without a Throwable; a business-error marker still wins
+     * because it names the cause more precisely than the transport code.
+     *
+     * <p>Takes primitives rather than io.grpc.Status so this module stays free of
+     * a gRPC dependency.
+     */
+    public static void finishWithGrpcStatus(Span span, String canonicalCode, int numericCode, boolean ok) {
+        if (span == null) {
+            return;
+        }
+        setAttribute(span, RPC_RESPONSE_STATUS_CODE, canonicalCode);
+        setAttribute(span, GRPC_STATUS_CODE, numericCode);
+        if (ok) {
+            finish(span, null);
+            return;
+        }
+        try {
+            BusinessError marker = BUSINESS_ERRORS.remove(span);
+            if (marker != null) {
+                setBusinessError(span, marker.code(), marker.type());
+            } else {
+                setAttribute(span, ERROR_TYPE, canonicalCode);
+                span.setStatus(StatusCode.ERROR, canonicalCode);
+            }
+        } catch (Throwable ignored) {
+            // Exporter/provider failures are explicitly fail-open.
+        } finally {
+            try {
+                span.end();
+            } catch (Throwable ignored) {
+                // Exporter/provider failures are explicitly fail-open.
+            }
+        }
+    }
+
+    /** Marks an already-created span from an asynchronous scheduling callback. */
+    public static void markBusinessError(Context context, long code, String type) {
+        // Whole body guarded: this runs on scheduling callbacks, and a throwing
+        // Span or marker-map implementation must not reach the schedule response,
+        // the gRPC status, or the routing result.
+        try {
+            Span span = spanFromContext(context);
+            if (span.getSpanContext().isValid()) {
+                // Apply the status now rather than only leaving a marker: for an
+                // upstream-owned SERVER span (for example, auto-instrumentation or
+                // another interceptor), GrpcTraceInterceptor keeps ownsSpan=false and
+                // never calls finish() on it, so a marker alone would never be
+                // consumed and its owner would end the span with no error recorded.
+                // Keep the marker as well -- finish() on a span this class owns
+                // consumes it and re-applies the error, which is what stops its
+                // default setStatus(OK) from overwriting this ERROR (the SDK only
+                // treats OK as final, so ERROR->OK does overwrite).
+                setBusinessError(span, code, type);
+                BUSINESS_ERRORS.put(span, new BusinessError(code, type));
+            }
+        } catch (Throwable ignored) {
+            // Trace must never affect routing or dispatch.
+        }
+    }
+
+    private static Span start(String name, Context parent, SpanKind kind) {
+        try {
+            Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+            SpanBuilder builder = tracer.spanBuilder(name).setSpanKind(kind);
+            if (parent == null) {
+                builder.setParent(Context.current());
+            } else {
+                builder.setParent(parent);
+            }
+            return builder.startSpan();
+        } catch (Throwable ignored) {
+            return Span.getInvalid();
+        }
+    }
+
+    private static Span spanFromContext(Context context) {
+        try {
+            return context == null ? Span.getInvalid() : Span.fromContext(context);
+        } catch (Throwable ignored) {
+            return Span.getInvalid();
+        }
+    }
+
+    private static void setBusinessError(Span span, long code, String type) {
+        String description = type == null ? "FLEXLB_BUSINESS_REJECTED" : type;
+        setAttribute(span, ERROR_TYPE, description);
+        setAttribute(span, SCHEDULE_CODE, code);
+        span.setStatus(StatusCode.ERROR, description);
+    }
+
+    private record BusinessError(long code, String type) {
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/telemetry/FlexlbTraceTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/telemetry/FlexlbTraceTest.java
@@ -1,0 +1,140 @@
+package org.flexlb.telemetry;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FlexlbTraceTest {
+
+    private RecordingExporter exporter;
+    private OpenTelemetrySdk sdk;
+
+    @BeforeEach
+    void setUp() {
+        GlobalOpenTelemetry.resetForTest();
+        exporter = new RecordingExporter();
+        SdkTracerProvider provider = SdkTracerProvider.builder()
+                .setSampler(Sampler.alwaysOn())
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(provider)
+                .setPropagators(ContextPropagators.create(
+                        W3CTraceContextPropagator.getInstance()))
+                .build();
+        GlobalOpenTelemetry.set(sdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        sdk.close();
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void injectAndExtractRoundTripUsesW3cContext() {
+        Tracer tracer = GlobalOpenTelemetry.getTracer("test");
+        Span root = tracer.spanBuilder("root").setSpanKind(SpanKind.SERVER).startSpan();
+        try {
+            Context rootContext = root.storeInContext(Context.root());
+            Map<String, String> carrier = FlexlbTrace.inject(rootContext);
+            assertTrue(carrier.get("traceparent").startsWith("00-"));
+
+            Context extracted = FlexlbTrace.extract(
+                    Context.root(), carrier, new MapGetter());
+            assertEquals(root.getSpanContext().getTraceId(),
+                    Span.fromContext(extracted).getSpanContext().getTraceId());
+            assertEquals(root.getSpanContext().getSpanId(),
+                    Span.fromContext(extracted).getSpanContext().getSpanId());
+        } finally {
+            root.end();
+        }
+    }
+
+    @Test
+    void scheduleAttributesStayOnExistingServerSpan() {
+        Tracer tracer = GlobalOpenTelemetry.getTracer("test");
+        Span root = tracer.spanBuilder("root").setSpanKind(SpanKind.SERVER).startSpan();
+        try {
+            Context context = root.storeInContext(Context.root());
+            FlexlbTrace.setScheduleAttribute(context, FlexlbTrace.SCHEDULE_MODE, "BATCH");
+            FlexlbTrace.setScheduleAttribute(context, FlexlbTrace.BATCH_ID, 42L);
+            FlexlbTrace.setScheduleAttribute(context, FlexlbTrace.ENQUEUED_BY_MASTER, true);
+            FlexlbTrace.setScheduleDuration(context, FlexlbTrace.BATCH_WAIT_MS,
+                    1_000_000L, 8_000_000L);
+        } finally {
+            root.end();
+        }
+
+        assertEquals(1, exporter.spans.size());
+        SpanData rootData = exporter.spans.get(0);
+        assertEquals(SpanKind.SERVER, rootData.getKind());
+        assertNotNull(rootData.getAttributes().get(
+                AttributeKey.stringKey(FlexlbTrace.SCHEDULE_MODE)));
+        assertEquals("BATCH", rootData.getAttributes().get(
+                AttributeKey.stringKey(FlexlbTrace.SCHEDULE_MODE)));
+        assertEquals(42L, rootData.getAttributes().get(
+                AttributeKey.longKey(FlexlbTrace.BATCH_ID)));
+        assertEquals(true, rootData.getAttributes().get(
+                AttributeKey.booleanKey(FlexlbTrace.ENQUEUED_BY_MASTER)));
+        assertEquals(7L, rootData.getAttributes().get(
+                AttributeKey.longKey(FlexlbTrace.BATCH_WAIT_MS)));
+    }
+
+    private static final class MapGetter implements TextMapGetter<Map<String, String>> {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+            return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+            return carrier.get(key);
+        }
+    }
+
+    private static final class RecordingExporter implements SpanExporter {
+        private final List<SpanData> spans = new ArrayList<>();
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> batch) {
+            spans.addAll(batch);
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/DefaultBatchDispatcher.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/DefaultBatchDispatcher.java
@@ -204,8 +204,9 @@ public class DefaultBatchDispatcher implements BatchDispatcher {
                         // failure through the Engine-side request-id fence.
                         markUncertain(items, batchId, cause, callback);
                     } else if (response == null) {
-                        markUncertain(items, batchId, new RuntimeException(
-                                "EnqueueBatch returned null response"), callback);
+                        RuntimeException missingResponse = new RuntimeException(
+                                "EnqueueBatch returned null response");
+                        markUncertain(items, batchId, missingResponse, callback);
                     } else {
                         handleResponse(batchId, items, response, callback);
                     }
@@ -223,7 +224,8 @@ public class DefaultBatchDispatcher implements BatchDispatcher {
             // execution, which is also post-invocation and therefore
             // ambiguous.
             completionObserver.exceptionally(observerFailure -> {
-                markUncertain(items, batchId, unwrapCompletionFailure(observerFailure), callback);
+                Throwable cause = unwrapCompletionFailure(observerFailure);
+                markUncertain(items, batchId, cause, callback);
                 return null;
             });
         } catch (Throwable registrationFailure) {

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/FlexlbBatchScheduler.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/FlexlbBatchScheduler.java
@@ -28,6 +28,7 @@ import org.flexlb.enums.PriorityPreemptionProgress;
 import org.flexlb.enums.TaskPhase;
 import org.flexlb.balance.scheduler.priority.InflightRegistrar.PriorityCanceledObservation;
 import org.flexlb.service.monitor.BatchSchedulerReporter;
+import org.flexlb.telemetry.FlexlbTrace;
 import org.flexlb.util.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -188,6 +189,14 @@ public class FlexlbBatchScheduler implements BatchDecisionHandler, DispatchCallb
 
             ServerStatus prefill = findServer(routeResponse, RoleType.PREFILL);
             ServerStatus decode = findServer(routeResponse, RoleType.DECODE);
+            if (prefill != null) {
+                FlexlbTrace.setScheduleAttribute(ctx.getTraceContext(), FlexlbTrace.PREFILL_ADDRESS,
+                        prefill.getServerIp() + ":" + prefill.getHttpPort());
+            }
+            if (decode != null) {
+                FlexlbTrace.setScheduleAttribute(ctx.getTraceContext(), FlexlbTrace.DECODE_ADDRESS,
+                        decode.getServerIp() + ":" + decode.getHttpPort());
+            }
             if (prefill == null) {
                 rollback(routeResponse);
                 completeError(future, StrategyErrorType.NO_PREFILL_WORKER, null);
@@ -224,6 +233,8 @@ public class FlexlbBatchScheduler implements BatchDecisionHandler, DispatchCallb
             WorkerBatcher batcher = prefillEp.getBatcher();
             ctx.setRouteSubmittedNanos(System.nanoTime());
             batcher.offer(item);
+            FlexlbTrace.setScheduleDuration(ctx.getTraceContext(), FlexlbTrace.ROUTE_SUBMIT_MS,
+                    ctx.getServiceStartNanos(), ctx.getRouteSubmittedNanos());
 
             // Report route+submit time: from schedule() entry (ctx.startTime) to batcher offer completion
             reporter.reportRouteSubmitTimeMs(
@@ -1288,6 +1299,16 @@ public class FlexlbBatchScheduler implements BatchDecisionHandler, DispatchCallb
                     if (entry != null) {
                         entry.lifecycle.markDispatched();
                         item.ctx().setBatchDispatchedNanos(System.nanoTime());
+                        FlexlbTrace.setScheduleAttribute(item.ctx().getTraceContext(),
+                                FlexlbTrace.BATCH_ID, batchId);
+                        FlexlbTrace.setScheduleAttribute(item.ctx().getTraceContext(),
+                                FlexlbTrace.BATCH_SIZE, dispatchable.size());
+                        FlexlbTrace.setScheduleAttribute(item.ctx().getTraceContext(),
+                                FlexlbTrace.DISPATCH_REASON, reason);
+                        FlexlbTrace.setScheduleDuration(item.ctx().getTraceContext(),
+                                FlexlbTrace.BATCH_WAIT_MS,
+                                item.ctx().getRouteSubmittedNanos(),
+                                item.ctx().getBatchDispatchedNanos());
                     }
                 }
 
@@ -1406,6 +1427,9 @@ public class FlexlbBatchScheduler implements BatchDecisionHandler, DispatchCallb
         // Record ACK timestamp for ack_to_response_time_ms metric (reported in FlexlbServiceImpl.completeSchedule)
         item.ctx().setAckAtMs(System.currentTimeMillis());
         item.ctx().setAckAtNanos(System.nanoTime());
+        FlexlbTrace.setScheduleDuration(item.ctx().getTraceContext(),
+                FlexlbTrace.ENQUEUE_BATCH_MS,
+                item.ctx().getBatchDispatchedNanos(), item.ctx().getAckAtNanos());
 
         long dispatchedAtMs = entry.lifecycle.getDispatchedAtMs();
         if (dispatchedAtMs > 0) {

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/priority/PriorityAdmissionScheduler.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/priority/PriorityAdmissionScheduler.java
@@ -21,6 +21,7 @@ import org.flexlb.dao.route.RoleType;
 import org.flexlb.enums.DecodeTaskPhase;
 import org.flexlb.service.monitor.BatchSchedulerReporter;
 import org.flexlb.service.monitor.PrioritySchedulerReporter;
+import org.flexlb.telemetry.FlexlbTrace;
 import org.flexlb.util.CommonUtils;
 import org.flexlb.util.Logger;
 import org.flexlb.util.PriorityNormalizer;
@@ -1049,6 +1050,10 @@ public class PriorityAdmissionScheduler {
 
         ServerStatus prefill = FlexlbBatchScheduler.findServer(routeResponse, RoleType.PREFILL);
         ServerStatus decode = FlexlbBatchScheduler.findServer(routeResponse, RoleType.DECODE);
+        // Endpoint attributes are written in onCommitted() from the plan that
+        // actually committed, not here: this candidate is still discarded by the
+        // two infeasible exits below (and by a failed commit), and recording it
+        // now would name a node the request never used.
         if (prefill == null) {
             rollbackRoute(routeResponse);
             return PlacementOutcome.infeasible(null);
@@ -1178,6 +1183,16 @@ public class PriorityAdmissionScheduler {
         }
         ServerStatus prefill = plan.item().prefill();
         ctx.setScheduledPrefillEndpoint(prefill.getServerIp() + ":" + prefill.getHttpPort());
+        // Written here rather than at routing time so the attributes always name
+        // the committed placement. Covers the eviction paths too, since they
+        // reach this method as well.
+        FlexlbTrace.setScheduleAttribute(ctx.getTraceContext(), FlexlbTrace.PREFILL_ADDRESS,
+                prefill.getServerIp() + ":" + prefill.getHttpPort());
+        ServerStatus committedDecode = plan.item().decode();
+        if (committedDecode != null) {
+            FlexlbTrace.setScheduleAttribute(ctx.getTraceContext(), FlexlbTrace.DECODE_ADDRESS,
+                    committedDecode.getServerIp() + ":" + committedDecode.getHttpPort());
+        }
         priorityReporter.reportNormalPlacement(plan.envelope().priority());
         // Parity with the legacy path's route+submit latency metric.
         batchReporter.reportRouteSubmitTimeMs(

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/RouteService.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/RouteService.java
@@ -10,6 +10,7 @@ import org.flexlb.config.FlexlbConfig;
 import org.flexlb.dao.BalanceContext;
 import org.flexlb.dao.loadbalance.Response;
 import org.flexlb.enums.ScheduleModeEnum;
+import org.flexlb.telemetry.FlexlbTrace;
 import org.flexlb.util.Logger;
 import org.springframework.stereotype.Component;
 
@@ -47,13 +48,22 @@ public class RouteService {
 
         ScheduleModeEnum mode = flexlbConfig.getDefaultScheduleModeEnum();
         balanceContext.setScheduleMode(mode);
+        FlexlbTrace.setScheduleAttribute(
+                balanceContext.getTraceContext(), FlexlbTrace.SCHEDULE_MODE, mode.name());
+
+        boolean batchEligible = mode == ScheduleModeEnum.BATCH
+                && flexlbBatchScheduler != null
+                && hasValidGenerateInput(balanceContext);
 
         CompletableFuture<Response> resultFuture;
         switch (mode) {
             case BATCH -> {
-                if (flexlbBatchScheduler == null || !hasValidGenerateInput(balanceContext)) {
+                if (!batchEligible) {
                     Logger.debug("BATCH mode cannot process this request, falling back to DIRECT");
                     balanceContext.setScheduleMode(ScheduleModeEnum.DIRECT);
+                    FlexlbTrace.setScheduleAttribute(
+                            balanceContext.getTraceContext(), FlexlbTrace.SCHEDULE_MODE,
+                            ScheduleModeEnum.DIRECT.name());
                     try {
                         resultFuture = CompletableFuture.completedFuture(router.route(balanceContext));
                     } catch (Exception e) {
@@ -84,6 +94,8 @@ public class RouteService {
         }
 
         return resultFuture.whenComplete((result, throwable) -> {
+            // The Schedule SERVER interceptor owns the span lifetime. This
+            // callback only publishes the result and business metrics.
             if (throwable != null) {
                 return;
             }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/DefaultBatchDispatcherTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/DefaultBatchDispatcherTest.java
@@ -1,5 +1,8 @@
 package org.flexlb.balance.scheduler;
 
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
 import org.flexlb.balance.endpoint.PrefillEndpoint;
 import org.flexlb.config.ConfigService;
 import org.flexlb.config.FlexlbConfig;
@@ -477,8 +480,150 @@ class DefaultBatchDispatcherTest {
         assertEquals(RoleType.PREFILL, RoleTypeProtoConverter.fromRoleAddr(addr));
     }
 
+    @Test
+    void dispatchPreservesDistinctPerRequestTraceContextsInOneBatch() throws Exception {
+        PrefillEndpoint prefillEp = createPrefillEndpoint();
+        BatchItem first = createBatchItem(501L, 500, 200, prefillEp);
+        BatchItem second = createBatchItem(502L, 500, 200, prefillEp);
+        first.ctx().setGenerateInputPbBytes(generateInputWithTraceContext(
+                501L,
+                "00-11111111111111111111111111111111-1111111111111111-01",
+                "vendor=one").toByteArray());
+        second.ctx().setGenerateInputPbBytes(generateInputWithTraceContext(
+                502L,
+                "00-22222222222222222222222222222222-2222222222222222-01",
+                "vendor=two").toByteArray());
+
+        List<EngineRpcService.EnqueueBatchRequestPB> sent = new CopyOnWriteArrayList<>();
+        when(grpcClient.batchEnqueueAsync(anyString(), anyInt(), any(), anyLong()))
+                .thenAnswer(inv -> {
+                    sent.add(inv.getArgument(2));
+                    return CompletableFuture.completedFuture(ackResponse(92L, List.of(501L, 502L)));
+                });
+
+        dispatcher.dispatch(List.of(first, second), prefillEp,
+                92L, 100, "trace_context", callback);
+
+        assertTrue(callback.successLatch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, sent.size());
+        List<EngineRpcService.EnqueueBatchExternalInputPB> requests =
+                sent.getFirst().getDpSlots(0).getRequestsList();
+        assertEquals(2, requests.size());
+        EngineRpcService.GenerateInputPB firstSent = requests.stream()
+                .map(EngineRpcService.EnqueueBatchExternalInputPB::getInput)
+                .filter(input -> input.getRequestId() == 501L)
+                .findFirst().orElseThrow();
+        EngineRpcService.GenerateInputPB secondSent = requests.stream()
+                .map(EngineRpcService.EnqueueBatchExternalInputPB::getInput)
+                .filter(input -> input.getRequestId() == 502L)
+                .findFirst().orElseThrow();
+        assertEquals("00-11111111111111111111111111111111-1111111111111111-01",
+                firstSent.getRequestInfo().getTraceContext().getTraceparent());
+        assertEquals("vendor=one", firstSent.getRequestInfo().getTraceContext().getTracestate());
+        assertEquals("00-22222222222222222222222222222222-2222222222222222-01",
+                secondSent.getRequestInfo().getTraceContext().getTraceparent());
+        assertEquals("vendor=two", secondSent.getRequestInfo().getTraceContext().getTracestate());
+    }
+
+    @Test
+    void oldDescriptorRoundTripPreservesNestedTraceContextUnknownField() throws Exception {
+        EngineRpcService.GenerateInputPB payload = generateInputWithTraceContext(
+                503L,
+                "00-33333333333333333333333333333333-3333333333333333-01",
+                "vendor=legacy");
+        Descriptors.Descriptor legacy = legacyGenerateInputDescriptor();
+
+        DynamicMessage oldReader = DynamicMessage.parseFrom(legacy, payload.toByteArray());
+        Descriptors.FieldDescriptor requestInfoField = legacy.findFieldByNumber(9);
+        DynamicMessage oldRequestInfo = (DynamicMessage) oldReader.getField(requestInfoField);
+        assertTrue(!oldRequestInfo.getUnknownFields().getField(6).getLengthDelimitedList().isEmpty());
+
+        DynamicMessage oldWriter = oldReader.toBuilder()
+                .setField(legacy.findFieldByNumber(10), 73)
+                .build();
+        EngineRpcService.GenerateInputPB reparsed =
+                EngineRpcService.GenerateInputPB.parseFrom(oldWriter.toByteArray());
+
+        assertEquals(73, reparsed.getPriority());
+        assertEquals(payload.getRequestInfo().getTraceContext(),
+                reparsed.getRequestInfo().getTraceContext());
+    }
+
     private static EngineRpcService.GenerateInputPB sentInput(EngineRpcService.EnqueueBatchRequestPB request) {
         return request.getDpSlotsList().getFirst().getRequestsList().getFirst().getInput();
+    }
+
+    private static EngineRpcService.GenerateInputPB generateInputWithTraceContext(
+            long requestId, String traceparent, String tracestate) {
+        return EngineRpcService.GenerateInputPB.newBuilder()
+                .setRequestId(requestId)
+                .setGenerateConfig(EngineRpcService.GenerateConfigPB.newBuilder().build())
+                .setRequestInfo(EngineRpcService.RequestInfoPB.newBuilder()
+                        .setTraceContext(EngineRpcService.TraceContextPB.newBuilder()
+                                .setTraceparent(traceparent)
+                                .setTracestate(tracestate)
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static Descriptors.Descriptor legacyGenerateInputDescriptor() throws Exception {
+        DescriptorProtos.DescriptorProto requestInfo = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("RequestInfoPB")
+                .addField(optionalField("frontend_ip", 1,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, null))
+                .addField(optionalField("dash_ip", 2,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, null))
+                .addField(optionalField("trace_id", 3,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, null))
+                .addField(optionalField("request_id", 4,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, null))
+                .addField(optionalField("source_role", 5,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, null))
+                .build();
+        DescriptorProtos.DescriptorProto generateConfig = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GenerateConfigPB")
+                .build();
+        DescriptorProtos.DescriptorProto generateInput = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GenerateInputPB")
+                .addField(optionalField("request_id", 1,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64, null))
+                .addField(optionalField("generate_config", 4,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE,
+                        ".legacy_trace.GenerateConfigPB"))
+                .addField(optionalField("request_info", 9,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE,
+                        ".legacy_trace.RequestInfoPB"))
+                .addField(optionalField("priority", 10,
+                        DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32, null))
+                .build();
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("legacy_trace_generate_input.proto")
+                .setPackage("legacy_trace")
+                .setSyntax("proto3")
+                .addMessageType(requestInfo)
+                .addMessageType(generateConfig)
+                .addMessageType(generateInput)
+                .build();
+        return Descriptors.FileDescriptor.buildFrom(file, new Descriptors.FileDescriptor[0])
+                .findMessageTypeByName("GenerateInputPB");
+    }
+
+    private static DescriptorProtos.FieldDescriptorProto optionalField(
+            String name,
+            int number,
+            DescriptorProtos.FieldDescriptorProto.Type type,
+            String typeName) {
+        DescriptorProtos.FieldDescriptorProto.Builder builder =
+                DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName(name)
+                        .setNumber(number)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(type);
+        if (typeName != null) {
+            builder.setTypeName(typeName);
+        }
+        return builder.build();
     }
 
     // ---- helpers ----

--- a/rtp_llm/server/master_client.py
+++ b/rtp_llm/server/master_client.py
@@ -30,6 +30,8 @@ from rtp_llm.metrics import kmonitor
 from rtp_llm.metrics.kmonitor_metric_reporter import AccMetrics
 from rtp_llm.server.host_service import HostService
 from rtp_llm.server.worker_status import _coerce_role_type
+from rtp_llm.telemetry import attributes as trace_attrs
+from rtp_llm.telemetry import start_client_span
 from rtp_llm.utils.base_model_datatypes import GenerateInput
 
 route_logger = logging.getLogger("route_logger")
@@ -203,7 +205,52 @@ class MasterClient:
                 request_id,
                 request_pb.priority,
             )
-            response = await stub.Schedule(request_pb, timeout=timeout_s)
+            client_span, trace_metadata = start_client_span(
+                "rtp_llm.flexlb.schedule", target
+            )
+            if client_span is not None:
+                # Double-write: the platform indexes the unprefixed string key for
+                # span search, the numeric twin stays for internal correlation.
+                # Same contract as the generate_stream_call / fetch_response spans.
+                client_span.set_attribute(trace_attrs.REQUEST_ID, str(request_id))
+                client_span.set_attribute(trace_attrs.RTP_LLM_REQUEST_ID, request_id)
+            try:
+                response = await stub.Schedule(
+                    request_pb,
+                    timeout=timeout_s,
+                    metadata=trace_metadata or None,
+                )
+            except BaseException as error:
+                if client_span is not None:
+                    if isinstance(error, grpc.aio.AioRpcError):
+                        client_span.set_attribute(
+                            trace_attrs.RPC_RESPONSE_STATUS_CODE, error.code().name
+                        )
+                        client_span.finish(error=error, error_type="RpcError")
+                    elif isinstance(error, asyncio.CancelledError):
+                        client_span.finish(error=error, error_type="Cancelled")
+                    else:
+                        client_span.finish(error=error, error_type="RpcError")
+                raise
+            if client_span is not None:
+                # The transport succeeded whatever the business code says; the
+                # sibling fetch_response CLIENT span already ships this key, so it
+                # is known not to disturb the platform's token aggregation.
+                client_span.set_attribute(
+                    trace_attrs.RPC_RESPONSE_STATUS_CODE, grpc.StatusCode.OK.name
+                )
+                client_span.set_attribute(
+                    trace_attrs.RTP_LLM_SCHEDULE_CODE, int(response.code)
+                )
+                # A rejecting business code on an otherwise successful transport is
+                # still a failed schedule: the caller raises FtRuntimeException on
+                # it (see the SUCCESS_CODE branch below). Closing this span as OK
+                # would contradict the code just recorded above and hide the
+                # rejection from status-based filtering on the CLIENT span.
+                if int(response.code) != SUCCESS_CODE:
+                    client_span.finish(error_type="FlexlbBusinessRejected")
+                else:
+                    client_span.finish()
             return response
         except grpc.aio.AioRpcError as e:
             elapsed = time.time() - start

--- a/rtp_llm/telemetry/README.md
+++ b/rtp_llm/telemetry/README.md
@@ -8,8 +8,11 @@ RTP-LLM 内置 OpenTelemetry trace（Python frontend + C++ engine 双侧自产 s
 export RTP_LLM_OTEL_TRACE_ENABLE=1        # 总开关，默认关闭
 # 二选一：
 export RTP_LLM_OTEL_REGION=cn-hangzhou    # region 映射自动解析 endpoint/headers/CA
-# 或显式指定 endpoint：
+# 或显式指定（此时需自行把 endpoint 和鉴权 headers 一起给齐）：
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://<collector>/v1/traces
+# collector 需鉴权时必须同时给 headers，否则导出被拒（401/403）；
+# 引擎不把 headers 传给 exporter 构造参数，而是依赖 OTel SDK 从该 env 读取。
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS='x-arms-license-key=<key>,x-arms-project=<proj>,x-cms-workspace=<ws>'
 ```
 
 行为要点（代码依据：`tracing.py` / `cpp/telemetry/TelemetryRuntime.cc`）：
@@ -63,13 +66,71 @@ Python/C++ 两侧均在 **`POD_IP` 环境变量非空**时向 Resource 写入 `h
 
 以上默认值 Python 与 C++ 两侧一致；两侧读取同一组环境变量，无需分别配置。
 
-## 5. 部署后验证
+## 5. FlexLB（Java master）的 trace
+
+FlexLB 是独立的 Java 进程，与 Python/C++ 引擎共用
+`RTP_LLM_OTEL_TRACE_ENABLE` 总开关，导出配置使用标准 `OTEL_*` 环境变量。
+开关为真且配置了 OTLP endpoint 时，`Application` 会在 Spring 启动前自动启用
+OpenTelemetry provider；无需额外添加 JVM `-D` 参数或 Java agent。
+
+FlexLB 内的埋点分两部分：
+- **手工埋点**（`GrpcTraceInterceptor` + `FlexlbTrace`）：负责 Schedule 的 SERVER span、
+  业务属性（`flexlb.schedule.*`、`rtp_llm.*`）与业务拒绝的 ERROR 状态。默认只启用
+  trace exporter；metrics/log exporter 默认关闭。
+- **自动埋点**（OpenTelemetry Java agent，可选）：额外补 gRPC 客户端/服务端 span、
+  `rpc.*` / `network.*` 等属性。当前生产启动脚本不加载 `-javaagent`。
+
+### 5.1 手工埋点的最小开启方式
+
+```bash
+export RTP_LLM_OTEL_TRACE_ENABLE=1
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://<collector>/apm/trace/opentelemetry/otlp/v1/traces
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS='x-arms-license-key=<key>,x-arms-project=<proj>,x-cms-workspace=<ws>'
+
+java -jar flexlb.jar ...
+```
+
+应用默认设置 `OTEL_SERVICE_NAME=rtp_llm_flexlb`，并关闭 metrics/log exporter；部署侧显式配置
+对应 `OTEL_*` 变量时以用户配置为准。若总开关关闭或 endpoint 缺失，provider 保持 no-op，
+不影响调度或远端 traceparent 透传。`OTEL_EXPORTER_OTLP_TRACES_HEADERS` 承载接入凭证，
+应通过 Secret 在运行时注入，不应硬编码进镜像或发布包（与第 2 节口径一致）。
+
+### 5.2 启用自动埋点（Java agent，可选）
+
+若还想要 gRPC/HTTP 层的自动 span，再额外挂 agent：
+
+```bash
+java -javaagent:/path/to/opentelemetry-javaagent.jar -jar flexlb.jar ...
+```
+
+启用 agent 前需要知道的两点（均为实测结论）：
+
+1. **成功请求的 Schedule span 状态是 `UNSET`，不是 `OK`。** agent 拥有 SERVER span 时
+   由 agent 结束，而 OTel 规范要求 instrumentation 成功时不设 OK。按 `status == OK`
+   过滤成功请求的看板会漏掉这些 span —— 应改用「非 ERROR」或依赖 `flexlb.schedule.code`。
+   （业务拒绝仍会被手工埋点标为 `ERROR` + `error.type=FLEXLB_BUSINESS_REJECTED`，不受影响。）
+2. **agent 会显著放大 span 量。** 实测约 88% 是定时健康检查等后台任务产生的 span，
+   接入前需评估 collector 侧的采样与配额。
+
+手工 SERVER span 与 agent SERVER span **不会重复**：`GrpcTraceInterceptor` 检测到已有
+current span 时复用它（`ownsSpan=false`），不会再建第二个。
+
+## 6. 部署后验证
 
 1. 发一条 chat completions 请求（trace 仅覆盖 `/v1/chat/completions` 入口）。
 2. 从 access log 取 trace_id：`grep <prompt关键词> logs/access_r*_s*.log`，取 `trace_id` 字段。
 3. 确认导出无失败：`grep 'failed to export' logs/*.log` 应无命中。
-4. 在观测平台用 trace_id 检索，确认 span 树完整（PD 分离 11 span，含 decode 侧 `load_cache` 子 span；Fusion 6 span）、
+4. 在观测平台用 trace_id 检索，确认 span 树完整、
    流式请求的 POST span 附加信息 Events(1) 为 `first_response_chunk`；非流式请求无该 event、
    平台上能看到该实例 IP（`<POD_IP>`）、且请求数/耗时指标有数据。
+
+   按拓扑对照 span 数（实测值）：
+
+   | 拓扑 | span 数 | 特征 span |
+   |---|---|---|
+   | Fusion | 6 | — |
+   | PD 分离（frontend 直连 prefill） | 11 | `rtp_llm.prefill_generate_stream_call`；decode 侧 `load_cache` |
+   | PD 分离 + master 凑批 | 14 | `rtp_llm.prefill_batch_request`、`rtp_llm.fetch_response`；FlexLB 的 `rtp_llm.flexlb.schedule` |
 
 新 service.name 首批 trace 的平台索引可能有分钟级延迟，属正常现象。

--- a/rtp_llm/telemetry/README.md
+++ b/rtp_llm/telemetry/README.md
@@ -18,7 +18,7 @@ export OTEL_EXPORTER_OTLP_TRACES_HEADERS='x-arms-license-key=<key>,x-arms-projec
 行为要点（代码依据：`tracing.py` / `cpp/telemetry/TelemetryRuntime.cc`）：
 
 - **fail-open**：telemetry 任何初始化/导出失败只降级关闭，不影响推理。
-- **仅 tp_rank 0 产 span**，其余 rank 自动禁用；DP 部署下每个 DP 组的 tp_rank0 均产 span（请求只路由到一组，trace 不重复）。C++ 侧 Resource 带 `rtp_llm.dp_rank` / `rtp_llm.world_rank` 用于区分副本；Python frontend 侧 Resource 只有 `service.name` / `service.instance.id` / `process.pid` / `rtp_llm.role`，副本靠 `service.instance.id`（`hostname-pid`）区分。
+- **仅 tp_rank 0 产 span**，其余 rank 自动禁用；DP 部署下每个 DP 组的 tp_rank0 均产 span（请求只路由到一组，trace 不重复）。C++ 侧 Resource 带 `rtp_llm.dp_rank` / `rtp_llm.world_rank` 用于区分副本；Python frontend 侧无 rank 字段，副本靠 `service.instance.id` 区分（见第 3 节）。
 - 开关打开但无 endpoint 时 telemetry 静默禁用（error 日志可查）。
 
 ## 2. endpoint 解析优先级
@@ -34,20 +34,32 @@ export OTEL_EXPORTER_OTLP_TRACES_HEADERS='x-arms-license-key=<key>,x-arms-projec
 `/etc/rtp_llm/trace_regions.json`）。region 解析结果不会覆盖用户已显式设置的 env。
 region 解析在 launcher 进程（`start_server.py`）中执行后随环境继承给 C++ backend 子进程。
 
-## 3. POD_IP 与平台指标面板（重要）
+## 3. 实例身份与平台指标面板（重要）
 
-Python/C++ 两侧均在 **`POD_IP` 环境变量非空**时向 Resource 写入 `host.ip`。
-观测平台的请求数/错误数/耗时面板依赖该属性做实例维度的过滤统计，
-**span 缺少它时这些面板恒为"暂无数据"**——trace 本身仍然完整，只是指标面板统计不到。
+观测平台的请求数/错误数/耗时面板依赖 Resource 的 `host.ip` 做实例维度的过滤统计，
+**span 缺少它时这些面板恒为“暂无数据”**——trace 本身仍然完整，只是指标面板统计不到。
 
-- **k8s 部署**：`POD_IP` 通常已由 downward API 注入，无需额外配置。
-- **非 k8s 部署（物理机 / docker 直跑）**：必须显式设置，例如：
+Python / C++ / FlexLB 三侧写入同一组 Resource 属性：
+
+| 属性 | 取值 | 写入条件 |
+|---|---|---|
+| `host.name` | 主机名 | 主机名可取到时 |
+| `host.ip` | `{主机名}-{pid}`（**不是 IP**） | 同上 |
+| `service.instance.id` | 同 `host.ip` | 恒写（主机名不可得时为 `unknown-{pid}`） |
+| `rtp_llm.pod_ip` | `POD_IP` | `POD_IP` 非空时 |
+| `gen_ai.instrumentation.sdk.name` | 固定 `loongsuite-genai-utils` | 恒写 |
+
+部署要点：
+
+- `host.name` / `host.ip` 由进程自行取主机名得到，**无需配置**，也不受 `$HOSTNAME` 影响（设该变量不会改变它们）。
+- `POD_IP` **不再影响指标面板**，只决定 `rtp_llm.pod_ip` 是否有值。k8s 下通常已由 downward API
+  注入；非 k8s 部署如需该字段，显式设置：
 
   ```bash
   export POD_IP=$(hostname -i | awk '{print $1}')
   ```
 
-注：时间窗内无错误请求时错误数显示"暂无数据"属正常现象（口径为 OTel status=ERROR 的 span 数）。
+注：时间窗内无错误请求时错误数显示“暂无数据”属正常现象（口径为 OTel status=ERROR 的 span 数）。
 
 ## 4. 环境变量一览
 
@@ -62,7 +74,7 @@ Python/C++ 两侧均在 **`POD_IP` 环境变量非空**时向 Resource 写入 `h
 | `RTP_LLM_OTEL_BSP_SCHEDULE_DELAY_MS` | `5000` | BSP 导出周期 |
 | `RTP_LLM_OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | `512` | 单批导出条数（自动 clamp 到不超过队列上限） |
 | `RTP_LLM_OTEL_HTTP_TIMEOUT_MS` | `3000` | OTLP HTTP 导出超时 |
-| `POD_IP` | 空 | 非空时写 Resource `host.ip`（指标面板依赖，见第 3 节） |
+| `POD_IP` | 空 | 非空时写 Resource `rtp_llm.pod_ip`（不影响指标面板，见第 3 节） |
 
 以上默认值 Python 与 C++ 两侧一致；两侧读取同一组环境变量，无需分别配置。
 
@@ -123,7 +135,7 @@ current span 时复用它（`ownsSpan=false`），不会再建第二个。
 3. 确认导出无失败：`grep 'failed to export' logs/*.log` 应无命中。
 4. 在观测平台用 trace_id 检索，确认 span 树完整、
    流式请求的 POST span 附加信息 Events(1) 为 `first_response_chunk`；非流式请求无该 event、
-   平台上能看到该实例 IP（`<POD_IP>`）、且请求数/耗时指标有数据。
+   平台上该实例显示为 `host.ip`（即 `{主机名}-{pid}`，不是 IP）、且请求数/耗时指标有数据。
 
    按拓扑对照 span 数（实测值）：
 

--- a/rtp_llm/telemetry/attributes.py
+++ b/rtp_llm/telemetry/attributes.py
@@ -108,12 +108,28 @@ RTP_LLM_SCHEDULE_CODE = "flexlb.schedule.code"
 
 # --- C++-side span keys (single-source registry; C++ mirror lives in
 # rtp_llm/cpp/telemetry/TraceAttributes.h and must stay in sync with this
-# section). host.ip is a resource attribute set in TelemetryRuntime.cc and is
-# intentionally excluded from the span-key registry. ---
+# section). Resource attributes (service.name, service.instance.id, process.pid,
+# rtp_llm.role, rtp_llm.dp_rank, rtp_llm.world_rank,
+# gen_ai.instrumentation.sdk.name, host.name, host.ip, rtp_llm.pod_ip) are
+# process identity written once per TracerProvider, so they are deliberately
+# absent from this span-key registry. Note host.ip carries "{hostname}-{pid}"
+# for per-process platform aggregation, while the real pod address lives in
+# rtp_llm.pod_ip. ---
 # Bailian Unitrace indexes spans by the unprefixed string request_id; the
 # rtp_llm.* twin retains the numeric engine id for internal correlation.
 REQUEST_ID = "request_id"
 RTP_LLM_REQUEST_ID = "rtp_llm.request_id"
+# Engine identity on C++-synthesized phase spans, sourced from world_rank alone
+# (not a dp_rank/world_rank pair: the world rank is already unique per
+# deployment). Written as an integer so the platform aggregates it numerically.
+GEN_AI_ENGINE_INDEX = "gen_ai.engine.index"
+# PD topology role of the measured phase. Only the compute phases carry it:
+# `wait` (queueing) and `load_cache` (transfer) produce and consume nothing.
+# A fused deployment reports "none" instead of omitting the key.
+GEN_AI_PD_ROLE = "gen_ai.pd_role"
+GEN_AI_PD_ROLE_PRODUCER = "producer"
+GEN_AI_PD_ROLE_CONSUMER = "consumer"
+GEN_AI_PD_ROLE_NONE = "none"
 # Numeric gRPC status companion to error.type (GrpcStatusSpanGuard).
 RTP_LLM_GRPC_STATUS_CODE = "rtp_llm.grpc_status_code"
 # Stable application error identity on the operation that directly observed

--- a/rtp_llm/telemetry/attributes.py
+++ b/rtp_llm/telemetry/attributes.py
@@ -100,6 +100,12 @@ RTP_LLM_ROUTE_SOURCE_VALUES = frozenset(
 RTP_LLM_ROUTE_QUEUE_LENGTH = "rtp_llm.route.queue_length"
 RTP_LLM_ROUTE_QUEUE_REJECT_THRESHOLD = "rtp_llm.route.queue_reject_threshold"
 
+# FlexLB business status on the schedule CLIENT span. A non-SUCCESS value is a
+# rejected schedule even when the gRPC transport closed OK, so it is recorded
+# alongside RPC_RESPONSE_STATUS_CODE rather than instead of it. The Java master
+# writes the same key on its SERVER span (FlexlbTrace.SCHEDULE_CODE).
+RTP_LLM_SCHEDULE_CODE = "flexlb.schedule.code"
+
 # --- C++-side span keys (single-source registry; C++ mirror lives in
 # rtp_llm/cpp/telemetry/TraceAttributes.h and must stay in sync with this
 # section). host.ip is a resource attribute set in TelemetryRuntime.cc and is
@@ -124,6 +130,11 @@ RTP_LLM_POLL_LOCAL_OUTPUT_RT_US = "rtp_llm.poll_local_output_rt_us"
 RTP_LLM_POLL_REMOTE_OUTPUT_RT_US = "rtp_llm.poll_remote_output_rt_us"
 # True only when a failed request cuts off a phase before its natural end.
 RTP_LLM_PHASE_TRUNCATED = "rtp_llm.phase.truncated"
+# Frontend-to-prefill handoff delay on the master coalescing path, covering the
+# FlexLB coalescing wait plus both network hops. Written by the C++ prefill node
+# only; it subtracts two machines' wall clocks, so it is an approximation
+# subject to NTP skew rather than a precise latency metric.
+RTP_LLM_PREFILL_HANDOFF_DELAY_US = "rtp_llm.prefill_handoff_delay_us"
 
 # --- HTTP semconv (root SERVER span only). Platform views read the two
 # semconv generations with inconsistent priority, and the HTTP-error counter

--- a/rtp_llm/telemetry/test/test_tracing.py
+++ b/rtp_llm/telemetry/test/test_tracing.py
@@ -191,8 +191,11 @@ class TestConfig(TracingTestCase):
         os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = (
             "http://127.0.0.1:4318/v1/traces"
         )
-        with mock.patch.object(tracing, "OTEL_AVAILABLE", False), mock.patch.object(
-            tracing, "_OTEL_IMPORT_ERROR", ImportError("simulated"), create=True
+        with (
+            mock.patch.object(tracing, "OTEL_AVAILABLE", False),
+            mock.patch.object(
+                tracing, "_OTEL_IMPORT_ERROR", ImportError("simulated"), create=True
+            ),
         ):
             assert not tracing.init_telemetry("frontend", 0)
             assert tracing.telemetry_state() == tracing.TelemetryState.DISABLED
@@ -476,11 +479,12 @@ class TestResource(TracingTestCase):
         assert os.environ["POD_IP"] == "10.7.8.9"
 
     def test_resolve_region_env_uses_hostname_ip(self):
-        with mock.patch.object(
-            socket, "gethostname", return_value="test-host"
-        ), mock.patch.object(
-            socket, "gethostbyname", return_value="10.7.8.9"
-        ) as gethostbyname:
+        with (
+            mock.patch.object(socket, "gethostname", return_value="test-host"),
+            mock.patch.object(
+                socket, "gethostbyname", return_value="10.7.8.9"
+            ) as gethostbyname,
+        ):
             tracing.resolve_region_env()
         assert os.environ["POD_IP"] == "10.7.8.9"
         gethostbyname.assert_called_once_with("test-host")
@@ -859,6 +863,25 @@ class TestActiveRuntime(TracingTestCase):
         spans = {s.name: s for s in exporter.get_finished_spans()}
         assert spans["client"].parent.span_id == spans["server"].context.span_id
         assert spans["client"].context.trace_id == spans["server"].context.trace_id
+
+    def test_internal_span_parents_schedule_client_and_resets_context(self):
+        exporter = _start_in_memory_runtime()
+        state = tracing.start_server_span("server", {})
+        internal = tracing.start_internal_span("batch_wait")
+        assert internal is not None
+        client, metadata = tracing.start_client_span("schedule", "master:7003")
+        assert client is not None
+        assert dict(metadata)["traceparent"]
+        client.finish()
+        internal.finish()
+        assert tracing.CURRENT_INTERNAL_CONTEXT.get() is None
+        state.finish()
+        tracing.shutdown_telemetry()
+
+        spans = {span.name: span for span in exporter.get_finished_spans()}
+        assert spans["batch_wait"].parent.span_id == spans["server"].context.span_id
+        assert spans["schedule"].parent.span_id == spans["batch_wait"].context.span_id
+        assert spans["schedule"].context.trace_id == spans["server"].context.trace_id
 
     def test_shutdown_idempotent(self):
         _start_in_memory_runtime()

--- a/rtp_llm/telemetry/test/test_tracing.py
+++ b/rtp_llm/telemetry/test/test_tracing.py
@@ -424,7 +424,7 @@ class TestScopeVersion(TracingTestCase):
 
 
 class TestResource(TracingTestCase):
-    """Parity with the C++ runtime: host.ip only from POD_IP."""
+    """Parity with the C++ runtime: host.ip is hostname-pid, pod IP is separate."""
 
     def setUp(self):
         super().setUp()
@@ -439,17 +439,52 @@ class TestResource(TracingTestCase):
         assert len(spans) == 1
         return spans[0].resource.attributes
 
-    def test_host_ip_from_pod_ip(self):
+    def test_pod_ip_lands_on_rtp_llm_pod_ip(self):
         os.environ["POD_IP"] = "10.1.2.3"
         exporter = _start_in_memory_runtime()
         attributes = self._finished_resource_attributes(exporter)
-        assert attributes.get("host.ip") == "10.1.2.3"
+        assert attributes.get("rtp_llm.pod_ip") == "10.1.2.3"
+        # The pod address must never leak back into host.ip: the platform's
+        # per-instance panels key off host.ip and a pod IP is not process-unique.
+        assert attributes.get("host.ip") != "10.1.2.3"
         assert attributes.get("rtp_llm.role") == "test"
 
-    def test_host_ip_absent_without_pod_ip(self):
+    def test_rtp_llm_pod_ip_absent_without_pod_ip(self):
         exporter = _start_in_memory_runtime()
         attributes = self._finished_resource_attributes(exporter)
+        assert "rtp_llm.pod_ip" not in attributes
+        # host.ip no longer depends on POD_IP, so it stays present.
+        assert attributes.get("host.ip", "").endswith(f"-{os.getpid()}")
+
+    def test_host_identity_is_hostname_and_hostname_pid(self):
+        with mock.patch.object(socket, "gethostname", return_value="probe-host"):
+            exporter = _start_in_memory_runtime()
+            attributes = self._finished_resource_attributes(exporter)
+        assert attributes.get("host.name") == "probe-host"
+        assert attributes.get("host.ip") == f"probe-host-{os.getpid()}"
+        assert attributes.get("service.instance.id") == f"probe-host-{os.getpid()}"
+
+    def test_host_keys_skipped_when_hostname_unknown(self):
+        # "unknown-<pid>" would pollute exactly the per-instance aggregation the
+        # host keys exist to serve, so neither is synthesized. The instance id
+        # keeps its fallback so it is never absent.
+        with mock.patch.object(socket, "gethostname", return_value=""):
+            exporter = _start_in_memory_runtime()
+            attributes = self._finished_resource_attributes(exporter)
         assert "host.ip" not in attributes
+        assert "host.name" not in attributes
+        assert attributes.get("service.instance.id") == f"unknown-{os.getpid()}"
+
+    def test_instrumentation_sdk_name_is_always_present(self):
+        # Fixed marker the platform's GenAI statistics match on; unconditional so
+        # it cannot depend on host or pod information being available.
+        with mock.patch.object(socket, "gethostname", return_value=""):
+            exporter = _start_in_memory_runtime()
+            attributes = self._finished_resource_attributes(exporter)
+        assert (
+            attributes.get("gen_ai.instrumentation.sdk.name")
+            == "loongsuite-genai-utils"
+        )
 
     def test_resolve_region_env_preserves_existing_pod_ip(self):
         os.environ["POD_IP"] = "10.1.2.3"
@@ -519,7 +554,9 @@ class TestResource(TracingTestCase):
         tracing.resolve_region_env()
         exporter = _start_in_memory_runtime()
         attributes = self._finished_resource_attributes(exporter)
-        assert attributes.get("host.ip") == "10.4.5.6"
+        # The POD_IP derivation chain still reaches the exported resource; it now
+        # lands on rtp_llm.pod_ip instead of host.ip.
+        assert attributes.get("rtp_llm.pod_ip") == "10.4.5.6"
 
     def test_service_name_derived_from_role(self):
         # no env override -> "rtp_llm_" + role (role-split components)

--- a/rtp_llm/telemetry/tracing.py
+++ b/rtp_llm/telemetry/tracing.py
@@ -788,6 +788,7 @@ _CLIENT_ERROR_DESCRIPTIONS = {
     "Cancelled": "Client operation was cancelled",
     "RpcError": "Model RPC request failed",
     "TrafficLimit": "Request routing was rejected by traffic limits",
+    "FlexlbBusinessRejected": "Master rejected the schedule request",
 }
 
 
@@ -984,6 +985,13 @@ CURRENT_TRACE_STATE: ContextVar[Optional[RequestTraceState]] = ContextVar(
     "rtp_llm_current_trace_state", default=None
 )
 
+# A short-lived child context used by in-process orchestration.  This lets a
+# real outbound RPC started inside an INTERNAL span inherit that span without
+# mutating the request root or relying on implicit thread-local propagation.
+CURRENT_INTERNAL_CONTEXT: ContextVar[Optional[Any]] = ContextVar(
+    "rtp_llm_current_internal_context", default=None
+)
+
 
 def reset_telemetry_for_test(deadline_ms: int = 2000) -> bool:
     """Reset process telemetry state for test isolation only."""
@@ -995,6 +1003,7 @@ def reset_telemetry_for_test(deadline_ms: int = 2000) -> bool:
         _provider = None
         _state = TelemetryState.UNINITIALIZED
     CURRENT_TRACE_STATE.set(None)
+    CURRENT_INTERNAL_CONTEXT.set(None)
     return True
 
 
@@ -1005,9 +1014,11 @@ class ClientSpanHandle:
         self,
         span: Any,
         error_description: Callable[[str], str] = _client_error_description,
+        context_token: Any = None,
     ):
         self._span = span
         self._error_description = error_description
+        self._context_token = context_token
         self._finished = False
         self._lock = threading.Lock()
 
@@ -1027,6 +1038,13 @@ class ClientSpanHandle:
                 if self._finished:
                     return
                 self._finished = True
+                context_token = self._context_token
+                self._context_token = None
+            if context_token is not None:
+                try:
+                    CURRENT_INTERNAL_CONTEXT.reset(context_token)
+                except Exception:  # noqa: BLE001 - context cleanup is fail-open
+                    pass
             if error is not None or error_type:
                 resolved_error_type = error_type or type(error).__name__
                 if OTEL_AVAILABLE:
@@ -1092,9 +1110,10 @@ def start_client_span(
         tracer = get_tracer()
         if tracer is None:
             return None, []
+        parent_context = CURRENT_INTERNAL_CONTEXT.get() or state.server_context
         span = tracer.start_span(
             span_name,
-            context=state.server_context,
+            context=parent_context,
             kind=trace.SpanKind.CLIENT,
             attributes=_parse_server_endpoint(target_address) or None,
         )
@@ -1132,7 +1151,8 @@ def start_internal_span(span_name: str) -> Optional[ClientSpanHandle]:
             context=state.server_context,
             kind=trace.SpanKind.INTERNAL,
         )
-        return ClientSpanHandle(span, _internal_error_description)
+        context_token = CURRENT_INTERNAL_CONTEXT.set(trace.set_span_in_context(span))
+        return ClientSpanHandle(span, _internal_error_description, context_token)
     except Exception:  # noqa: BLE001 - fail-open
         return None
 

--- a/rtp_llm/telemetry/tracing.py
+++ b/rtp_llm/telemetry/tracing.py
@@ -269,9 +269,9 @@ def resolve_region_env() -> None:
 
     Must run in the top-level launcher BEFORE child processes spawn: the C++
     backend reads OTEL_EXPORTER_OTLP_TRACES_* strictly from its inherited
-    environment (TelemetryRuntime::init), and both runtimes read POD_IP for
-    host.ip. Disabled tracing is a pure no-op. Idempotent (only fills unset
-    keys) and fail-open.
+    environment (TelemetryRuntime::init), and both runtimes read POD_IP for the
+    rtp_llm.pod_ip resource attribute. Disabled tracing is a pure no-op.
+    Idempotent (only fills unset keys) and fail-open.
     """
     if not _env_bool("RTP_LLM_OTEL_TRACE_ENABLE", False):
         return
@@ -502,20 +502,37 @@ def _init_with_exporter_locked(exporter: Any, role: str, tp_rank: int) -> bool:
     # Unitrace topology shows each role as its own component; an explicit
     # RTP_LLM_OTEL_SERVICE_NAME still overrides globally.
     service_name = os.environ.get("RTP_LLM_OTEL_SERVICE_NAME") or f"rtp_llm_{role}"
+    # Resolved once so service.instance.id, host.name and host.ip can never
+    # disagree about which host this process runs on.
+    hostname = socket.gethostname()
+    pid = os.getpid()
     resource_attributes = {
         "service.name": service_name,
-        "service.instance.id": f"{socket.gethostname()}-{os.getpid()}",
-        "process.pid": os.getpid(),
+        # "unknown" fallback mirrors the C++ runtime: the instance id must never
+        # degrade into a bare "-<pid>".
+        "service.instance.id": f"{hostname or 'unknown'}-{pid}",
+        "process.pid": pid,
         "rtp_llm.role": role,
+        # Fixed marker the platform's GenAI statistics match on. It names the
+        # instrumentation contract being followed, not a library we link.
+        "gen_ai.instrumentation.sdk.name": "loongsuite-genai-utils",
         # rtp_llm.tp_rank is intentionally NOT a resource attribute: the
         # rank0-only gate makes it constantly 0 on every exported span (zero
         # information). tp_rank stays an init_telemetry() gate parameter only.
     }
-    # Aligned with the C++ runtime: host.ip only from a real POD_IP, never
-    # faked from hostname-pid.
+    # Aligned with the C++ runtime: host.ip carries "{hostname}-{pid}", not an IP.
+    # The platform's per-instance request/error/latency panels key off host.ip,
+    # and a pod IP is not process-unique -- frontend and backend share one pod --
+    # so an IP-valued host.ip merges them into a single bucket. The real address
+    # stays reported under rtp_llm.pod_ip. Neither host key is synthesized when
+    # the hostname is unknown: "unknown-<pid>" would pollute exactly the
+    # aggregation these fields exist to serve.
+    if hostname:
+        resource_attributes["host.name"] = hostname
+        resource_attributes["host.ip"] = f"{hostname}-{pid}"
     pod_ip = os.environ.get("POD_IP", "")
     if pod_ip:
-        resource_attributes["host.ip"] = pod_ip
+        resource_attributes["rtp_llm.pod_ip"] = pod_ip
     resource = Resource.create(resource_attributes)
     root_sampler = TraceIdRatioBased(
         _env_ratio("RTP_LLM_OTEL_TRACE_SAMPLER_RATIO", 1.0)


### PR DESCRIPTION
## Summary

Complete end-to-end OpenTelemetry tracing for requests delivered through the
FlexLB `EnqueueBatch` / `EnqueueGroup` and `FetchResponse` path.

A batch RPC may contain requests from different traces, so its shared gRPC
metadata cannot carry a request-specific parent. This change propagates a
bounded W3C context in each serialized `GenerateInputPB` and preserves
per-request trace isolation throughout Prefill, P-to-D, Decode, and Fetch.

## Design

- Add `TraceContextPB` with `traceparent` and `tracestate` to `RequestInfoPB`.
- Inject the current per-request OTel context before serializing
  `GenerateInputPB`; do not derive parents from diagnostic
  `request_info.trace_id` or propagate arbitrary baggage.
- Preserve the carrier through FlexLB's existing
  `GenerateInputPB.parseFrom(...).toBuilder()` flow.
- Create `rtp_llm.prefill_batch_request` before Prefill preparation, allowing
  P-to-D CLIENT and Decode SERVER spans to inherit the correct request parent.
- Trace the later physical Fetch RPC independently as
  `rtp_llm.fetch_response` CLIENT/SERVER spans.
- Keep logical request status separate from physical gRPC status.

```text
[SERVER] HTTP / Dash request
├── [INTERNAL] rtp_llm.master_route
├── [INTERNAL] rtp_llm.prefill_batch_request
│   ├── [INTERNAL] wait / prefill
│   └── [CLIENT]   rtp_llm.remote_generate
│       └── [SERVER] rtp_llm.decode_remote_generate
│           └── [INTERNAL] load_cache / wait / decode
└── [CLIENT] rtp_llm.fetch_response
    └── [SERVER] rtp_llm.fetch_response
```

The logical Prefill span and Fetch CLIENT span are siblings. `FetchResponse`
arrives after Prefill preparation and P-to-D stream creation, so it cannot
retroactively parent those operations.

## Lifecycle

Logical request spans are finalized exactly once across:

- prepare failure
- successful Fetch
- missing, expired, or duplicate Fetch
- context TTL expiry
- cancellation and priority preemption
- P-to-D retry and late errors
- shutdown and exception unwinding

Missing or malformed carriers and disabled telemetry fail open without changing
inference results, retry behavior, protobuf semantics, gRPC status, FlexLB, or
KMonitor behavior.

## Compatibility

- The protobuf change is additive.
- Old senders remain supported.
- Old readers preserve the new field as an unknown field across round trips.
- Only `traceparent` and `tracestate` are propagated.
- No Java product code changes are required.

## Tests

- C++ batch server: 153/153 passed across three runs, no skips.
- Python model RPC client: all new Trace cases passed across three runs.
- Java dispatcher: 19/19 passed, covering two-request isolation and old-schema
  round-trip compatibility.
- Existing Prefill regression: 54/54 passed.
- gRPC propagation: 9/9 passed.
- Phase synthesizer: 66/66 passed.
- Cancellation race: 10/10 passed.
- Full CI: 30 succeeded, 0 failed, 0 canceled, 0 not run.

Real gRPC tests verify that `FetchResponse` receives the injected metadata and
records the expected name, parent, status, usage, TTFT, and TPOT. Cross-language
batching tests verify that two requests in one batch retain different trace
parents.

## Remaining Validation

The local master-batching + PD path has been exercised successfully. A queryable
Unitrace capture for this exact change is still pending because the available
OTLP endpoint was unreachable during local validation.
