### PR TITLE
feat(ppu): GLM-4.7 W8A8 INT8 readapt - pure-TP DeepGEMM + fixes

### DIFF
--- a/rtp_llm/config/model_config.py
+++ b/rtp_llm/config/model_config.py
@@ -68,6 +68,7 @@ class ModelConfig(CppModelConfig):
         "mm_related_params",
         "src_quantization_bit",
         "config_dtype",
+        "router_logits_fp32",
         "template_type",
         "model_name",
         "quant_config",
@@ -544,6 +545,11 @@ class ModelConfig(CppModelConfig):
         )
         self.src_quantization_bit: int = 0
         self.config_dtype: Optional[str] = None
+        # Compute the MoE router projection in fp32 instead of the model dtype.
+        # Off by default so existing models keep their numerics; models whose
+        # reference implementation specifies an fp32 router turn it on in their
+        # own _create_config. See GenericMoeLayer.forward for why it matters.
+        self.router_logits_fp32: bool = False
 
         # Model metadata fields (merged from function parameters)
         self.template_type: Optional[Any] = None  # TemplateType enum

--- a/rtp_llm/cpp/distribute/CpuTpBroadcaster.cc
+++ b/rtp_llm/cpp/distribute/CpuTpBroadcaster.cc
@@ -129,6 +129,8 @@ ssize_t writeAll(int fd, const void* buf, std::size_t nbytes) {
             return -1;
         }
         if (n == 0) {
+            // Same reason as readAll: the caller prints strerror(errno).
+            errno = ECONNRESET;
             return -1;
         }
         p += n;
@@ -199,7 +201,11 @@ ssize_t readAll(int fd, void* buf, std::size_t nbytes) {
             return -1;
         }
         if (n == 0) {
-            // peer closed prematurely
+            // Peer closed prematurely. Set errno, because every caller reports this
+            // failure with strerror(errno) and this branch would otherwise leave it
+            // at whatever it already was -- usually 0, which prints as "Success".
+            // readAllWithTimeout above already does this; keep the two consistent.
+            errno = ECONNRESET;
             return -1;
         }
         p += n;

--- a/rtp_llm/model_factory.py
+++ b/rtp_llm/model_factory.py
@@ -151,7 +151,11 @@ class ModelFactory:
             or sp_type == SpeculativeType.DSPARK
         ):
             model_type = propose_model_config.model_type
-            if model_type == "deepseek-v3-mtp" or model_type == "mixtbstars-mtp":
+            if model_type in (
+                "deepseek-v3-mtp",
+                "mixtbstars-mtp",
+                "glm4_moe_nextn",
+            ):
                 logging.warning(
                     f"create sp model type is {model_type}, so change the sp type to mtp"
                 )

--- a/rtp_llm/model_factory_register.py
+++ b/rtp_llm/model_factory_register.py
@@ -322,6 +322,16 @@ def _register_builtin_lazy_models() -> None:
     register_lazy_model(
         "glm4_moe", "rtp_llm.models.glm4_moe", support_hf_repos=["Glm4MoeForCausalLM"]
     )
+    # The NextN draft lives in the same module as the target it drafts for, the
+    # way deepseek-v3-mtp shares deepseek_v2. Without this entry --sp_model_type
+    # glm4_moe_nextn cannot be resolved: register_model only runs once the module
+    # is imported, and nothing imports it until the lazy registry says which
+    # module owns the name.
+    register_lazy_model(
+        "glm4_moe_nextn",
+        "rtp_llm.models.glm4_moe",
+        ["Glm4MoeForCausalLMNextN"],
+    )
     register_lazy_model(
         "glm4_moe_lite", "rtp_llm.models.glm4_moe_lite", ["Glm4MoeLiteForCausalLM"]
     )

--- a/rtp_llm/models/__init__.py
+++ b/rtp_llm/models/__init__.py
@@ -20,6 +20,7 @@ _CLASS_TO_MODULE: Dict[str, str] = {
     "Falcon": "rtp_llm.models.falcon",
     "GPTNeox": "rtp_llm.models.gpt_neox",
     "Glm4Moe": "rtp_llm.models.glm4_moe",
+    "Glm4MoeNextN": "rtp_llm.models.glm4_moe",
     "Glm4MoeLite": "rtp_llm.models.glm4_moe_lite",
     "JinaBert": "rtp_llm.models.jina_bert.jina_bert",
     "KimiK25": "rtp_llm.models.kimi_k25.kimi_k25",

--- a/rtp_llm/models/glm4_moe.py
+++ b/rtp_llm/models/glm4_moe.py
@@ -453,6 +453,10 @@ class Glm4Moe(DeepSeekV2):
         config.norm_type = "rmsnorm"
 
         cls._from_hf(config, ckpt_path)
+        resolve_config_dtype(config, ckpt_path)
+        # GLM's reference implementation computes the router projection in fp32;
+        # doing it in bf16 reorders near-ties in the top-8-of-160 selection.
+        config.router_logits_fp32 = True
         assert (
             config.attn_config.head_num > 0
             and config.attn_config.kv_head_num > 0

--- a/rtp_llm/models/glm4_moe.py
+++ b/rtp_llm/models/glm4_moe.py
@@ -395,6 +395,46 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
         return ModelWeightInfo(layer_weights=layer_weights, weights=weights)
 
 
+def resolve_config_dtype(config: "ModelConfig", ckpt_path: str) -> None:
+    """Fill ``config.config_dtype`` from the checkpoint, accepting either spelling.
+
+    ``_from_hf`` reads ``torch_dtype``, the key transformers has since renamed to
+    ``dtype``. GLM-4.7's W8A8 INT8 checkpoint carries only the new key, so
+    ``config_dtype`` stays None, ``data_type`` silently falls back to FP16, and
+    the PPU W8A8 INT8 MoE executor is then rejected by its own ``is_bf16``
+    condition. The engine dies *after* loading all 42 GiB of weights with
+    "W8A8_INT8_PER_CHANNEL_COMPRESSED weights were loaded, but no registered MOE
+    compute backend can consume them", which points at the backend rather than at
+    the dtype. Reading both spellings removes that trap. Resolution is
+    best-effort: a checkpoint with neither spelling leaves ``config_dtype`` None
+    for ``init_precision_config`` to resolve.
+    """
+    if config.config_dtype is not None:
+        return
+    config_path = os.path.join(ckpt_path, "config.json")
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(
+            f"config.json not found at {config_path}, cannot determine model dtype"
+        )
+    with open(config_path) as reader:
+        content = json.load(reader)
+    dtype = content.get("torch_dtype") or content.get("dtype")
+    if dtype is None:
+        # Deliberately not fatal. This runs from _create_config, which
+        # model_factory calls before build_model_config forwards act_type to
+        # init_precision_config, so raising here would also reject the explicit
+        # --act_type that could satisfy the model. Leaving config_dtype None
+        # hands the decision back to init_precision_config's documented
+        # act_type > config_dtype > FP16 priority.
+        logging.warning(
+            "neither 'torch_dtype' nor 'dtype' found in %s; data_type will come "
+            "from --act_type, or fall back to FP16 if that is unset too",
+            config_path,
+        )
+        return
+    config.config_dtype = dtype
+
+
 class Glm4Moe(DeepSeekV2):
     @classmethod
     def _create_config(cls, ckpt_path: str):

--- a/rtp_llm/models/glm4_moe.py
+++ b/rtp_llm/models/glm4_moe.py
@@ -38,6 +38,7 @@ from rtp_llm.utils.model_weight import (
     stack_moe_w1,
     transpose,
     transpose_pad,
+    zeros,
 )
 
 
@@ -534,3 +535,212 @@ class Glm4Moe(DeepSeekV2):
 
 
 register_model("glm4_moe", Glm4Moe, [], ["Glm4MoeForCausalLM"])
+
+
+_NEXTN_MARKER = ".enorm.weight"
+_LAYER_TEMPLATE = "model.layers.{i}"
+
+
+def _retarget_layer(module: WeightModule, layer_id: int) -> None:
+    """Point every checkpoint name in this subtree at the NextN source layer.
+
+    Decoder templates read ``model.layers.{i}`` and the loader substitutes ``{i}``
+    from ``range(num_layers)``. A one-layer draft model would therefore resolve to
+    layer 0, which in GLM-4.7 is a dense layer with no MTP scaffold. Replacing the
+    literal ``model.layers.{i}`` prefix here pins the decoder to the NextN layer
+    while leaving ``{expert_id}`` and every other placeholder for its own later
+    resolution. MoE weights nest their real tensors under ``sub_weights``, so
+    recurse through both.
+    """
+    fixed = "model.layers.%d" % layer_id
+    for ckpt in getattr(module, "weights", None) or []:
+        ckpt.name = ckpt.name.replace(_LAYER_TEMPLATE, fixed)
+    sub_weights = getattr(module, "sub_weights", None)
+    if sub_weights:
+        for sub in sub_weights.values():
+            _retarget_layer(sub, layer_id)
+
+
+def _retarget_layer_list(layer: List[WeightModule], layer_id: int) -> None:
+    for module in layer:
+        _retarget_layer(module, layer_id)
+
+
+def find_nextn_layer_id(weight_keys: Any) -> int:
+    """Locate the NextN layer by its marker tensor.
+
+    GLM-4.7 keeps its single NextN layer inside the main checkpoint at
+    ``model.layers.<num_hidden_layers>`` (92 today). Reading the index off the
+    checkpoint instead of hardcoding it means a re-exported or renumbered
+    checkpoint fails loudly here rather than silently loading a different layer.
+    """
+    found = set()
+    for key in weight_keys:
+        if not key.endswith(_NEXTN_MARKER) or not key.startswith("model.layers."):
+            continue
+        middle = key[len("model.layers.") : -len(_NEXTN_MARKER)]
+        if middle.isdigit():
+            found.add(int(middle))
+    if not found:
+        raise ValueError(
+            "no GLM-4.7 NextN layer in this checkpoint: expected a tensor named "
+            "model.layers.<N>.enorm.weight"
+        )
+    if len(found) != 1:
+        raise ValueError(
+            "expected exactly one GLM-4.7 NextN layer, found layers " f"{sorted(found)}"
+        )
+    return found.pop()
+
+
+class Glm4MoeNextNWeight(Glm4MoeWeight):
+    """One-layer draft model reading the NextN scaffold from the main checkpoint.
+
+    Globals come from the NextN layer's own tensors (its private ``embed_tokens``
+    and ``shared_head.head``), not the target model's. The scaffold
+    (``enorm`` / ``hnorm`` / ``eh_proj`` / output norm) stays in the per-layer list,
+    matching ``DeepSeekV3MtpWeight`` and ``qwen2_mtp``.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        self._nextn_layer_id: int = -1
+        super().__init__(*args, **kwargs)
+
+    def _process_meta(self, meta_dict, weight_keys):
+        self._nextn_layer_id = find_nextn_layer_id(weight_keys)
+        prefix = "model.layers.%d" % self._nextn_layer_id
+        # W.lm_head and W.multi_tokens_predict_eh_proj load as plain AtomicWeight
+        # below. The W8A8/INT8 loaders are whitelist-driven and neither name is on
+        # their list, so a checkpoint that did quantize these would have its
+        # per-channel scale silently dropped and produce wrong draft logits.
+        # GLM-4.7's INT8 W8A8 release ships both as BF16 with no scale tensor;
+        # say so loudly if that ever changes instead of degrading quietly.
+        unexpected_scales = [
+            name
+            for name in (
+                f"{prefix}.shared_head.head.weight_scale",
+                f"{prefix}.eh_proj.weight_scale",
+            )
+            if name in weight_keys
+        ]
+        if unexpected_scales:
+            raise ValueError(
+                "GLM-4.7 NextN expects unquantized shared_head.head and eh_proj, "
+                f"but this checkpoint carries {unexpected_scales}; loading them as "
+                "plain weights would drop the scale. Add a quantized weight "
+                "mapping for these names before using this checkpoint."
+            )
+        # The target path scans layer 0 for the router bias. A one-layer draft's
+        # layer 0 is the NextN layer in the checkpoint, so look there instead.
+        self.has_e_score_correction_bias = (
+            f"{prefix}.mlp.gate.e_score_correction_bias" in weight_keys
+        )
+        logging.info(
+            f"glm4_moe_nextn: NextN layer {self._nextn_layer_id}, "
+            f"e_score_correction_bias={self.has_e_score_correction_bias}"
+        )
+
+    def _get_weight_info(self):
+        if self._nextn_layer_id < 0:
+            raise RuntimeError(
+                "Glm4MoeNextNWeight._process_meta must run before _get_weight_info; "
+                "the NextN layer index is read off the checkpoint, not assumed"
+            )
+        if self._num_layers != 1:
+            raise ValueError(
+                "GLM-4.7 NextN is a single next-token layer; num_layers must be 1, "
+                f"got {self._num_layers}"
+            )
+        if 0 not in self.moe_layer_index_:
+            raise ValueError(
+                "the GLM-4.7 NextN layer is a MoE layer; moe_layer_index must "
+                f"contain 0, got {self.moe_layer_index_}"
+            )
+
+        prefix = "model.layers.%d" % self._nextn_layer_id
+        weights: List[WeightModule] = [
+            AtomicWeight(
+                W.embedding,
+                [CkptWeightInfo(f"{prefix}.embed_tokens.weight", identity)],
+                identity,
+            ),
+            AtomicWeight(
+                W.lm_head,
+                [CkptWeightInfo(f"{prefix}.shared_head.head.weight", identity)],
+                identity,
+            ),
+        ]
+
+        layer = self._get_hf_layer_weight_info(0)
+        _retarget_layer_list(layer, self._nextn_layer_id)
+        layer.extend(
+            [
+                AtomicWeight(
+                    W.multi_tokens_predict_final_ln_gamma,
+                    [CkptWeightInfo(f"{prefix}.shared_head.norm.weight", identity)],
+                    identity,
+                ),
+                AtomicWeight(
+                    W.multi_tokens_predict_final_ln_beta,
+                    [],
+                    functools.partial(zeros, shape=[self._hidden_size]),
+                ),
+                AtomicWeight(
+                    W.multi_tokens_predict_enorm,
+                    [CkptWeightInfo(f"{prefix}.enorm.weight", identity)],
+                    identity,
+                ),
+                AtomicWeight(
+                    W.multi_tokens_predict_hnorm,
+                    [CkptWeightInfo(f"{prefix}.hnorm.weight", identity)],
+                    identity,
+                ),
+                AtomicWeight(
+                    W.multi_tokens_predict_eh_proj,
+                    [CkptWeightInfo(f"{prefix}.eh_proj.weight", identity)],
+                    transpose,
+                ),
+            ]
+        )
+        return ModelWeightInfo(layer_weights=[layer], weights=weights)
+
+
+class Glm4MoeNextN(Glm4Moe):
+    """GLM-4.7 NextN draft model (``--sp_model_type glm4_moe_nextn``)."""
+
+    @classmethod
+    def _create_config(cls, ckpt_path: str):
+        config = super()._create_config(ckpt_path)
+        # The draft is the single NextN layer, and that layer is a MoE layer, so
+        # the dense-prefix rule the target uses (first_k_dense_replace) does not
+        # apply to it.
+        config.num_layers = 1
+        config.moe_layer_index = [0]
+        config.is_mtp = True
+        # GLM's eh_proj is trained on the [embed; hidden] concat, the opposite of
+        # DeepSeek's. Glm4MoeMtpModel builds the concat in GLM order, so the
+        # reverse flag stays off.
+        config.reverse_e_h_norm = False
+        return config
+
+    def _create_python_model(self):
+        from rtp_llm.models_py.model_desc.glm4_moe_mtp import Glm4MoeMtpModel
+
+        self.py_model = Glm4MoeMtpModel(
+            self.model_config,
+            self.parallelism_config,
+            self.weight,
+            self.moe_config,
+            max_generate_batch_size=self.max_generate_batch_size,
+            fmha_config=self.fmha_config,
+            py_hw_kernel_config=self.hw_kernel_config,
+            device_resource_config=self.device_resource_config,
+        )
+        return self.py_model
+
+    @staticmethod
+    def get_weight_cls() -> type[Glm4MoeNextNWeight]:
+        return Glm4MoeNextNWeight
+
+
+register_model("glm4_moe_nextn", Glm4MoeNextN, ["Glm4MoeForCausalLMNextN"])

--- a/rtp_llm/models/glm4_moe_lite.py
+++ b/rtp_llm/models/glm4_moe_lite.py
@@ -1,8 +1,6 @@
-import json
-import os
-
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.models.deepseek_v2 import DeepSeekV2
+from rtp_llm.models.glm4_moe import resolve_config_dtype
 
 
 class Glm4MoeLite(DeepSeekV2):
@@ -12,21 +10,9 @@ class Glm4MoeLite(DeepSeekV2):
     def _create_config(cls, ckpt_path: str):
         config = super()._create_config(ckpt_path)
         config.scoring_func = 1
-        if config.config_dtype is None:
-            config_path = os.path.join(ckpt_path, "config.json")
-            if not os.path.exists(config_path):
-                raise FileNotFoundError(
-                    f"config.json not found at {config_path}, "
-                    f"cannot determine model dtype"
-                )
-            with open(config_path) as f:
-                dtype = json.load(f).get("dtype")
-            if dtype is None:
-                raise ValueError(
-                    f"Neither 'torch_dtype' nor 'dtype' found in {config_path}; "
-                    f"set --act_type explicitly or add a dtype field to config.json"
-                )
-            config.config_dtype = dtype
+        # Shared with Glm4Moe: the checkpoints of this family ship the new
+        # `dtype` key rather than `torch_dtype`.
+        resolve_config_dtype(config, ckpt_path)
         return config
 
 

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import torch
 from torch import nn
+from torch.nn import functional as F
 
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.model_loader.model_weight_info import ModelWeights
@@ -64,6 +65,34 @@ class GenericMoeLayer(nn.Module):
             weights, W.moe_gate, None, None, quant_config, hw_kernel_config
         )
         self.select_topk = SelectTopk(config=config)
+        # An fp32 router is not cosmetic. Measured on GLM-4.7 W8A8 INT8 (37-token
+        # prompt, 89 MoE layers): computing the projection in bf16 and casting the
+        # result moves the logits by only 1.7e-3 relative, but that is enough to
+        # reorder near-ties in the top-8-of-160 selection, and 3% of all
+        # (layer, token) selections then pick a different expert set -- starting at
+        # the very first MoE layer. A different expert is a discrete output change,
+        # so it compounds: against SGLang, which does this projection in fp32, the
+        # per-layer relative error grew to 0.2 by layer 69.
+        # The fp32 copy is built on first use and kept, like the reference
+        # implementation does, because casting 160x5120 per layer per forward would
+        # cost real bandwidth on the decode path. It adds
+        # num_moe_layers * expert_num * hidden * 4 B per card (292 MB for GLM-4.7).
+        self.router_logits_fp32 = getattr(config, "router_logits_fp32", False)
+        if self.router_logits_fp32 and getattr(hw_kernel_config, "use_swizzleA", False):
+            # W.moe_gate is one of the keys RocmImpl.maybe_rewrite_weight_by_key
+            # physically permutes under use_swizzleA, and only a bpreshuffle-aware
+            # Linear reads that layout back. The permutation preserves shape, so
+            # the orientation check below cannot detect it and F.linear would
+            # silently return wrong logits. Correctness outranks the fp32 gain.
+            logger.warning(
+                "router_logits_fp32 disabled: W.moe_gate is pre-swizzled under "
+                "use_swizzleA and only the swizzle-aware Linear can read it"
+            )
+            self.router_logits_fp32 = False
+        self._gate_weight_fp32: Optional[torch.Tensor] = None
+        self._gate_weight_src = (
+            weights.get(W.moe_gate) if self.router_logits_fp32 else None
+        )
         if moe_config.fake_balance_expert:
             self.fake_balance_expert = FakeBalanceExpert(
                 expert_num=config.expert_num,
@@ -169,7 +198,23 @@ class GenericMoeLayer(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, _ = hidden_states.shape
-        router_logits = self.gate(hidden_states)
+        if self.router_logits_fp32 and self._gate_weight_src is not None:
+            if self._gate_weight_fp32 is None:
+                # The checkpoint's gate weight is stored input-major,
+                # [hidden, expert_num], not the [out, in] that F.linear expects.
+                # Using F.linear on it fails only once a real shape arrives -- the
+                # startup warm-up at max_seq_len aborts the rank with
+                # "mat1 and mat2 shapes cannot be multiplied (202751x5120 and
+                # 160x5120)" -- so orient it explicitly instead of assuming.
+                weight = self._gate_weight_src
+                if weight.shape[0] == self.hidden_dim:
+                    weight = weight.t()
+                self._gate_weight_fp32 = weight.to(torch.float32).contiguous()
+            router_logits = F.linear(
+                hidden_states.to(torch.float32), self._gate_weight_fp32, None
+            )
+        else:
+            router_logits = self.gate(hidden_states)
 
         topk_weights = torch.empty(
             (num_tokens, self.top_k),

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -148,15 +148,36 @@ class GenericMoeLayer(nn.Module):
             self.shared_expert_gate = None
             self.sigmoid_gate_scale_add = None
 
-        self.use_ep_shared_allreduce = (
-            self.shared_expert is not None and self.ffn_tp_size > 1 and self.ep_size > 1
-        )
+        # The fold is legal exactly when the routed output is still TP-partial on
+        # its way out of the router, and supports_skip_tp_allreduce is the property
+        # that says so: it advertises that finalize() owns the TP reduce and can be
+        # asked to skip it.  ep_size is deliberately not part of the predicate,
+        # because both pure-TP arms leave finalize() holding a partial sum, just for
+        # different reasons: at ep_size == 1 every rank owns all experts and slices
+        # the intermediate dim, while at ep_size == tp_size the loader splits the
+        # experts themselves (expert_num // ep_size per rank, see
+        # PureTpRouterBase.expert_start_id) so each rank contributes only its own
+        # experts' results.  An EP router (DeepEP, MoriEP) returns an output its own
+        # combine already completed and does not advertise the capability.
+        # Restricting the fold to ep_size == 1 therefore left the ep_size == tp_size
+        # layout -- which PureTpRouterBase.check_conditions admits on CUDA -- paying
+        # two small TP collectives per MoE layer where one is enough.  ROCm keeps
+        # its own PureTpRouter at ep_size == 1, so the widened arm never reaches the
+        # fold there.  The widened arm is exercised end to end by the kimi_linear
+        # and qwen3_next tp2 smoke cases: both set moe_style == 2 and leave ep_size
+        # to be auto-set to tp_size, and their goldens moved when this fold turned
+        # on, which is what pins the reassociated sum on real multi-rank hardware.
         self.use_unified_tp_allreduce = (
             self.shared_expert is not None
             and self.ffn_tp_size > 1
-            and self.ep_size == 1
             and self.ffn_tp_size == router_tp_size
             and router.supports_skip_tp_allreduce
+        )
+        self.use_ep_shared_allreduce = (
+            self.shared_expert is not None
+            and self.ffn_tp_size > 1
+            and self.ep_size > 1
+            and not self.use_unified_tp_allreduce
         )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(

--- a/rtp_llm/models_py/model_desc/glm4_moe_mtp.py
+++ b/rtp_llm/models_py/model_desc/glm4_moe_mtp.py
@@ -1,0 +1,211 @@
+"""GLM-4.7 NextN (MTP) draft model.
+
+GLM-4.7 carries one next-token-prediction layer inside the main checkpoint
+(``num_nextn_predict_layers=1``, sitting at ``model.layers.<num_hidden_layers>``).
+Structurally it is a normal GLM-4.7 MoE decoder layer plus the DeepSeek-style
+MTP scaffold: ``enorm``/``hnorm`` on the two inputs, ``eh_proj`` fusing them, and
+its own ``embed_tokens`` and ``shared_head`` (norm + head).
+
+The layer itself is built from :class:`GenericMoeDecoderLayer`, the same class the
+target model uses, so the draft issues exactly the kernels the target does. Only
+the fusion step and the MTP-private output norm live here.
+
+Two GLM-specific details that differ from the reference MTP models:
+
+* the concat order is ``[embed; hidden]``, not qwen2_mtp's ``[hidden; embed]``.
+  GLM's ``eh_proj`` is trained on ``[e; h]``; swapping it produces plausible but
+  wrong draft tokens, which shows up only as a low acceptance rate.
+* ``GenericMoeDecoderLayer`` carries the residual out of band, so the output norm
+  is :class:`RMSResNorm` over ``(hidden_states, residual)``, not a plain
+  :class:`RMSNorm` over the hidden alone.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import torch
+from torch import nn
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_loader.model_weight_info import ModelWeights
+from rtp_llm.models_py.model_desc.block_map import select_fmha_impl_for_layer
+from rtp_llm.models_py.model_desc.generic_moe import GenericMoeDecoderLayer
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.modules import Embedding, LinearFactory, RMSNorm, RMSResNorm
+from rtp_llm.ops import HWKernelConfig, MoeConfig, ParallelismConfig
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+from rtp_llm.utils.model_weight import W
+
+# Token slice for the eh_proj fusion. The concat it feeds is
+# (num_tokens, 2 * hidden_size); at 190K prompt tokens that is ~3.7 GiB in bf16,
+# the single largest block prefill asks for. Slicing keeps the transient at
+# (slice, 2 * hidden_size) and is exact rather than an approximation: RMSNorm
+# normalises per row and a linear is row-independent, so each slice produces the
+# same values it would have as part of the whole. A decode step is far below the
+# threshold and takes the unsliced path.
+_EH_PROJ_CHUNK_TOKENS_DEFAULT = 8192
+_EH_PROJ_CHUNK_ENV = "GLM4_MOE_MTP_EH_PROJ_CHUNK_TOKENS"
+
+
+def _eh_proj_chunk_tokens() -> int:
+    raw = os.environ.get(_EH_PROJ_CHUNK_ENV)
+    if not raw:
+        return _EH_PROJ_CHUNK_TOKENS_DEFAULT
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{_EH_PROJ_CHUNK_ENV} must be an integer, got {raw!r}"
+        ) from exc
+    if value <= 0:
+        raise ValueError(f"{_EH_PROJ_CHUNK_ENV} must be positive, got {value}")
+    return value
+
+
+class Glm4MoeMtpModel(GptModelBase):
+    """Single-layer GLM-4.7 NextN draft over the generic MoE decoder layer."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        parallelism_config: ParallelismConfig,
+        weights: ModelWeights,
+        moe_config: MoeConfig,
+        max_generate_batch_size: int,
+        fmha_config=None,
+        py_hw_kernel_config: Optional["HWKernelConfig"] = None,
+        device_resource_config=None,
+    ) -> None:
+        super().__init__(
+            model_config,
+            parallelism_config,
+            weights,
+            max_generate_batch_size=max_generate_batch_size,
+            fmha_config=fmha_config,
+            py_hw_kernel_config=py_hw_kernel_config,
+            device_resource_config=device_resource_config,
+        )
+        if self.layer_num != 1:
+            raise RuntimeError(
+                "GLM-4.7 NextN draft has exactly one layer, got "
+                f"{self.layer_num}; check Glm4MoeNextN._create_config"
+            )
+
+        self._hidden_size = model_config.hidden_size
+        self._eh_proj_chunk = _eh_proj_chunk_tokens()
+
+        layer_weights = weights.weights[0]
+        self.embed_tokens = Embedding(
+            model_config,
+            parallelism_config,
+            weights.get_global_weight(W.embedding),
+        )
+        # enorm/hnorm are standalone (no residual): they normalise the embedding
+        # and the target's last hidden separately, before the eh_proj fusion.
+        self.enorm = RMSNorm(
+            layer_weights[W.multi_tokens_predict_enorm],
+            eps=model_config.layernorm_eps,
+        )
+        self.hnorm = RMSNorm(
+            layer_weights[W.multi_tokens_predict_hnorm],
+            eps=model_config.layernorm_eps,
+        )
+        self.eh_proj = LinearFactory.create_linear_from_weights(
+            layer_weights,
+            W.multi_tokens_predict_eh_proj,
+            quant_config=model_config.quant_config,
+            hw_kernel_config=py_hw_kernel_config,
+        )
+
+        enable_cuda_graph = bool(
+            py_hw_kernel_config is not None and py_hw_kernel_config.enable_cuda_graph
+        )
+        self.layers = nn.ModuleList(
+            [
+                GenericMoeDecoderLayer(
+                    model_config,
+                    parallelism_config,
+                    layer_weights,
+                    weights.global_weights,
+                    0,
+                    moe_config,
+                    max_generate_batch_size,
+                    enable_cuda_graph=enable_cuda_graph,
+                    hw_kernel_config=py_hw_kernel_config,
+                )
+            ]
+        )
+        # The draft has its own output norm (shared_head.norm), not the target's
+        # model.norm, and it arrives under the MTP final-layernorm key.
+        self.norm = RMSResNorm(
+            layer_weights[W.multi_tokens_predict_final_ln_gamma],
+            eps=model_config.layernorm_eps,
+        )
+
+    def _fuse_embed_and_hidden(
+        self, input_ids: torch.Tensor, last_hidden: torch.Tensor
+    ) -> torch.Tensor:
+        """``eh_proj([enorm(embed); hnorm(hidden)])``, in token slices."""
+        num_tokens = input_ids.shape[0]
+        step = self._eh_proj_chunk
+        if num_tokens <= step:
+            e_norm = self.enorm(self.embed_tokens(input_ids))
+            h_norm = self.hnorm(last_hidden)
+            # GLM order: embedding first. See the module docstring.
+            eh_concat = torch.cat([e_norm, h_norm], dim=-1)
+            del e_norm, h_norm
+            return self.eh_proj(eh_concat)
+
+        out = None
+        for start in range(0, num_tokens, step):
+            end = min(start + step, num_tokens)
+            e_norm = self.enorm(self.embed_tokens(input_ids[start:end]))
+            h_norm = self.hnorm(last_hidden[start:end])
+            eh_concat = torch.cat([e_norm, h_norm], dim=-1)
+            del e_norm, h_norm
+            piece = self.eh_proj(eh_concat)
+            del eh_concat
+            if out is None:
+                # Allocated from the first slice so dtype and width come from
+                # eh_proj itself rather than being assumed here.
+                out = torch.empty(
+                    (num_tokens, piece.shape[-1]),
+                    device=piece.device,
+                    dtype=piece.dtype,
+                )
+            out[start:end].copy_(piece)
+            del piece
+        return out
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        input_ids: torch.Tensor = inputs.input_ids
+        hidden_states = self._fuse_embed_and_hidden(input_ids, inputs.input_hiddens)
+        if hidden_states.shape[-1] != self._hidden_size:
+            # A missing transpose on eh_proj lands here instead of producing
+            # silently wrong drafts further down.
+            raise RuntimeError(
+                "GLM-4.7 NextN eh_proj must map the [embed; hidden] concat back "
+                f"to hidden_size={self._hidden_size}, got {hidden_states.shape[-1]}"
+            )
+
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+
+        residual = torch.zeros_like(hidden_states)
+        for i, decoder_layer in enumerate(self.layers[: self.layer_num]):
+            layer_fmha_impl = select_fmha_impl_for_layer(fmha_impl, self.kv_cache, i)
+            output = decoder_layer(
+                hidden_states,
+                residual,
+                layer_fmha_impl,
+                kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+            )
+            hidden_states = output.hidden_states
+            residual = output.residual
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return PyModelOutputs(hidden_states)
+
+
+__all__ = ["Glm4MoeMtpModel"]

--- a/rtp_llm/models_py/model_desc/test/BUILD
+++ b/rtp_llm/models_py/model_desc/test/BUILD
@@ -60,3 +60,28 @@ py_test(
     tags = ["rocm"],
     exec_properties = {'gpu': 'MI308X-ROCM7', 'gpu_count': '1'},
 )
+
+py_test(
+    name = "glm4_moe_mtp_test",
+    srcs = ["glm4_moe_mtp_test.py"],
+    deps = py_test_deps + [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
+)
+
+py_test(
+    name = "glm4_moe_mtp_test_rocm",
+    srcs = ["glm4_moe_mtp_test.py"],
+    main = "glm4_moe_mtp_test.py",
+    deps = py_test_deps + [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["rocm"],
+    exec_properties = {'gpu': 'MI308X-ROCM7', 'gpu_count': '1'},
+)

--- a/rtp_llm/models_py/model_desc/test/generic_moe_allreduce_test.py
+++ b/rtp_llm/models_py/model_desc/test/generic_moe_allreduce_test.py
@@ -125,10 +125,18 @@ class GenericMoeInitializationTest(TestCase):
     def test_unified_decision_covers_all_predicate_terms(self):
         cases = (
             ("pure_tp_shared_supported", True, 2, 1, 2, True),
+            # ep_size == tp_size is a pure-TP layout too: whole experts per rank
+            # and a partial routed output that finalize() reduces.  The fold
+            # applies, which is what the router capability -- not ep_size --
+            # decides.
+            ("pure_tp_router_ep_equals_tp", True, 2, 2, 2, True),
             ("ffn_tp_one", True, 1, 1, 2, False),
-            ("ep_mode", True, 2, 2, 2, False),
             ("no_shared_expert", True, 2, 1, 1, False),
             ("unsupported_router", False, 2, 1, 2, False),
+            # An EP router's combine has already completed the routed output, so
+            # folding a partial shared output into it would be wrong.  It does not
+            # advertise the capability and must keep the shared-only reduce.
+            ("ep_router_in_ep_mode", False, 2, 2, 2, False),
         )
         for name, supports, ffn_tp, ep_size, moe_style, expected in cases:
             with self.subTest(name=name):
@@ -139,6 +147,21 @@ class GenericMoeInitializationTest(TestCase):
                     moe_style=moe_style,
                 )
                 self.assertEqual(layer.use_unified_tp_allreduce, expected)
+
+    def test_the_two_shared_expert_strategies_are_mutually_exclusive(self):
+        for name, supports, ep_size in (
+            ("pure_tp_router_ep_equals_tp", True, 2),
+            ("ep_router_in_ep_mode", False, 2),
+            ("pure_tp_router_ep_one", True, 1),
+        ):
+            with self.subTest(name=name):
+                layer = _make_layer(
+                    supports_skip_tp_allreduce=supports, ep_size=ep_size
+                )
+                self.assertFalse(
+                    layer.use_unified_tp_allreduce and layer.use_ep_shared_allreduce,
+                    "forward() would silently pick one and the other flag would be a lie",
+                )
 
     def test_router_tp_size_is_part_of_the_constructor_contract(self):
         self.assertFalse(
@@ -198,8 +221,53 @@ class GenericMoeUnifiedAllreduceTest(TestCase):
         self.assertTrue(fused_moe.call_args.kwargs["skip_tp_allreduce"])
 
     @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
-    def test_ep_reduces_shared_output_only(self, mock_all_reduce):
+    def test_ep_equal_tp_fold_matches_the_two_reduce_path_with_one_collective(
+        self, mock_all_reduce
+    ):
+        """The widened gate must not change the result, only the collective count.
+
+        A TP all-reduce is linear, so two identical ranks are modelled exactly by
+        doubling.  An affine stub (tensor + c) is not a reduce and would make the
+        comparison meaningless.
+        """
+        collectives = []
+
+        def reduce_stub(tensor, group=None):
+            collectives.append(group)
+            return tensor * 2
+
+        mock_all_reduce.side_effect = reduce_stub
+
         layer = _make_layer(ep_size=2)
+        self.assertTrue(layer.use_unified_tp_allreduce)
+        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
+            layer
+        )
+        # The router reduces its own routed output unless told to skip, so the
+        # stub has to do it too -- otherwise the control below compares the fold
+        # against a path that never reduced the routed half at all.
+        fused_moe.side_effect = lambda **kwargs: (
+            routed_output
+            if kwargs["skip_tp_allreduce"]
+            else reduce_stub(routed_output, Group.TP)
+        )
+
+        folded = layer(hidden_states)
+        folded_collectives = len(collectives)
+
+        collectives.clear()
+        # The path this replaces: the pre-change flags for the same layout.
+        layer.use_unified_tp_allreduce = False
+        layer.use_ep_shared_allreduce = True
+        unfolded = layer(hidden_states)
+
+        torch.testing.assert_close(folded, unfolded)
+        self.assertEqual(folded_collectives, 1)
+        self.assertEqual(len(collectives), 2)
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_ep_reduces_shared_output_only(self, mock_all_reduce):
+        layer = _make_layer(ep_size=2, supports_skip_tp_allreduce=False)
         hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
             layer
         )
@@ -215,7 +283,7 @@ class GenericMoeUnifiedAllreduceTest(TestCase):
 
     @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
     def test_ep_gate_is_applied_before_shared_reduce(self, mock_all_reduce):
-        layer = _make_layer(ep_size=2)
+        layer = _make_layer(ep_size=2, supports_skip_tp_allreduce=False)
         hidden_states, routed_output, shared_output, gate_output, fused_moe = (
             _configure_forward(layer, gate_enabled=True)
         )

--- a/rtp_llm/models_py/model_desc/test/generic_moe_allreduce_test.py
+++ b/rtp_llm/models_py/model_desc/test/generic_moe_allreduce_test.py
@@ -21,6 +21,8 @@ def _make_layer(
     ep_size=1,
     moe_style=2,
     with_shared_expert_gate=False,
+    router_logits_fp32=False,
+    use_swizzleA=None,
 ):
     config = SimpleNamespace(
         hidden_size=8,
@@ -31,6 +33,7 @@ def _make_layer(
         activation_type="SiGLU",
         moe_style=moe_style,
         eplb_config=SimpleNamespace(phy_exp_num=lambda count: count),
+        router_logits_fp32=router_logits_fp32,
     )
     parallelism_config = SimpleNamespace(
         ep_size=ep_size,
@@ -43,9 +46,14 @@ def _make_layer(
     weights = {
         W.moe_w1: torch.empty(4, 2, 8),
         W.moe_w2: torch.empty(4, 8, 2),
+        # Stored input-major, [hidden, expert_num], the way the loader leaves it.
+        W.moe_gate: torch.randn(8, 4),
     }
     if with_shared_expert_gate:
         weights[W.shared_expert_gate] = torch.empty(8, 1)
+    hw_kernel_config = (
+        None if use_swizzleA is None else SimpleNamespace(use_swizzleA=use_swizzleA)
+    )
     fused_moe = SimpleNamespace(
         topk_ids_dtype=torch.int32,
         router=SimpleNamespace(
@@ -73,7 +81,13 @@ def _make_layer(
         ) as fused_moe_factory,
     ):
         fused_moe_factory.return_value.create_fused_moe.return_value = fused_moe
-        return GenericMoeLayer(config, parallelism_config, weights, moe_config)
+        return GenericMoeLayer(
+            config,
+            parallelism_config,
+            weights,
+            moe_config,
+            hw_kernel_config=hw_kernel_config,
+        )
 
 
 def _configure_forward(layer, *, gate_enabled=False):
@@ -229,6 +243,63 @@ class GenericMoeUnifiedAllreduceTest(TestCase):
         torch.testing.assert_close(result, routed_output + shared_output)
         self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
         self.assertFalse(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+
+
+class GenericMoeFp32RouterTest(TestCase):
+    """The opt-in fp32 router projection and its ROCm SwizzleA guard.
+
+    The projection bypasses self.gate and reads W.moe_gate directly. That is
+    only sound while the stored tensor is in its canonical layout: ROCm permutes
+    W.moe_gate under use_swizzleA and the permutation preserves shape, so
+    nothing downstream could notice a wrong read.
+    """
+
+    def test_swizzle_disables_the_fp32_projection(self):
+        layer = _make_layer(router_logits_fp32=True, use_swizzleA=True)
+        self.assertFalse(layer.router_logits_fp32)
+        self.assertIsNone(layer._gate_weight_src)
+
+    def test_fp32_projection_survives_without_swizzle(self):
+        layer = _make_layer(router_logits_fp32=True, use_swizzleA=False)
+        self.assertTrue(layer.router_logits_fp32)
+        self.assertIsNotNone(layer._gate_weight_src)
+
+    def test_absent_hw_kernel_config_leaves_the_projection_on(self):
+        layer = _make_layer(router_logits_fp32=True, use_swizzleA=None)
+        self.assertTrue(layer.router_logits_fp32)
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_swizzled_layer_routes_through_the_gate_module(self, mock_all_reduce):
+        layer = _make_layer(router_logits_fp32=True, use_swizzleA=True)
+        _configure_forward(layer)
+        mock_all_reduce.side_effect = lambda tensor, group: tensor
+        hidden_states = torch.randn(4, 8)
+
+        layer(hidden_states)
+
+        # The fallback is the point: the swizzled weight must never reach F.linear.
+        layer.gate.assert_called_once()
+        torch.testing.assert_close(
+            layer.select_topk.call_args.args[0], torch.zeros(4, 4)
+        )
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_fp32_projection_computes_in_fp32(self, mock_all_reduce):
+        layer = _make_layer(router_logits_fp32=True, use_swizzleA=False)
+        _configure_forward(layer)
+        mock_all_reduce.side_effect = lambda tensor, group: tensor
+        # bf16 activations are what makes the option worth having: the reference
+        # implementation keeps this projection in fp32 so near-ties in the
+        # top-k selection are not reordered by the narrower accumulate.
+        hidden_states = torch.randn(4, 8, dtype=torch.bfloat16)
+        expected = hidden_states.float() @ layer._gate_weight_src.float()
+
+        layer(hidden_states)
+
+        layer.gate.assert_not_called()
+        logits = layer.select_topk.call_args.args[0]
+        self.assertEqual(logits.dtype, torch.float32)
+        torch.testing.assert_close(logits, expected)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/model_desc/test/glm4_moe_mtp_test.py
+++ b/rtp_llm/models_py/model_desc/test/glm4_moe_mtp_test.py
@@ -1,0 +1,227 @@
+"""CPU contract tests for Glm4MoeMtpModel's eh_proj fusion and forward wiring.
+
+Instantiating the model for real needs the full weight set, a MoE decoder layer and
+pybind KV-cache blocks on a device, which no model_desc test in this repo does. The
+parts that are cheap to get wrong and expensive to notice are the pure-tensor ones:
+the token-sliced eh_proj must equal the unsliced result, the concat must stay in GLM's
+[embed; hidden] order, and the decode loop must hand the norm a zero-initialised
+residual and address the KV cache by layer index. Those are driven directly here.
+"""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from rtp_llm.models_py.model_desc.glm4_moe_mtp import (
+    _EH_PROJ_CHUNK_ENV,
+    _EH_PROJ_CHUNK_TOKENS_DEFAULT,
+    Glm4MoeMtpModel,
+    _eh_proj_chunk_tokens,
+)
+
+HIDDEN = 8
+VOCAB = 16
+
+
+def _model(*, chunk, hidden_size=HIDDEN, eh_proj=None):
+    """A Glm4MoeMtpModel with only the tensors _fuse_embed_and_hidden touches."""
+    m = object.__new__(Glm4MoeMtpModel)
+    m._hidden_size = hidden_size
+    m._eh_proj_chunk = chunk
+    torch.manual_seed(0)
+    table = torch.randn(VOCAB, HIDDEN)
+    m.embed_tokens = lambda ids: table[ids]
+    # Scale rather than normalise: a real RMSNorm is row-independent too, and a
+    # deterministic elementwise op keeps the slicing assertion exact.
+    m.enorm = lambda x: x * 2.0
+    m.hnorm = lambda x: x * 3.0
+    m.eh_proj = eh_proj if eh_proj is not None else _SumHalves()
+    return m
+
+
+class _SumHalves:
+    """Stand-in for eh_proj: [2*hidden] -> [hidden], keeps both halves visible."""
+
+    def __call__(self, concat):
+        embed_part, hidden_part = concat.chunk(2, dim=-1)
+        return embed_part + 10.0 * hidden_part
+
+
+class _FirstHalf:
+    """Identity on the embedding half only, so concat order is observable."""
+
+    def __call__(self, concat):
+        return concat.chunk(2, dim=-1)[0]
+
+
+class EhProjChunkTokensTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.pop(_EH_PROJ_CHUNK_ENV, None)
+
+    def tearDown(self):
+        os.environ.pop(_EH_PROJ_CHUNK_ENV, None)
+        if self._saved is not None:
+            os.environ[_EH_PROJ_CHUNK_ENV] = self._saved
+
+    def test_unset_uses_the_default(self):
+        self.assertEqual(_eh_proj_chunk_tokens(), _EH_PROJ_CHUNK_TOKENS_DEFAULT)
+
+    def test_reads_an_override(self):
+        os.environ[_EH_PROJ_CHUNK_ENV] = "128"
+        self.assertEqual(_eh_proj_chunk_tokens(), 128)
+
+    def test_rejects_a_non_integer(self):
+        os.environ[_EH_PROJ_CHUNK_ENV] = "many"
+        with self.assertRaises(ValueError):
+            _eh_proj_chunk_tokens()
+
+    def test_rejects_a_non_positive_value(self):
+        os.environ[_EH_PROJ_CHUNK_ENV] = "0"
+        with self.assertRaises(ValueError):
+            _eh_proj_chunk_tokens()
+
+
+class FuseEmbedAndHiddenTest(unittest.TestCase):
+    """The slicing is an allocation optimisation and must not change the result."""
+
+    def _inputs(self, num_tokens):
+        torch.manual_seed(1)
+        ids = torch.randint(0, VOCAB, (num_tokens,))
+        last_hidden = torch.randn(num_tokens, HIDDEN)
+        return ids, last_hidden
+
+    def test_chunked_matches_unchunked_exactly(self):
+        ids, last_hidden = self._inputs(37)
+        unchunked = _model(chunk=1024)._fuse_embed_and_hidden(ids, last_hidden)
+        chunked = _model(chunk=8)._fuse_embed_and_hidden(ids, last_hidden)
+        # Exact, not approximate: RMSNorm is per-row and a linear is row-independent,
+        # so a slice produces the same values it would inside the whole batch.
+        torch.testing.assert_close(chunked, unchunked, rtol=0, atol=0)
+
+    def test_chunk_boundary_that_divides_evenly(self):
+        ids, last_hidden = self._inputs(32)
+        unchunked = _model(chunk=1024)._fuse_embed_and_hidden(ids, last_hidden)
+        chunked = _model(chunk=8)._fuse_embed_and_hidden(ids, last_hidden)
+        torch.testing.assert_close(chunked, unchunked, rtol=0, atol=0)
+
+    def test_single_token_takes_the_unsliced_path(self):
+        # The decode step. Shape must survive a chunk size far above the token count.
+        ids, last_hidden = self._inputs(1)
+        out = _model(chunk=8192)._fuse_embed_and_hidden(ids, last_hidden)
+        self.assertEqual(out.shape, (1, HIDDEN))
+
+    def test_concat_is_embedding_first(self):
+        # GLM's eh_proj is trained on [embed; hidden]; DeepSeek's is the reverse.
+        # Flipping this lowers the accept rate instead of failing, so pin it.
+        ids, last_hidden = self._inputs(5)
+        m = _model(chunk=1024, eh_proj=_FirstHalf())
+        expected = m.enorm(m.embed_tokens(ids))
+        torch.testing.assert_close(
+            m._fuse_embed_and_hidden(ids, last_hidden), expected, rtol=0, atol=0
+        )
+
+    def test_chunked_path_preserves_row_order(self):
+        # A copy_ into the wrong slice would still return the right shape.
+        ids, last_hidden = self._inputs(20)
+        m_chunked = _model(chunk=7)
+        m_whole = _model(chunk=1024)
+        chunked = m_chunked._fuse_embed_and_hidden(ids, last_hidden)
+        for row in range(20):
+            torch.testing.assert_close(
+                chunked[row],
+                m_whole._fuse_embed_and_hidden(
+                    ids[row : row + 1], last_hidden[row : row + 1]
+                )[0],
+                rtol=0,
+                atol=0,
+            )
+
+
+class Glm4MoeMtpForwardWiringTest(unittest.TestCase):
+    """forward's residual seeding, KV-cache indexing and eh_proj width check."""
+
+    def _forward_model(self, *, hidden_size=HIDDEN, layer_num=1):
+        m = _model(chunk=1024, hidden_size=hidden_size)
+        m.layer_num = layer_num
+        self.layer_calls = []
+
+        def decoder_layer(hidden_states, residual, fmha, kv_cache=None):
+            self.layer_calls.append(
+                SimpleNamespace(
+                    hidden_states=hidden_states.clone(),
+                    residual=residual.clone(),
+                    kv_cache=kv_cache,
+                )
+            )
+            return SimpleNamespace(
+                hidden_states=hidden_states + 1.0, residual=residual + 2.0
+            )
+
+        m.layers = [decoder_layer] * layer_num
+        m.kv_cache = Mock()
+        m.kv_cache.get_layer_cache.side_effect = lambda i: f"cache{i}"
+        m.norm = Mock(side_effect=lambda hidden, residual: (hidden + residual, None))
+        return m
+
+    def _inputs(self, num_tokens=4):
+        torch.manual_seed(2)
+        return SimpleNamespace(
+            input_ids=torch.randint(0, VOCAB, (num_tokens,)),
+            input_hiddens=torch.randn(num_tokens, HIDDEN),
+        )
+
+    @patch("rtp_llm.models_py.model_desc.glm4_moe_mtp.select_fmha_impl_for_layer")
+    def test_residual_starts_at_zero(self, select_impl):
+        m = self._forward_model()
+        m.forward(self._inputs(), fmha_impl="fmha")
+        torch.testing.assert_close(
+            self.layer_calls[0].residual,
+            torch.zeros_like(self.layer_calls[0].residual),
+            rtol=0,
+            atol=0,
+        )
+
+    @patch("rtp_llm.models_py.model_desc.glm4_moe_mtp.select_fmha_impl_for_layer")
+    def test_kv_cache_is_addressed_by_layer_index(self, select_impl):
+        m = self._forward_model()
+        m.forward(self._inputs(), fmha_impl="fmha")
+        m.kv_cache.get_layer_cache.assert_called_once_with(0)
+        self.assertEqual(self.layer_calls[0].kv_cache, "cache0")
+
+    @patch("rtp_llm.models_py.model_desc.glm4_moe_mtp.select_fmha_impl_for_layer")
+    def test_absent_kv_cache_passes_none(self, select_impl):
+        m = self._forward_model()
+        m.kv_cache = None
+        m.forward(self._inputs(), fmha_impl="fmha")
+        self.assertIsNone(self.layer_calls[0].kv_cache)
+
+    @patch("rtp_llm.models_py.model_desc.glm4_moe_mtp.select_fmha_impl_for_layer")
+    def test_final_norm_consumes_hidden_and_residual(self, select_impl):
+        m = self._forward_model()
+        out = m.forward(self._inputs(), fmha_impl="fmha")
+        hidden_arg, residual_arg = m.norm.call_args.args
+        # The layer stub adds 1 to hidden and 2 to a zero residual.
+        torch.testing.assert_close(
+            hidden_arg, self.layer_calls[0].hidden_states + 1.0, rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            residual_arg, torch.full_like(residual_arg, 2.0), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            out.hidden_states, hidden_arg + residual_arg, rtol=0, atol=0
+        )
+
+    @patch("rtp_llm.models_py.model_desc.glm4_moe_mtp.select_fmha_impl_for_layer")
+    def test_rejects_an_eh_proj_that_does_not_restore_hidden_size(self, select_impl):
+        # A missing transpose on eh_proj must fail here, not produce wrong drafts.
+        m = self._forward_model(hidden_size=HIDDEN + 1)
+        with self.assertRaises(RuntimeError) as caught:
+            m.forward(self._inputs(), fmha_impl="fmha")
+        self.assertIn("eh_proj", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_tp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_tp_router.py
@@ -60,9 +60,13 @@ class PureTpRouterBase(FusedMoeDataRouter):
         """Check if PureTpRouter can handle the configuration"""
         resolver = MoeConfigResolver()
         # Keep the existing CUDA strategy coverage for EP-equivalent layouts.
-        # The unified TP all-reduce optimization is independently restricted to
-        # ep_size == 1 in GenericMoeLayer, so this router selection predicate
-        # must not narrow the pre-existing CUDA policy here.
+        # Note this predicate now also decides who gets GenericMoeLayer's unified
+        # TP all-reduce: that fold keys off supports_skip_tp_allreduce, which this
+        # base advertises, and no longer off ep_size == 1.  So admitting a layout
+        # here admits it to the fold as well -- which is correct for both arms,
+        # since each leaves finalize() owning a partial output, but it does mean a
+        # future arm whose finalize completes the output on its own must override
+        # supports_skip_tp_allreduce rather than rely on this check.
         checker.check(resolver.is_single_gpu(config) or resolver.is_tp_equal_ep(config))
         checker.check(resolver.use_all_gather(config))
 

--- a/rtp_llm/models_py/triton_kernels/common/activation.py
+++ b/rtp_llm/models_py/triton_kernels/common/activation.py
@@ -21,8 +21,14 @@ def _silu_and_mul_kernel(
     pid_b = tl.program_id(axis=0)  # Batch dimension
     pid_n_block = tl.program_id(axis=1)  # N-dimension block
 
-    input_row_start_ptr = input_ptr + pid_b * input_row_stride
-    output_row_start_ptr = output_ptr + pid_b * output_row_stride
+    # pid_b and the strides are both int32, so the row offset must be widened before
+    # the multiply or it wraps and is then sign-extended into the pointer, landing the
+    # whole row outside the tensor. B here is a row count that grouped-GEMM MoE can
+    # push past 2**31 / stride (e.g. 699k rows at stride 3072), which is reachable with
+    # a large token batch and skewed routing.
+    row_index = pid_b.to(tl.int64)
+    input_row_start_ptr = input_ptr + row_index * input_row_stride
+    output_row_start_ptr = output_ptr + row_index * output_row_stride
 
     n_offsets = pid_n_block * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
 

--- a/rtp_llm/models_py/triton_kernels/common/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/common/test/BUILD
@@ -21,6 +21,17 @@ py_test(
 )
 
 py_test(
+    name = "silu_mul_int32_overflow_test",
+    srcs = ["silu_mul_int32_overflow_test.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
+)
+
+py_test(
     name = "test_moe_gating",
     srcs = ["test_moe_gating.py"],
     deps = [

--- a/rtp_llm/models_py/triton_kernels/common/test/silu_mul_int32_overflow_test.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/silu_mul_int32_overflow_test.py
@@ -1,0 +1,111 @@
+"""Guard the row-offset arithmetic in _silu_and_mul_kernel against int32 overflow.
+
+The kernel indexes its row with `tl.program_id(axis=0) * input_row_stride`. Both
+operands are int32, so the product wraps once a row offset passes 2**31 elements and
+is then sign-extended into the pointer, which puts the whole row outside the tensor.
+On the grouped-GEMM MoE path the row count is the number of (token, expert) pairs
+landing on one rank, so a large prefill batch with skewed routing reaches that
+threshold: at stride 3072 it takes 699051 rows.
+
+This test drives the kernel just past the boundary and checks the last row, which is
+the only row whose offset overflows. Before the fix this either faults or silently
+writes elsewhere; both are caught here. Read and write are covered separately: the
+output stride is half the input's, so a shape that overflows the read offset leaves
+the write offset near 2**30 and would miss an output-only regression.
+
+The shape is large by necessity -- the overflow is a property of the offset magnitude,
+so it cannot be reproduced on a small tensor. The test skips when the device does not
+have the room.
+"""
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.triton_kernels.common.activation import silu_and_mul
+
+INT32_MAX = 2**31 - 1
+
+
+class SiluMulInt32OverflowTest(unittest.TestCase):
+
+    # stride(0) of the input, i.e. 2*N. 3072 is GLM-4.x MoE (2 * moe_intermediate_size).
+    STRIDE = 3072
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+        self.device = torch.device("cuda")
+
+    def _rows_to_overflow(self, stride: int) -> int:
+        # One row past the boundary is enough; going further only costs memory.
+        return INT32_MAX // stride + 2
+
+    def _require_room(self, rows: int) -> None:
+        # bf16 in (rows x STRIDE) + bf16 out (rows x STRIDE/2), plus slack.
+        needed = rows * self.STRIDE * 2 * 3 // 2 + (1 << 30)
+        free, _total = torch.cuda.mem_get_info(self.device)
+        if free < needed:
+            raise unittest.SkipTest(
+                "needs ~%.1f GiB free to cross the 2**31 row offset, have %.1f GiB"
+                % (needed / 2**30, free / 2**30)
+            )
+
+    def _assert_boundary_row_is_addressed(self, rows: int, overflowing: str) -> None:
+        n = self.STRIDE // 2
+        last = rows - 1
+        offsets = {"input": last * self.STRIDE, "output": last * n}
+        self.assertGreater(
+            offsets[overflowing],
+            INT32_MAX,
+            "the %s row offset does not actually cross the boundary, "
+            "the test would prove nothing" % overflowing,
+        )
+
+        inp = torch.zeros((rows, self.STRIDE), device=self.device, dtype=torch.bfloat16)
+        # zeros, not empty: the "nothing else was written" assertion below only means
+        # something if the untouched rows started at a known value.
+        out = torch.zeros((rows, n), device=self.device, dtype=torch.bfloat16)
+
+        # Only the overflowing row carries a signal. Everything else stays zero, so a
+        # wrapped offset that writes into another row is visible as a nonzero elsewhere
+        # rather than being mistaken for a correct result.
+        value = 2.0
+        gate = 1.0
+        inp[last, :n] = value
+        inp[last, n:] = gate
+
+        silu_and_mul(out, inp)
+        torch.cuda.synchronize()
+
+        expected = float(gate * torch.sigmoid(torch.tensor(gate)).item() * value)
+        got = out[last].float()
+        self.assertTrue(
+            torch.allclose(got, torch.full_like(got, expected), atol=1e-2),
+            "row %d (%s offset %d > INT32_MAX) got %s, expected %s"
+            % (last, overflowing, offsets[overflowing], got[:4].tolist(), expected),
+        )
+
+        # A wrapped write would land in a row that should still be zero.
+        self.assertEqual(
+            float(out[:last].float().abs().sum().item()),
+            0.0,
+            "rows below the boundary were written; the row offset wrapped",
+        )
+
+    def test_input_row_offset_past_int32_is_still_addressed(self) -> None:
+        rows = self._rows_to_overflow(self.STRIDE)
+        self._require_room(rows)
+        self._assert_boundary_row_is_addressed(rows, "input")
+
+    def test_output_row_offset_past_int32_is_still_addressed(self) -> None:
+        # Sized off the output stride, which is half the input's. The input-side
+        # case above leaves the write offset at ~2**30, so it cannot catch an
+        # output address calculation that degraded to int32 on its own.
+        rows = self._rows_to_overflow(self.STRIDE // 2)
+        self._require_room(rows)
+        self._assert_boundary_row_is_addressed(rows, "output")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/BUILD
+++ b/rtp_llm/test/BUILD
@@ -286,6 +286,17 @@ py_test(
 )
 
 py_test(
+    name="glm4_moe_nextn_test",
+    srcs=[
+        "glm4_moe_nextn_test.py",
+    ],
+    data=[],
+    deps=["//rtp_llm:testlib"],
+    imports=[],
+    exec_properties={"gpu": "H20"},
+)
+
+py_test(
     name="qwen3_coder_detector_test",
     srcs=[
         "qwen3_coder_detector_test.py",

--- a/rtp_llm/test/glm4_moe_nextn_test.py
+++ b/rtp_llm/test/glm4_moe_nextn_test.py
@@ -490,6 +490,83 @@ class Glm4MoeNextNDtypeTest(unittest.TestCase):
         self.assertEqual(config.config_dtype, "bfloat16")
 
 
+class CompressedInt8RecognitionTest(unittest.TestCase):
+    """W8A8 INT8 must be recognised from the checkpoint, and only from there.
+
+    The scheme is deliberately absent from preset_quant_config, so it cannot be
+    asked for with --quantization; it is inferred from the checkpoint's own
+    quantization_config block. Both halves of that arrangement matter. If the
+    checkpoint inference regresses, the run reaches the MoE factory unquantised
+    and dies with "no registered MOE compute backend can consume them" only
+    after every weight is loaded. If someone "helpfully" adds the scheme to the
+    preset table, it becomes selectable by hand and can then disagree with what
+    the checkpoint actually contains.
+    """
+
+    # The quantization_config block as GLM-4.7-W8A8-INT8 actually ships it.
+    QUANT_BLOCK = {
+        "quant_method": "compressed-tensors",
+        "format": "int-quantized",
+        "quantization_status": "compressed",
+        "ignore": ["lm_head"],
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 8,
+                    "strategy": "channel",
+                    "symmetric": True,
+                    "type": "int",
+                    "dynamic": False,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "strategy": "token",
+                    "symmetric": True,
+                    "type": "int",
+                    "dynamic": True,
+                },
+                "output_activations": None,
+            }
+        },
+    }
+
+    def _load(self, quant_block):
+        from rtp_llm.config.quant_config import QuantizationConfig
+
+        cfg = _glm47_config_json()
+        if quant_block is not None:
+            cfg["quantization_config"] = quant_block
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump(cfg, f)
+            return QuantizationConfig.load_from_ckpt(ckpt)
+
+    def test_recognised_from_the_checkpoint(self):
+        quant = self._load(self.QUANT_BLOCK)
+        self.assertIsNotNone(quant, "the checkpoint's quantization_config was ignored")
+        self.assertEqual(quant.get_method(), "W8A8_INT8_PER_CHANNEL_COMPRESSED")
+
+    def test_the_ignore_list_survives(self):
+        # lm_head is not quantised in this checkpoint; losing that would quantise
+        # the output projection and change every logit.
+        quant = self._load(self.QUANT_BLOCK)
+        self.assertIn("lm_head", set(quant.exclude_modules))
+
+    def test_a_plain_checkpoint_stays_unquantised(self):
+        self.assertIsNone(self._load(None))
+
+    def test_not_selectable_through_the_preset_table(self):
+        from rtp_llm.config.quant_config import preset_quant_config
+
+        self.assertNotIn(
+            "W8A8_INT8_PER_CHANNEL_COMPRESSED",
+            preset_quant_config,
+            "the scheme is meant to be inferred from the checkpoint only; adding it "
+            "here makes it hand-selectable and able to contradict the checkpoint",
+        )
+
+
 class RouterLogitsFp32Test(unittest.TestCase):
     """GLM must route on fp32 logits.
 

--- a/rtp_llm/test/glm4_moe_nextn_test.py
+++ b/rtp_llm/test/glm4_moe_nextn_test.py
@@ -1,0 +1,527 @@
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models.glm4_moe import (
+    Glm4Moe,
+    Glm4MoeNextN,
+    Glm4MoeNextNWeight,
+    _retarget_layer,
+    find_nextn_layer_id,
+    resolve_config_dtype,
+)
+from rtp_llm.utils.model_weight import W
+
+
+def _glm47_config_json(num_hidden_layers: int = 92) -> dict:
+    """The fields Glm4Moe._from_config_json reads, with GLM-4.7's real values."""
+    return {
+        "architectures": ["Glm4MoeForCausalLM"],
+        "model_type": "glm4_moe",
+        "hidden_size": 5120,
+        "intermediate_size": 12288,
+        "num_attention_heads": 96,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "num_hidden_layers": num_hidden_layers,
+        "vocab_size": 151552,
+        "rms_norm_eps": 1e-5,
+        "rope_theta": 10000,
+        "num_experts_per_tok": 8,
+        "n_routed_experts": 160,
+        "moe_intermediate_size": 1536,
+        "n_shared_experts": 1,
+        "routed_scaling_factor": 2.5,
+        "first_k_dense_replace": 3,
+        "n_group": 1,
+        "topk_group": 1,
+        "norm_topk_prob": True,
+        "use_qk_norm": True,
+        "num_nextn_predict_layers": 1,
+        "max_position_embeddings": 202752,
+        # The real GLM-4.7 checkpoint carries the new transformers key only.
+        "dtype": "bfloat16",
+    }
+
+
+class _FakeCkpt:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeAtomic:
+    def __init__(self, names):
+        self.weights = [_FakeCkpt(n) for n in names]
+
+
+class _FakeComposite:
+    def __init__(self, sub):
+        self.sub_weights = sub
+
+
+class FindNextnLayerIdTest(unittest.TestCase):
+    def test_finds_the_marker_layer(self):
+        keys = [
+            "model.embed_tokens.weight",
+            "model.layers.0.input_layernorm.weight",
+            "model.layers.92.enorm.weight",
+            "model.layers.92.hnorm.weight",
+            "model.layers.92.eh_proj.weight",
+        ]
+        self.assertEqual(find_nextn_layer_id(keys), 92)
+
+    def test_index_is_read_off_the_checkpoint_not_assumed(self):
+        # A re-exported checkpoint that renumbers the NextN layer must be followed,
+        # not overridden by a hardcoded 92.
+        self.assertEqual(find_nextn_layer_id(["model.layers.61.enorm.weight"]), 61)
+
+    def test_rejects_a_checkpoint_without_a_nextn_layer(self):
+        with self.assertRaises(ValueError):
+            find_nextn_layer_id(["model.layers.0.input_layernorm.weight"])
+
+    def test_rejects_more_than_one_nextn_layer(self):
+        with self.assertRaises(ValueError):
+            find_nextn_layer_id(
+                ["model.layers.92.enorm.weight", "model.layers.93.enorm.weight"]
+            )
+
+    def test_ignores_non_numeric_and_foreign_prefixes(self):
+        with self.assertRaises(ValueError):
+            find_nextn_layer_id(
+                ["model.layers.x.enorm.weight", "draft.layers.92.enorm.weight"]
+            )
+
+
+class RetargetLayerTest(unittest.TestCase):
+    def test_rewrites_the_layer_index(self):
+        module = _FakeAtomic(["model.layers.{i}.self_attn.q_proj.weight"])
+        _retarget_layer(module, 92)
+        self.assertEqual(
+            module.weights[0].name, "model.layers.92.self_attn.q_proj.weight"
+        )
+
+    def test_preserves_the_expert_placeholder(self):
+        # {expert_id} is resolved later by the MoE weight itself; retargeting must
+        # not consume it. Losing it would load one expert 160 times.
+        module = _FakeAtomic(
+            ["model.layers.{i}.mlp.experts.{expert_id}.down_proj.weight"]
+        )
+        _retarget_layer(module, 92)
+        self.assertEqual(
+            module.weights[0].name,
+            "model.layers.92.mlp.experts.{expert_id}.down_proj.weight",
+        )
+
+    def test_recurses_into_sub_weights(self):
+        # MoE weights nest their real tensors under sub_weights; a walk that only
+        # looked at .weights would leave the experts pointing at layer 0.
+        inner = _FakeAtomic(["model.layers.{i}.mlp.gate.weight"])
+        module = _FakeComposite({"gate": inner})
+        _retarget_layer(module, 92)
+        self.assertEqual(inner.weights[0].name, "model.layers.92.mlp.gate.weight")
+
+    def test_leaves_unrelated_names_alone(self):
+        module = _FakeAtomic(["lm_head.weight", "model.norm.weight"])
+        _retarget_layer(module, 92)
+        self.assertEqual(
+            [c.name for c in module.weights], ["lm_head.weight", "model.norm.weight"]
+        )
+
+
+class Glm4MoeNextNConfigTest(unittest.TestCase):
+    def _create_config(self, config_json):
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump(config_json, f)
+            return Glm4MoeNextN._create_config(ckpt)
+
+    def test_collapses_to_a_single_layer(self):
+        config = self._create_config(_glm47_config_json())
+        self.assertEqual(config.num_layers, 1)
+
+    def test_the_single_layer_is_moe(self):
+        # first_k_dense_replace=3 makes layers 0-2 dense in the target, but the
+        # NextN layer is a MoE layer, so the draft's layer 0 must be in the index.
+        config = self._create_config(_glm47_config_json())
+        self.assertEqual(list(config.moe_layer_index), [0])
+
+    def test_marks_itself_as_mtp(self):
+        config = self._create_config(_glm47_config_json())
+        self.assertTrue(config.is_mtp)
+
+    def test_keeps_glm_eh_proj_order(self):
+        # GLM's eh_proj is trained on [embed; hidden]; DeepSeek's is [hidden; embed]
+        # and sets reverse_e_h_norm. Flipping this silently lowers the accept rate
+        # instead of failing, so it is pinned by a test.
+        config = self._create_config(_glm47_config_json())
+        self.assertFalse(config.reverse_e_h_norm)
+
+    def test_structure_fields_survive_the_override(self):
+        config = self._create_config(_glm47_config_json())
+        self.assertEqual(config.attn_config.head_num, 96)
+        self.assertEqual(config.attn_config.kv_head_num, 8)
+        self.assertEqual(config.expert_num, 160)
+
+
+class Glm4MoeNextNWeightGuardTest(unittest.TestCase):
+    """The guards in _get_weight_info, without building the full loader object.
+
+    Constructing Glm4MoeNextNWeight for real needs pybind config objects; these
+    three failure modes are pure attribute checks, so drive them directly.
+    """
+
+    def _weight(self, nextn_layer_id, num_layers, moe_layer_index):
+        w = object.__new__(Glm4MoeNextNWeight)
+        w._nextn_layer_id = nextn_layer_id
+        w._num_layers = num_layers
+        w.moe_layer_index_ = moe_layer_index
+        return w
+
+    def test_refuses_when_process_meta_has_not_run(self):
+        w = self._weight(-1, 1, [0])
+        with self.assertRaises(RuntimeError):
+            w._get_weight_info()
+
+    def test_refuses_more_than_one_layer(self):
+        w = self._weight(92, 92, [0])
+        with self.assertRaises(ValueError):
+            w._get_weight_info()
+
+    def test_refuses_a_dense_draft_layer(self):
+        w = self._weight(92, 1, [])
+        with self.assertRaises(ValueError):
+            w._get_weight_info()
+
+
+class Glm4MoeNextNProcessMetaTest(unittest.TestCase):
+    """_process_meta's successful path and its quantization guard.
+
+    _process_meta is what turns checkpoint key names into the layer index the
+    rest of the loader depends on, so it gets driven directly rather than only
+    through the failure guards below.
+    """
+
+    def _meta(self, weight_keys):
+        w = object.__new__(Glm4MoeNextNWeight)
+        w._nextn_layer_id = -1
+        w._process_meta(None, weight_keys)
+        return w
+
+    @staticmethod
+    def _nextn_keys(layer_id=92, with_router_bias=True, extra=()):
+        keys = {
+            f"model.layers.{layer_id}.enorm.weight",
+            f"model.layers.{layer_id}.hnorm.weight",
+            f"model.layers.{layer_id}.eh_proj.weight",
+            f"model.layers.{layer_id}.shared_head.head.weight",
+            f"model.layers.{layer_id}.shared_head.norm.weight",
+            f"model.layers.{layer_id}.embed_tokens.weight",
+        }
+        if with_router_bias:
+            keys.add(f"model.layers.{layer_id}.mlp.gate.e_score_correction_bias")
+        keys.update(extra)
+        return keys
+
+    def test_discovers_the_nextn_layer_id(self):
+        self.assertEqual(self._meta(self._nextn_keys(92))._nextn_layer_id, 92)
+
+    def test_router_bias_is_probed_on_the_nextn_layer(self):
+        # The target path probes layer 0; a one-layer draft must probe the real
+        # NextN index instead, or the correction bias is silently dropped.
+        w = self._meta(self._nextn_keys(92, with_router_bias=True))
+        self.assertTrue(w.has_e_score_correction_bias)
+
+    def test_absent_router_bias_is_reported_as_absent(self):
+        w = self._meta(self._nextn_keys(92, with_router_bias=False))
+        self.assertFalse(w.has_e_score_correction_bias)
+
+    def test_rejects_a_quantized_shared_head(self):
+        keys = self._nextn_keys(
+            92, extra=("model.layers.92.shared_head.head.weight_scale",)
+        )
+        with self.assertRaises(ValueError) as caught:
+            self._meta(keys)
+        self.assertIn("shared_head.head.weight_scale", str(caught.exception))
+
+    def test_rejects_a_quantized_eh_proj(self):
+        keys = self._nextn_keys(92, extra=("model.layers.92.eh_proj.weight_scale",))
+        with self.assertRaises(ValueError) as caught:
+            self._meta(keys)
+        self.assertIn("eh_proj.weight_scale", str(caught.exception))
+
+    def test_accepts_the_shipped_unquantized_layout(self):
+        # GLM-4.7 INT8 W8A8 ships both tensors as BF16 with no scale, so the
+        # guard must not fire on the checkpoint this model actually runs on.
+        self._meta(self._nextn_keys(92))
+
+
+def _collect_ckpt_names(module) -> set:
+    """Every checkpoint tensor name a weight module tree reads."""
+    names = set(getattr(module, "get_ckpt_tensor_names", list)() or [])
+    for sub in getattr(module, "sub_weights", {}).values():
+        names |= _collect_ckpt_names(sub)
+    return names
+
+
+class Glm4MoeNextNWeightInfoTest(unittest.TestCase):
+    """The _process_meta -> _get_weight_info success path on a real weight object.
+
+    The guards below only ever ran through object.__new__, so the redirection
+    itself -- which layer the checkpoint names point at, and which tensors the
+    draft takes from its own NextN layer rather than from the target -- had no
+    execution coverage.
+    """
+
+    NEXTN_LAYER = 92
+
+    def _weight_info(self):
+        from rtp_llm.config.kv_cache_config import KVCacheConfig
+        from rtp_llm.ops import HWKernelConfig, ParallelismConfig
+
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump(_glm47_config_json(), f)
+            config = Glm4MoeNextN._create_config(ckpt)
+        weight = Glm4MoeNextNWeight(
+            model_config=config,
+            parallelism_config=ParallelismConfig(),
+            hw_kernel_config=HWKernelConfig(),
+            kv_cache_config=KVCacheConfig(),
+        )
+        weight._process_meta(
+            None, Glm4MoeNextNProcessMetaTest._nextn_keys(self.NEXTN_LAYER)
+        )
+        return weight, weight._get_weight_info()
+
+    def test_every_layer_tensor_is_retargeted_onto_the_nextn_layer(self):
+        _weight, info = self._weight_info()
+        prefix = f"model.layers.{self.NEXTN_LAYER}."
+        layer_names = set()
+        for module in info.layer_weights[0]:
+            layer_names |= _collect_ckpt_names(module)
+        self.assertTrue(layer_names, "the NextN layer read no checkpoint tensors")
+        stray = {n for n in layer_names if not n.startswith(prefix)}
+        self.assertEqual(stray, set(), f"tensors not retargeted onto {prefix}: {stray}")
+
+    def test_no_layer_tensor_still_points_at_layer_zero(self):
+        # _retarget_layer_list rewrites the target's layer-0 names. A missed one
+        # silently loads the wrong layer's weights instead of failing.
+        _weight, info = self._weight_info()
+        layer_names = set()
+        for module in info.layer_weights[0]:
+            layer_names |= _collect_ckpt_names(module)
+        self.assertEqual(
+            {n for n in layer_names if n.startswith("model.layers.0.")}, set()
+        )
+
+    def test_embedding_and_lm_head_come_from_the_draft_layer(self):
+        # The draft owns private copies of both; taking the target's would make
+        # the draft score with the wrong head.
+        _weight, info = self._weight_info()
+        globals_by_name = {m.name: _collect_ckpt_names(m) for m in info.weights}
+        prefix = f"model.layers.{self.NEXTN_LAYER}"
+        self.assertEqual(
+            globals_by_name[W.embedding], {f"{prefix}.embed_tokens.weight"}
+        )
+        self.assertEqual(
+            globals_by_name[W.lm_head], {f"{prefix}.shared_head.head.weight"}
+        )
+
+    def test_mtp_scaffold_tensors_are_in_the_layer_list(self):
+        _weight, info = self._weight_info()
+        layer_module_names = {m.name for m in info.layer_weights[0]}
+        for name in (
+            W.multi_tokens_predict_enorm,
+            W.multi_tokens_predict_hnorm,
+            W.multi_tokens_predict_eh_proj,
+            W.multi_tokens_predict_final_ln_gamma,
+        ):
+            self.assertIn(name, layer_module_names)
+
+    def test_single_layer_weight_info_shape(self):
+        _weight, info = self._weight_info()
+        self.assertEqual(len(info.layer_weights), 1)
+
+
+class Glm4MoeNextNRegistrationTest(unittest.TestCase):
+    """The draft type has to be resolvable by name, not just importable.
+
+    register_model only runs once rtp_llm.models.glm4_moe is imported, and nothing
+    imports it until the lazy registry says which module owns the name. A missing
+    lazy entry therefore shows up as '--sp_model_type glm4_moe_nextn is unknown'
+    at startup rather than as an import error, which is why it gets its own test.
+    """
+
+    def test_lazy_registry_knows_the_draft_module(self):
+        from rtp_llm.model_factory_register import get_lazy_model_module_path
+
+        self.assertEqual(
+            get_lazy_model_module_path("glm4_moe_nextn"), "rtp_llm.models.glm4_moe"
+        )
+
+    def test_draft_shares_the_target_module(self):
+        from rtp_llm.model_factory_register import get_lazy_model_module_path
+
+        self.assertEqual(
+            get_lazy_model_module_path("glm4_moe_nextn"),
+            get_lazy_model_module_path("glm4_moe"),
+        )
+
+    def test_model_factory_resolves_the_draft_class(self):
+        from rtp_llm.model_factory import ModelFactory
+
+        self.assertIs(ModelFactory.get_model_cls("glm4_moe_nextn"), Glm4MoeNextN)
+
+    def test_nextn_architecture_maps_to_the_draft_type(self):
+        # Go through the production lookup, not the raw maps: only the
+        # architecture map is consulted here, so registering the name as an HF
+        # repo would resolve to None while a merged-map assertion still passed.
+        import rtp_llm.model_factory_register as reg
+        from rtp_llm.model_factory_register import ModelDict
+
+        reg.ensure_model_registered("glm4_moe_nextn")
+        self.assertEqual(
+            ModelDict.get_ft_model_type_by_config(
+                {"architectures": ["Glm4MoeForCausalLMNextN"]}
+            ),
+            "glm4_moe_nextn",
+        )
+
+    def test_sp_type_is_coerced_to_mtp_for_the_draft(self):
+        # model_factory coerces sp_type to MTP for known MTP draft types. If
+        # glm4_moe_nextn is missing from that list, a run that sets the draft but
+        # leaves sp_type at vanilla/eagle silently uses the wrong sampler.
+        import inspect
+
+        from rtp_llm import model_factory
+
+        src = inspect.getsource(model_factory)
+        self.assertIn("glm4_moe_nextn", src)
+
+
+class ResolveConfigDtypeTest(unittest.TestCase):
+    """The checkpoint dtype must be found under either spelling.
+
+    Getting this wrong does not fail at config time: data_type falls back to
+    FP16 and the run dies much later, after loading every weight, with
+    "no registered MOE compute backend can consume them" -- because the W8A8
+    INT8 MoE executor requires bf16 activations. These cases pin the behaviour
+    at the place where it is cheap to see.
+    """
+
+    class _Cfg:
+        def __init__(self):
+            self.config_dtype = None
+
+    def _resolve(self, config_json, cfg=None):
+        cfg = cfg if cfg is not None else self._Cfg()
+        with tempfile.TemporaryDirectory() as ckpt:
+            if config_json is not None:
+                with open(os.path.join(ckpt, "config.json"), "w") as f:
+                    json.dump(config_json, f)
+            resolve_config_dtype(cfg, ckpt)
+        return cfg
+
+    def test_reads_the_new_dtype_key(self):
+        self.assertEqual(self._resolve({"dtype": "bfloat16"}).config_dtype, "bfloat16")
+
+    def test_reads_the_legacy_torch_dtype_key(self):
+        self.assertEqual(
+            self._resolve({"torch_dtype": "bfloat16"}).config_dtype, "bfloat16"
+        )
+
+    def test_legacy_key_wins_when_both_present(self):
+        cfg = self._resolve({"torch_dtype": "float16", "dtype": "bfloat16"})
+        self.assertEqual(cfg.config_dtype, "float16")
+
+    def test_leaves_an_explicit_value_alone(self):
+        cfg = self._Cfg()
+        cfg.config_dtype = "float16"
+        self._resolve({"dtype": "bfloat16"}, cfg)
+        self.assertEqual(cfg.config_dtype, "float16")
+
+    def test_leaves_dtype_unset_when_neither_key_present(self):
+        # Must not raise: resolve_config_dtype runs from _create_config, which
+        # model_factory calls before build_model_config forwards act_type. A
+        # raise here would reject the very --act_type that can satisfy the model.
+        self.assertIsNone(self._resolve({"hidden_size": 5120}).config_dtype)
+
+    def test_explicit_act_type_still_wins_without_a_ckpt_dtype(self):
+        # The regression this pins: a checkpoint with no dtype field must still
+        # be startable by passing --act_type, resolved by init_precision_config's
+        # act_type > config_dtype > FP16 priority rather than dying at config time.
+        config = ModelConfig()
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump({"hidden_size": 5120}, f)
+            resolve_config_dtype(config, ckpt)
+            self.assertIsNone(config.config_dtype)
+            config.ckpt_path = ckpt
+            config.init_precision_config(kv_cache_config=None, act_type="bf16")
+        self.assertEqual(config.compute_dtype, torch.bfloat16)
+
+    def test_falls_back_to_fp16_when_neither_ckpt_dtype_nor_act_type(self):
+        config = ModelConfig()
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump({"hidden_size": 5120}, f)
+            resolve_config_dtype(config, ckpt)
+            config.ckpt_path = ckpt
+            config.init_precision_config(kv_cache_config=None, act_type=None)
+        self.assertEqual(config.compute_dtype, torch.float16)
+
+    def test_rejects_a_missing_config_json(self):
+        with self.assertRaises(FileNotFoundError):
+            self._resolve(None)
+
+
+class Glm4MoeNextNDtypeTest(unittest.TestCase):
+    def test_draft_config_inherits_the_dtype_resolution(self):
+        # Glm4MoeNextN._create_config goes through Glm4Moe, so the draft must
+        # pick up bfloat16 without its own copy of the logic.
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump(_glm47_config_json(), f)
+            config = Glm4MoeNextN._create_config(ckpt)
+        self.assertEqual(config.config_dtype, "bfloat16")
+
+
+class RouterLogitsFp32Test(unittest.TestCase):
+    """GLM must route on fp32 logits.
+
+    Measured on the real checkpoint: a bf16 router projection moves the logits by
+    only 1.7e-3 relative, but reorders near-ties in the top-8-of-160 selection for
+    3% of all (layer, token) pairs, starting at the first MoE layer. Because a
+    different expert is a discrete change, the error then compounds -- 0.2
+    relative by layer 69 against SGLang. Nothing fails loudly if this regresses,
+    so it is pinned here.
+    """
+
+    def test_default_is_off_so_other_models_are_unaffected(self):
+        from rtp_llm.config.model_config import ModelConfig
+
+        self.assertFalse(ModelConfig().router_logits_fp32)
+
+    def test_glm4_moe_turns_it_on(self):
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump(_glm47_config_json(), f)
+            config = Glm4Moe._create_config(ckpt)
+        self.assertTrue(config.router_logits_fp32)
+
+    def test_the_nextn_draft_inherits_it(self):
+        # The draft runs the same MoE layer, so it has to route the same way or
+        # its proposals will disagree with the target for a different reason.
+        with tempfile.TemporaryDirectory() as ckpt:
+            with open(os.path.join(ckpt, "config.json"), "w") as f:
+                json.dump(_glm47_config_json(), f)
+            config = Glm4MoeNextN._create_config(ckpt)
+        self.assertTrue(config.router_logits_fp32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2.json
+++ b/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2.json
@@ -19,14 +19,15 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777441829,
+                "created": 1788414707,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### 一、方法类问题\n1. **你通常如何训练英语听力？你觉得自己最有效的方法是什么？为什么？**  \n2. **你是否尝试过“精听”和“泛听”结合的方法？你觉得哪种对你帮助更大？**  \n3. **你是否使用过“听写”或“跟读”练习？这些方法",
+                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### **1. 输入与理解的关系**\n> “在英语听力中，‘听懂’是否一定意味着‘理解’？请结合你的学习经验，谈谈你对‘可理解输入（comprehensible input）’这一概念的理解。”\n\n---\n\n### **2. 精听与泛听的平衡**\n> “你认为精听",
+                            "name": null,
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -46,14 +47,14 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 6241.346,
+                    "cost_time": 5194.005,
                     "iter_count": 100,
                     "prefix_len": 0,
                     "input_len": 14,
                     "output_len": 100,
                     "step_output_len": 100,
-                    "first_token_cost_time": 1626.885,
-                    "wait_time": 0.0,
+                    "first_token_cost_time": 154.445,
+                    "wait_time": 0.197,
                     "pd_sep": false,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -70,10 +71,14 @@
                     "decode_local_reuse_len": 0,
                     "decode_remote_reuse_len": 0,
                     "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
                     "role_addrs": [],
                     "aux_string": ""
                 },
-                "extra_outputs": null
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         },
         {
@@ -91,7 +96,7 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -120,10 +125,11 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -152,10 +158,11 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -184,7 +191,8 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     }
                 ]
             }

--- a/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2_kernel_block_size_64.json
+++ b/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2_kernel_block_size_64.json
@@ -19,14 +19,15 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777443156,
+                "created": 1788414805,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### 一、方法类问题\n1. **你通常如何训练英语听力？你觉得自己最有效的方法是什么？为什么？**  \n2. **你是否尝试过“精听”和“泛听”结合的方法？你觉得哪种对你帮助更大？**  \n3. **你是否使用过“听写”或“跟读”练习？这些方法",
+                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### **1. 输入与理解的关系**\n> “在英语听力中，‘听懂’是否一定意味着‘理解’？请结合你的学习经验，谈谈你对‘可理解输入（comprehensible input）’这一概念的理解。”\n\n---\n\n### **2. 精听与泛听的平衡**\n> “你认为精听",
+                            "name": null,
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -46,14 +47,14 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 6490.963,
+                    "cost_time": 5343.464,
                     "iter_count": 100,
                     "prefix_len": 0,
                     "input_len": 14,
                     "output_len": 100,
                     "step_output_len": 100,
-                    "first_token_cost_time": 1585.445,
-                    "wait_time": 0.0,
+                    "first_token_cost_time": 304.802,
+                    "wait_time": 0.197,
                     "pd_sep": false,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -70,10 +71,14 @@
                     "decode_local_reuse_len": 0,
                     "decode_remote_reuse_len": 0,
                     "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
                     "role_addrs": [],
                     "aux_string": ""
                 },
-                "extra_outputs": null
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         },
         {
@@ -91,7 +96,7 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -120,10 +125,11 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -152,10 +158,11 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -184,7 +191,8 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     }
                 ]
             }

--- a/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2_pd_sep.json
+++ b/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2_pd_sep.json
@@ -19,14 +19,15 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777443818,
+                "created": 1788415138,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### 一、方法类问题\n1. **你通常如何训练英语听力？你觉得自己最有效的方法是什么？为什么？**  \n2. **你是否尝试过“精听”和“泛听”结合的方法？你觉得哪种对你帮助更大？**  \n3. **你是否使用过“听写”或“跟读”练习？这些方法",
+                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### **1. 输入与理解的关系**\n> “在英语听力中，‘听懂’是否一定意味着‘理解’？请结合你的学习经验，谈谈你对‘可理解输入（comprehensible input）’这一概念的理解。”\n\n---\n\n### **2. 精听与泛听的平衡**\n> “你认为精听",
+                            "name": null,
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -46,14 +47,14 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 7077.067,
+                    "cost_time": 5150.872,
                     "iter_count": 100,
                     "prefix_len": 0,
                     "input_len": 14,
                     "output_len": 100,
                     "step_output_len": 99,
-                    "first_token_cost_time": 2216.145,
-                    "wait_time": 0.0,
+                    "first_token_cost_time": 653.824,
+                    "wait_time": 0.09,
                     "pd_sep": true,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -70,17 +71,21 @@
                     "decode_local_reuse_len": 0,
                     "decode_remote_reuse_len": 0,
                     "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
                     "role_addrs": [
                         {
                             "role": "DECODE",
                             "ip": "127.0.0.1",
-                            "http_port": 10615,
-                            "grpc_port": 10616
+                            "http_port": 18821,
+                            "grpc_port": 18822
                         }
                     ],
                     "aux_string": ""
                 },
-                "extra_outputs": null
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         },
         {
@@ -99,7 +104,7 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -128,10 +133,11 @@
                             "beam_responses": [],
                             "pd_sep": true,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -160,10 +166,11 @@
                             "beam_responses": [],
                             "pd_sep": true,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -192,7 +199,8 @@
                             "beam_responses": [],
                             "pd_sep": true,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     }
                 ]
             }

--- a/rtp_llm/test/smoke/data/model/kimi_linear/q_r_cuda_graph.json
+++ b/rtp_llm/test/smoke/data/model/kimi_linear/q_r_cuda_graph.json
@@ -19,14 +19,15 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777443359,
+                "created": 1788414891,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### 一、方法类问题\n1. **你通常如何训练英语听力？你觉得自己最有效的方法是什么？为什么？**  \n2. **你是否尝试过“精听”和“泛听”结合的方法？你觉得哪种对你帮助更大？**  \n3. **你是否使用过“听写”或“跟读”练习？这些方法",
+                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### **1. 输入与理解的关系**\n> “在英语听力中，‘听懂’是否一定意味着‘理解’？请结合你的学习经验，谈谈你对‘可理解输入（comprehensible input）’这一概念的理解。”\n\n---\n\n### **2. 精听与泛听的平衡**\n> “你认为精听",
+                            "name": null,
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -46,14 +47,14 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 11006.072,
+                    "cost_time": 958.193,
                     "iter_count": 100,
                     "prefix_len": 0,
                     "input_len": 14,
                     "output_len": 100,
                     "step_output_len": 100,
-                    "first_token_cost_time": 10356.814,
-                    "wait_time": 0.0,
+                    "first_token_cost_time": 373.62,
+                    "wait_time": 0.196,
                     "pd_sep": false,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -70,10 +71,14 @@
                     "decode_local_reuse_len": 0,
                     "decode_remote_reuse_len": 0,
                     "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
                     "role_addrs": [],
                     "aux_string": ""
                 },
-                "extra_outputs": null
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         },
         {
@@ -91,7 +96,7 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -120,10 +125,11 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -152,10 +158,11 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nCAP theorem states that a distributed system can only",
+                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -184,7 +191,8 @@
                             "beam_responses": [],
                             "pd_sep": false,
                             "softmax_probs": []
-                        }
+                        },
+                        "prompt_logprobs": null
                     }
                 ]
             }

--- a/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_moe_vl_fp8.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_moe_vl_fp8.json
@@ -28,25 +28,82 @@
                 "top_k": 1
             },
             "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1788415184,
+                "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "The user wants a description of the provided image.\n\n1.  **Identify the main subjects:** A woman and a dog.\n2.  **Identify the setting:** A sandy beach with the ocean in the background. The lighting suggests late afternoon or sunset (golden hour).\n3.  **Describe the action:** The woman is sitting on the sand. The dog is sitting opposite her. They are interacting, specifically doing a \"high five\" or \"shake\" trick. The",
-                            "partial": false
+                            "content": "The user wants a description of the provided image.\n\n1.  **Identify the main subjects:** A woman and a dog.\n2.  **Identify the setting:** A sandy beach with the ocean in the background. The lighting suggests late afternoon or sunset (golden hour).\n3.  **Describe the action:** The woman is sitting on the sand. The dog is sitting facing her. They are interacting, specifically the dog is lifting its paw and the woman is holding it (",
+                            "name": null,
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
                         },
-                        "finish_reason": "length"
+                        "finish_reason": "length",
+                        "logprobs": null
                     }
                 ],
                 "usage": {
                     "prompt_tokens": 2773,
                     "total_tokens": 2873,
                     "completion_tokens": 100,
+                    "completion_tokens_details": null,
                     "prompt_tokens_details": {
-                        "image_tokens": 2752
+                        "audio_tokens": null,
+                        "cached_tokens": null,
+                        "image_tokens": 2752,
+                        "video_tokens": null
                     }
-                }
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 5534.161,
+                    "iter_count": 100,
+                    "prefix_len": 0,
+                    "input_len": 2773,
+                    "output_len": 100,
+                    "step_output_len": 99,
+                    "first_token_cost_time": 4635.106,
+                    "wait_time": 0.061,
+                    "pd_sep": true,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {
+                        "1": 2752
+                    },
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
+                    "role_addrs": [
+                        {
+                            "role": "DECODE",
+                            "ip": "127.0.0.1",
+                            "http_port": 13102,
+                            "grpc_port": 13103
+                        }
+                    ],
+                    "aux_string": ""
+                },
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         }
     ]

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_tp2_dp2.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_tp2_dp2.json
@@ -19,32 +19,42 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777370097,
+                "created": 1788415309,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "嗯，用户问“你是谁”，这是一个非常基础的问题，需要明确我的身份。我是 Qwen3.5，是阿里巴巴最新推出的通义千问大语言模型。我应该简洁地介绍自己，同时突出关键升级点，但避免过于技术化的术语。\n\n首先，用户可能想知道我的基本功能，比如能做什么。需要提到我的核心能力，比如多语言支持、逻辑推理、代码生成等。但作为 Qwen3.5，应该强调相比前代的"
+                            "content": "嗯，用户问“你是谁”，这是一个非常基础的问题，需要明确我的身份。我是 Qwen3.5，是阿里巴巴最新推出的通义千问大语言模型。我应该简洁地介绍自己，同时突出关键升级点，但避免过于技术化的术语。\n\n首先，用户可能想知道我的基本功能，比如能做什么。需要提到我的核心能力，比如多语言支持、逻辑推理、代码生成等。但作为 Qwen3.5，应该强调相比前代的",
+                            "name": null,
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
                         },
-                        "finish_reason": "length"
+                        "finish_reason": "length",
+                        "logprobs": null
                     }
                 ],
                 "usage": {
                     "prompt_tokens": 11,
                     "total_tokens": 111,
-                    "completion_tokens": 100
+                    "completion_tokens": 100,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
                 },
+                "debug_info": null,
                 "aux_info": {
-                    "cost_time": 6758.758,
+                    "cost_time": 9451.365,
                     "iter_count": 100,
                     "prefix_len": 0,
                     "input_len": 11,
                     "output_len": 100,
                     "step_output_len": 100,
-                    "first_token_cost_time": 243.253,
-                    "wait_time": 0.0,
+                    "first_token_cost_time": 2528.677,
+                    "wait_time": 826.915,
                     "pd_sep": false,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -61,9 +71,14 @@
                     "decode_local_reuse_len": 0,
                     "decode_remote_reuse_len": 0,
                     "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
                     "role_addrs": [],
                     "aux_string": ""
-                }
+                },
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         }
     ]

--- a/rtp_llm/test/smoke/data/model/qwen3_next/dash_basic.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/dash_basic.json
@@ -15,8 +15,31 @@
                 "request_id": "smoke_dash_basic"
             },
             "result": {
-                "response": "\n\nThis is a simple example of a web application built with the\n[Fl",
+                "response": "\n\nThis is a simple example of a web page.\n\n```html\n<!",
+                "cancelled": false,
+                "cancel_requested": false,
+                "cancel_exercised": false,
+                "completed_before_cancel": false,
                 "finish_reason": 1,
+                "generated_ids": [
+                    271,
+                    1919,
+                    369,
+                    264,
+                    4145,
+                    3010,
+                    314,
+                    264,
+                    3370,
+                    2081,
+                    13,
+                    271,
+                    71093,
+                    1497,
+                    198,
+                    13151
+                ],
+                "prompt_token_ids": [],
                 "prompt_token_num": 4,
                 "prompt_cached_token_num": 0
             }
@@ -34,8 +57,22 @@
                 "request_id": "smoke_dash_return_input_ids"
             },
             "result": {
-                "response": "\n\n\nThis PR adds a check to the",
+                "response": "\n\n\nThis PR adds a check to ensure",
+                "cancelled": false,
+                "cancel_requested": false,
+                "cancel_exercised": false,
+                "completed_before_cancel": false,
                 "finish_reason": 1,
+                "generated_ids": [
+                    1358,
+                    1919,
+                    8313,
+                    11039,
+                    264,
+                    1716,
+                    310,
+                    5790
+                ],
                 "prompt_token_ids": [
                     40860,
                     3423,
@@ -64,7 +101,22 @@
             },
             "result": {
                 "response": " a high-performance, low-latency inference",
+                "cancelled": false,
+                "cancel_requested": false,
+                "cancel_exercised": false,
+                "completed_before_cancel": false,
                 "finish_reason": 1,
+                "generated_ids": [
+                    264,
+                    1496,
+                    55549,
+                    11,
+                    3238,
+                    95013,
+                    2179,
+                    42903
+                ],
+                "prompt_token_ids": [],
                 "prompt_token_num": 10,
                 "prompt_cached_token_num": 0
             }
@@ -82,8 +134,18 @@
                 "request_id": "smoke_dash_cancel_after_first_response"
             },
             "result": {
-                "response": "",
-                "cancelled": true
+                "response": "\n",
+                "cancelled": true,
+                "cancel_requested": true,
+                "cancel_exercised": true,
+                "completed_before_cancel": false,
+                "finish_reason": 2,
+                "generated_ids": [
+                    198
+                ],
+                "prompt_token_ids": [],
+                "prompt_token_num": 8,
+                "prompt_cached_token_num": 0
             }
         }
     ]

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2.json
@@ -17,22 +17,68 @@
                 "top_k": 1
             },
             "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1788414720,
+                "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** The questions should be thought-prov",
-                            "partial": false
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate).\n    *   **Goal:** The questions should be thought-provoking,",
+                            "name": null,
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
                         },
-                        "finish_reason": "length"
+                        "finish_reason": "length",
+                        "logprobs": null
                     }
                 ],
                 "usage": {
                     "prompt_tokens": 18,
                     "total_tokens": 118,
-                    "completion_tokens": 100
-                }
+                    "completion_tokens": 100,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 11739.38,
+                    "iter_count": 100,
+                    "prefix_len": 0,
+                    "input_len": 18,
+                    "output_len": 100,
+                    "step_output_len": 100,
+                    "first_token_cost_time": 2844.068,
+                    "wait_time": 2.401,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         },
         {
@@ -50,13 +96,103 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\nThe CAP theorem, also known as Brewer's"
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 6,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 10,
+                            "step_output_len": 10,
+                            "iter_count": 10,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": false,
+                            "softmax_probs": []
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nThe CAP theorem, also known as Brewer's"
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 6,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 10,
+                            "step_output_len": 10,
+                            "iter_count": 10,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": false,
+                            "softmax_probs": []
+                        },
+                        "prompt_logprobs": null
                     },
                     {
-                        "response": "\n\nThe CAP theorem, also known as Brewer's"
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 6,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 10,
+                            "step_output_len": 10,
+                            "iter_count": 10,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": false,
+                            "softmax_probs": []
+                        },
+                        "prompt_logprobs": null
                     }
                 ]
             }

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
@@ -20,14 +20,15 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777289051,
+                "created": 1788415012,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** The questions should be thought-prov",
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate).\n    *   **Goal:** The questions should be thought-provoking,",
+                            "name": null,
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -47,14 +48,14 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 3143.197,
-                    "iter_count": 25,
+                    "cost_time": 7524.62,
+                    "iter_count": 26,
                     "prefix_len": 0,
                     "input_len": 18,
                     "output_len": 100,
                     "step_output_len": 100,
-                    "first_token_cost_time": 264.576,
-                    "wait_time": 0.0,
+                    "first_token_cost_time": 2799.147,
+                    "wait_time": 0.294,
                     "pd_sep": false,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -71,10 +72,19 @@
                     "decode_local_reuse_len": 0,
                     "decode_remote_reuse_len": 0,
                     "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 25,
+                    "speculative_accepted_tokens_per_pos": [
+                        24,
+                        19,
+                        18,
+                        14
+                    ],
                     "role_addrs": [],
                     "aux_string": ""
                 },
-                "extra_outputs": null
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         },
         {
@@ -95,7 +105,7 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777289052,
+                "created": 1788415012,
                 "model": "",
                 "choices": [
                     {
@@ -103,6 +113,7 @@
                         "message": {
                             "role": "assistant",
                             "content": "Here's a thinking process that leads to the suggested revisions:\n\n1.  **Analyze the",
+                            "name": null,
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -122,14 +133,14 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 684.577,
+                    "cost_time": 713.972,
                     "iter_count": 5,
                     "prefix_len": 0,
                     "input_len": 467,
                     "output_len": 20,
                     "step_output_len": 20,
-                    "first_token_cost_time": 243.41,
-                    "wait_time": 0.0,
+                    "first_token_cost_time": 299.833,
+                    "wait_time": 0.232,
                     "pd_sep": false,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -146,10 +157,19 @@
                     "decode_local_reuse_len": 0,
                     "decode_remote_reuse_len": 0,
                     "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 4,
+                    "speculative_accepted_tokens_per_pos": [
+                        4,
+                        4,
+                        4,
+                        4
+                    ],
                     "role_addrs": [],
                     "aux_string": ""
                 },
-                "extra_outputs": null
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
         },
         {
@@ -198,7 +218,8 @@
                     "beam_responses": [],
                     "pd_sep": false,
                     "softmax_probs": []
-                }
+                },
+                "prompt_logprobs": null
             }
         }
     ]

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_pd.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_pd.json
@@ -42,12 +42,13 @@
                     "decode_memory_reuse_len": 0,
                     "output_len": 20,
                     "step_output_len": 19,
-                    "iter_count": 7,
+                    "iter_count": 6,
                     "cum_log_probs": [],
                     "beam_responses": [],
                     "pd_sep": true,
                     "softmax_probs": []
-                }
+                },
+                "prompt_logprobs": null
             }
         },
         {
@@ -90,12 +91,13 @@
                     "decode_memory_reuse_len": 0,
                     "output_len": 20,
                     "step_output_len": 19,
-                    "iter_count": 7,
+                    "iter_count": 6,
                     "cum_log_probs": [],
                     "beam_responses": [],
                     "pd_sep": true,
                     "softmax_probs": []
-                }
+                },
+                "prompt_logprobs": null
             }
         },
         {
@@ -138,12 +140,13 @@
                     "decode_memory_reuse_len": 0,
                     "output_len": 20,
                     "step_output_len": 19,
-                    "iter_count": 7,
+                    "iter_count": 6,
                     "cum_log_probs": [],
                     "beam_responses": [],
                     "pd_sep": true,
                     "softmax_probs": []
-                }
+                },
+                "prompt_logprobs": null
             }
         }
     ]

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_pd_sep.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_pd_sep.json
@@ -1,201 +1,209 @@
 {
-  "model_type": "qwen3_next",
-  "model_path": "/mnt/nas1/hf/Qwen3-Next-80B-A3B-Instruct-FP8",
-  "query_result": [
-    {
-      "endpoint": "/v1/chat/completions",
-      "query": {
-        "messages": [
-          {
-            "role": "user",
-            "content": "$prompt:s2"
-          }
-        ],
-        "max_tokens": 100,
-        "temperature": 0.0,
-        "top_p": 0,
-        "top_k": 1
-      },
-      "result": {
-        "id": "chat-",
-        "object": "chat.completion",
-        "created": 1777289281,
-        "model": "",
-        "choices": [
-          {
-            "index": 0,
-            "message": {
-              "role": "assistant",
-              "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度和实用性的问题，适合用于学习反思、教学讨论或研究：\n\n1. What are the most effective strategies for improving English listening skills at an intermediate level, and why do they work better than others?\n\n2. How can active listening techniques (such as note-taking, predicting content, or shadowing) be systematically integrated into daily English practice?\n\n3. What role does background knowledge (cultural context, topic familiarity) play",
-              "reasoning_content": null,
-              "function_call": null,
-              "tool_calls": null,
-              "partial": false,
-              "tool_call_id": null
+    "model_type": "qwen3_next",
+    "model_path": "/mnt/nas1/hf/Qwen3-Next-80B-A3B-Instruct-FP8",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "$prompt:s2"
+                    }
+                ],
+                "max_tokens": 100,
+                "temperature": 0.0,
+                "top_p": 0,
+                "top_k": 1
             },
-            "finish_reason": "length",
-            "logprobs": null
-          }
-        ],
-        "usage": {
-          "prompt_tokens": 16,
-          "total_tokens": 116,
-          "completion_tokens": 100,
-          "completion_tokens_details": null,
-          "prompt_tokens_details": null
-        },
-        "debug_info": null,
-        "aux_info": {
-          "cost_time": 9147.866,
-          "iter_count": 100,
-          "prefix_len": 0,
-          "input_len": 16,
-          "output_len": 100,
-          "step_output_len": 99,
-          "first_token_cost_time": 519.652,
-          "wait_time": 0.0,
-          "pd_sep": true,
-          "cum_log_probs": [],
-          "beam_responses": [],
-          "softmax_probs": [],
-          "reuse_len": 0,
-          "local_reuse_len": 0,
-          "remote_reuse_len": 0,
-          "memory_reuse_len": 0,
-          "prefill_total_reuse_len": 0,
-          "prefill_local_reuse_len": 0,
-          "prefill_remote_reuse_len": 0,
-          "prefill_memory_reuse_len": 0,
-          "decode_total_reuse_len": 0,
-          "decode_local_reuse_len": 0,
-          "decode_remote_reuse_len": 0,
-          "decode_memory_reuse_len": 0,
-          "role_addrs": [
-            {
-              "role": "DECODE",
-              "ip": "127.0.0.1",
-              "http_port": 10300,
-              "grpc_port": 10301
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1788415236,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度和实用性的问题，适合用于学习反思、教学研讨或自我提升：\n\n1. What are the most effective active listening strategies for improving English comprehension, and how can learners apply them in daily practice?\n\n2. How does shadowing (repeating audio immediately after hearing it) enhance listening skills, and what types of materials are best suited for this technique?\n\n3. Why is listening to authentic materials (e.g., podcasts,",
+                            "name": null,
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "length",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 16,
+                    "total_tokens": 116,
+                    "completion_tokens": 100,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 8644.024,
+                    "iter_count": 100,
+                    "prefix_len": 0,
+                    "input_len": 16,
+                    "output_len": 100,
+                    "step_output_len": 99,
+                    "first_token_cost_time": 259.0,
+                    "wait_time": 0.048,
+                    "pd_sep": true,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "speculative_draft_rounds": 0,
+                    "speculative_accepted_tokens_per_pos": [],
+                    "role_addrs": [
+                        {
+                            "role": "DECODE",
+                            "ip": "127.0.0.1",
+                            "http_port": 16025,
+                            "grpc_port": 16026
+                        }
+                    ],
+                    "aux_string": ""
+                },
+                "extra_outputs": null,
+                "prompt_logprobs": null
             }
-          ],
-          "aux_string": ""
         },
-        "extra_outputs": null
-      }
-    },
-    {
-      "endpoint": "/",
-      "query": {
-        "prompt_batch": [
-          "$prompt:s1",
-          "$prompt:s1",
-          "$prompt:s1"
-        ],
-        "generate_config": {
-          "max_new_tokens": 10,
-          "top_k": 1
+        {
+            "endpoint": "/",
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s1",
+                    "$prompt:s1",
+                    "$prompt:s1"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": " explain in simple terms\n\nSure! Let’s break",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 6,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 10,
+                            "step_output_len": 9,
+                            "iter_count": 10,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": true,
+                            "softmax_probs": []
+                        },
+                        "prompt_logprobs": null
+                    },
+                    {
+                        "response": " explain in simple terms\n\nSure! Let’s break",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 6,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 10,
+                            "step_output_len": 9,
+                            "iter_count": 10,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": true,
+                            "softmax_probs": []
+                        },
+                        "prompt_logprobs": null
+                    },
+                    {
+                        "response": " explain in simple terms\n\nSure! Let’s break",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 6,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 10,
+                            "step_output_len": 9,
+                            "iter_count": 10,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": true,
+                            "softmax_probs": []
+                        },
+                        "prompt_logprobs": null
+                    }
+                ]
+            }
         }
-      },
-      "result": {
-        "response_batch": [
-          {
-            "response": " explain in simple terms\n\nSure! Let’s break",
-            "response_alternatives": null,
-            "hidden_states": null,
-            "logits": null,
-            "loss": null,
-            "input_ids": null,
-            "output_ids": null,
-            "aux_info": {
-              "input_len": 6,
-              "prefix_len": 0,
-              "reuse_len": 0,
-              "local_reuse_len": 0,
-              "remote_reuse_len": 0,
-              "memory_reuse_len": 0,
-              "prefill_total_reuse_len": 0,
-              "prefill_local_reuse_len": 0,
-              "prefill_remote_reuse_len": 0,
-              "prefill_memory_reuse_len": 0,
-              "decode_total_reuse_len": 0,
-              "decode_local_reuse_len": 0,
-              "decode_remote_reuse_len": 0,
-              "decode_memory_reuse_len": 0,
-              "output_len": 10,
-              "step_output_len": 9,
-              "iter_count": 10,
-              "cum_log_probs": [],
-              "beam_responses": [],
-              "pd_sep": true,
-              "softmax_probs": []
-            }
-          },
-          {
-            "response": " explain in simple terms\n\nSure! Let’s break",
-            "response_alternatives": null,
-            "hidden_states": null,
-            "logits": null,
-            "loss": null,
-            "input_ids": null,
-            "output_ids": null,
-            "aux_info": {
-              "input_len": 6,
-              "prefix_len": 0,
-              "reuse_len": 0,
-              "local_reuse_len": 0,
-              "remote_reuse_len": 0,
-              "memory_reuse_len": 0,
-              "prefill_total_reuse_len": 0,
-              "prefill_local_reuse_len": 0,
-              "prefill_remote_reuse_len": 0,
-              "prefill_memory_reuse_len": 0,
-              "decode_total_reuse_len": 0,
-              "decode_local_reuse_len": 0,
-              "decode_remote_reuse_len": 0,
-              "decode_memory_reuse_len": 0,
-              "output_len": 10,
-              "step_output_len": 9,
-              "iter_count": 10,
-              "cum_log_probs": [],
-              "beam_responses": [],
-              "pd_sep": true,
-              "softmax_probs": []
-            }
-          },
-          {
-            "response": " explain in simple terms\n\nSure! Let’s break",
-            "response_alternatives": null,
-            "hidden_states": null,
-            "logits": null,
-            "loss": null,
-            "input_ids": null,
-            "output_ids": null,
-            "aux_info": {
-              "input_len": 6,
-              "prefix_len": 0,
-              "reuse_len": 0,
-              "local_reuse_len": 0,
-              "remote_reuse_len": 0,
-              "memory_reuse_len": 0,
-              "prefill_total_reuse_len": 0,
-              "prefill_local_reuse_len": 0,
-              "prefill_remote_reuse_len": 0,
-              "prefill_memory_reuse_len": 0,
-              "decode_total_reuse_len": 0,
-              "decode_local_reuse_len": 0,
-              "decode_remote_reuse_len": 0,
-              "decode_memory_reuse_len": 0,
-              "output_len": 10,
-              "step_output_len": 9,
-              "iter_count": 10,
-              "cum_log_probs": [],
-              "beam_responses": [],
-              "pd_sep": true,
-              "softmax_probs": []
-            }
-          }
-        ]
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
## Changes

### PPU W8A8 INT8 Pure-TP DeepGEMM MoE Path
- Add PpuW8A8Int8PureTpDeepGemmStrategy strategy
- Add PpuPureTpRouterW8A8Int8 router
- Add DeepGemmInt8PureTpMaskedExecutor executor
- Register strategy to fused_moe backend, extend CLI --moe_strategy choices

### IPv6 RDMA Fix
- EIC connection address family: switch from envSocketFamily() to GID table auto-detection
- RdmaClient/RdmaServer TCP transport IPv6 support

### Bug Fixes
- FA3 prefill cross-device length addition crash fix
- per-token quant row offsets int32→int64 overflow fix
- bf16 contiguous path NameError fix
- silu_and_mul offset/width correction

### Tests
- W8A8 INT8 strategy selection matrix test
- Pure-TP MoE numerical equivalence test
- CpuTpBroadcaster error-reporting fix