### PR TITLE
fix: defer SCR monitoring transport and refresh restored identity

### DIFF
--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -66,10 +66,13 @@ error, both reporters activate their external transport. They reread the Hippo
 runtime environment and rebuild the sink and identity tags so a restored process
 does not report with the seed Pod's host or container IP. Python also replaces
 stale runtime tags when rendering data points that were registered before the
-checkpoint. The native library must provide the matching lifecycle hooks; mixing
-new Python helpers with an older loaded native library rejects checkpoint
-participation rather than silently retaining sockets. Ordinary serving without
-SCR keeps the original eager reporting behavior.
+checkpoint. Native reporting applies the refreshed runtime identity at the
+publish boundary, so a metric declared before the checkpoint can retain its
+existing handle while its emitted records use the restored Pod's IP tags. The
+native library must provide the matching lifecycle hooks; mixing new Python
+helpers with an older loaded native library rejects checkpoint participation
+rather than silently retaining sockets. Ordinary serving without SCR keeps the
+original eager reporting behavior.
 
 CPU validation covers deferred Python transport activation, real TCP
 closure/reconnection, refreshed runtime identity, and native metric registration

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -2,7 +2,8 @@
 
 This branch adds opt-in stable loopback communication for ranks that share one
 Pod network namespace. It builds on `feat/dsv4_on_dev_scr` at
-`7eb9d7bc790b561e347e3bf4cc3c168c39787844`.
+`888476cf150c924b249d62b52afcd41753430e6b`, retaining its control-plane
+lifecycle and endpoint restore support.
 
 Set `RTP_LLM_SCR_LOCAL_COMM=1` on both the checkpoint seed and restore workload.
 Set `LOCAL_WORLD_SIZE` to `WORLD_SIZE`. RPC fan-out, TCPStore and NCCL rendezvous
@@ -12,10 +13,10 @@ After restore, the saved `self.ip` may differ from newly resolved member address
 that difference alone must not invalidate the topology.
 
 Local health polling uses numeric loopback to avoid transient resolver netlink
-sockets during checkpoint. With `SCR_ENABLE=1` and `SCR_PHASE=checkpoint`, grammar
-sandbox workers are created on first validation rather than eagerly at startup.
-Do not send grammar validation traffic before checkpoint: it can instantiate the
-sandbox pool. Ordinary startup retains eager pool creation.
+sockets during checkpoint. Grammar workers participate in the upstream template lifecycle; their sandbox
+pool is quiesced before the barrier and recreated when the template is released.
+The public integration switch is `RTPLLM_ENABLE_SCR=1`; the external controller
+selects `SCR_PHASE`.
 
 The internal entrypoint sets `NCCL_SOCKET_IFNAME=lo` in this mode and preloads the
 SCR-injected NCCL interposer for the checkpoint phase. The interposer and the
@@ -25,7 +26,9 @@ GCC 12 library search path needed by runtime JIT compilation.
 The fused RoPE call site supports both legacy and current rtp-kernel wrappers:
 the current API takes `position_ids` in prefill and separate position IDs plus
 sequence lengths in decode. Kernel feature detection is cached, uses the Python
-signature, and does not change tensors or native modules at runtime.
+signature, and does not change tensors or native modules at runtime. The paired
+image pins a kernel wheel using the current API, so this compatibility adapter
+is required even though the upstream branch removed it.
 
 ## Validation and acceptance boundary
 
@@ -61,8 +64,9 @@ or reporting thread. The native reporter initializes the factory configuration
 in manual mode and accepts metric registration, but does not start its metrics
 system or create the configured sink.
 
-After `epsilon.snapstart_checkpoint()` returns, including after a checkpoint
-error, both reporters activate their external transport. They reread the Hippo
+The upstream template lifecycle releases both reporters after the Epsilon
+barrier and restore fixup; its abort path also resumes prepared reporters.
+Both reporters then activate their external transport. They reread the Hippo
 runtime environment and rebuild the sink and identity tags so a restored process
 does not report with the seed Pod's host or container IP. Python also replaces
 stale runtime tags when rendering data points that were registered before the

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -74,6 +74,15 @@ helpers with an older loaded native library rejects checkpoint participation
 rather than silently retaining sockets. Ordinary serving without SCR keeps the
 original eager reporting behavior.
 
+CRIU can preserve `RequestedIP` from the seed even when the new Pod's hostname
+resolves to its new IP. Before native reporting resumes, the SCR helper resolves
+that hostname and refreshes `RequestedIP` in the process environment. If resolution
+fails, it logs the failure and leaves the existing value in place; that case still
+needs explicit monitoring validation. Rebuilding the native configuration also
+replaces its common tag map: otherwise the insert-only `host` tag would retain the
+seed value despite rerunning hostname resolution. Fresh-image acceptance checks
+both `container_ip` and `host` on actual emitted native records.
+
 CPU validation covers deferred Python transport activation, real TCP
 closure/reconnection, refreshed runtime identity, and native metric registration
 retention across sink replacement. Full acceptance must additionally verify

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -66,7 +66,9 @@ system or create the configured sink.
 
 The upstream template lifecycle releases both reporters after the Epsilon
 barrier and restore fixup; its abort path also resumes prepared reporters.
-Both reporters then activate their external transport. They reread the Hippo
+The main parent participates through the same lifecycle wrapper as its children,
+so its deferred Python reporter is also released. Both reporters then activate
+their external transport. They reread the Hippo
 runtime environment and rebuild the sink and identity tags so a restored process
 does not report with the seed Pod's host or container IP. Python also replaces
 stale runtime tags when rendering data points that were registered before the

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -54,20 +54,26 @@ network namespace. Leave it unset for multi-node deployments.
 
 ## Monitoring connections at the checkpoint boundary
 
-Each SCR participant pauses its already-loaded Kmonitor reporters before entering
-the Epsilon barrier. Python reporters join their reporting thread and close Flume.
-The native reporter stops its sampling/sending threads and reinitializes the
-configured sink in manual mode, releasing the old transport while retaining the
-registered metric sources. It does not shut down the Kmonitor factory.
+During an SCR checkpoint or restore phase, each participant creates its Python
+and native metric registries at the normal initialization points, but defers the
+external Kmonitor transport. The Python reporter does not create its Flume client
+or reporting thread. The native reporter initializes the factory configuration
+in manual mode and accepts metric registration, but does not start its metrics
+system or create the configured sink.
 
-When the barrier returns, including after a checkpoint error, both reporters
-resume using their original configuration. The native library must provide the
-matching lifecycle hooks; mixing new Python helpers with an older loaded native
-library rejects checkpoint participation rather than silently retaining sockets.
-Ordinary serving without SCR does not pause reporting.
+After `epsilon.snapstart_checkpoint()` returns, including after a checkpoint
+error, both reporters activate their external transport. They reread the Hippo
+runtime environment and rebuild the sink and identity tags so a restored process
+does not report with the seed Pod's host or container IP. Python also replaces
+stale runtime tags when rendering data points that were registered before the
+checkpoint. The native library must provide the matching lifecycle hooks; mixing
+new Python helpers with an older loaded native library rejects checkpoint
+participation rather than silently retaining sockets. Ordinary serving without
+SCR keeps the original eager reporting behavior.
 
-CPU validation covers real Python TCP closure/reconnection and native metric
-registration retention across sink replacement. Full acceptance must additionally
-verify dump/restore, restored inference, and resumed reporting in a fresh image.
+CPU validation covers deferred Python transport activation, real TCP
+closure/reconnection, refreshed runtime identity, and native metric registration
+retention across sink replacement. Full acceptance must additionally verify
+dump/restore, restored inference, and resumed reporting in a fresh image.
 These hooks address the configured built-in sink; custom sinks and independently
 retained sink references require their own external-connection lifecycle checks.

--- a/patches/havenask/havenask.patch
+++ b/patches/havenask/havenask.patch
@@ -47,3 +47,65 @@ index 03ff7ce5..bdaff505 100644
  def genshared(name, lib):
      return native.genrule(
          name = name,
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp
+index f0f8590e..6597e6a6 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp
+@@ -51,3 +51,13 @@
+ const string &MetricsRecord::Name() const { return info_->Name(); }
+-
++void MetricsRecord::OverrideTags(const map<string, string> &tags) {
++    if (tags.empty()) {
++        return;
++    }
++    auto mergedTags = tags_->GetTagsMap();
++    for (const auto &tag : tags) {
++        mergedTags[tag.first] = tag.second;
++    }
++    tags_.reset(new MetricsTags(mergedTags));
++}
++
+ void MetricsRecord::AddValue(const MetricsInfoPtr &info, double value) {
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h
+index cb2802e3..ec471b1b 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h
+@@ -31,2 +31,3 @@ public:
+     const std::vector<MetricsValue *> &Values() const { return values_; }
++    void OverrideTags(const std::map<std::string, std::string> &tags);
+     void AddValue(const MetricsInfoPtr &info, double value);
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp
+index 0bebb64e..6625f88d 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp
+@@ -55,2 +55,14 @@ MetricsSystem::~MetricsSystem() {
+ void MetricsSystem::Init(MetricsConfig *config) {
++    output_override_tags_.clear();
++    const auto &globalTags = config->global_tags()->GetTagsMap();
++    for (const auto &key : {"hippo_slave_ip", "host_ip", "container_ip"}) {
++        auto iter = globalTags.find(key);
++        if (iter != globalTags.end()) {
++            output_override_tags_[iter->first] = iter->second;
++        }
++    }
++    auto hostIter = config->CommonTags().find("host");
++    if (hostIter != config->CommonTags().end()) {
++        output_override_tags_[hostIter->first] = hostIter->second;
++    }
+     if (!initSink(config)) {
+@@ -116,2 +128,5 @@ void MetricsSystem::Stop() {
+ void MetricsSystem::PublishMetrics(MetricsRecords &records) {
++    for (auto record : records.getRecords()) {
++        record->OverrideTags(output_override_tags_);
++    }
+     for (auto e : sinks_) {
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h
+index 6ac5d7b8..840186ef 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h
+@@ -79,3 +79,4 @@ private:
+     std::queue<std::pair<int64_t, MetricsRecords>> publish_queue_;
+-
++    std::map<std::string, std::string> output_override_tags_;
++
+ private:

--- a/patches/havenask/havenask.patch
+++ b/patches/havenask/havenask.patch
@@ -109,3 +109,10 @@ index 6ac5d7b8..840186ef 100644
 +    std::map<std::string, std::string> output_override_tags_;
 +
  private:
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp
+@@ -76,2 +76,3 @@ MetricsConfig &MetricsConfig::operator=(const MetricsConfig &config) {
+         use_common_tag_ = config.use_common_tag();
++        common_tags_ = config.CommonTags();
+     }

--- a/rtp_llm/aios/kmonitor/python_client/kmonitor/report_worker.py
+++ b/rtp_llm/aios/kmonitor/python_client/kmonitor/report_worker.py
@@ -14,7 +14,6 @@ from rtp_llm.aios.kmonitor.python_client.kmonitor.metrics.metric_base import (
 )
 from rtp_llm.aios.kmonitor.python_client.kmonitor.utils.hippo_helper import HippoHelper
 
-_ReportWorker__REPORT_HOST = os.getenv("HIPPO_SLAVE_IP", "localhost")
 _ReportWorker__REPORT_PORT = 4141
 _ReportWorker__FLUME_CLIENT_TIMEOUT_MS = 1000
 
@@ -24,11 +23,28 @@ _ReportWorker__REPORT_KMONITOR_MULTI_SEP = "@"
 _ReportWorker__REPORT_KMONITOR_KEYVALUE_SEP = "^"
 
 
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _defer_transport_for_scr() -> bool:
+    enabled = any(
+        _env_enabled(name)
+        for name in ("RTPLLM_ENABLE_SCR", "RTP_LLM_ENABLE_SCR", "SCR_ENABLE")
+    )
+    return enabled and os.environ.get("SCR_PHASE", "").strip().lower() in {
+        "checkpoint",
+        "restore",
+    }
+
+
 class ReportWorker(object):
     def __init__(self, *args):
         super(ReportWorker, self).__init__(*args)
-        self.init_tags = HippoHelper.get_hippo_tags()
-        self.init_tags.update(self.parse_kmon_tags(os.environ.get("kmonitorTags", "")))
+        self._runtime_tags = HippoHelper.get_hippo_tags()
+        self._configured_tags = self.parse_kmon_tags(os.environ.get("kmonitorTags", ""))
+        self.init_tags = self._runtime_tags.copy()
+        self.init_tags.update(self._configured_tags)
         logging.info(
             f"kmonitor report default tags: {json.dumps(self.init_tags, indent=4)}"
         )
@@ -36,17 +52,14 @@ class ReportWorker(object):
         self.metric_lock: Lock = Lock()
         self.started = False
         self._report_thread: Thread | None = None
+        self._transport_deferred = False
         if HippoHelper.is_hippo_env():
-            self.flume = FlumeClient(
-                _ReportWorker__REPORT_HOST,
-                _ReportWorker__REPORT_PORT,
-                timeout=_ReportWorker__FLUME_CLIENT_TIMEOUT_MS,
-            )
-            self.start()
-            logging.info(
-                f"hippo role [{HippoHelper.role}] at host [{HippoHelper.host_ip}-{HippoHelper.container_ip}] "
-                "started reporting kmonitor."
-            )
+            self.flume = None
+            self._transport_deferred = _defer_transport_for_scr()
+            if self._transport_deferred:
+                logging.info("defer kmonitor transport until SCR steady-point returns")
+            else:
+                self._activate_hippo_transport(refresh_identity=False)
         else:
             self.flume = None
             self.start()
@@ -76,8 +89,12 @@ class ReportWorker(object):
         self, metric_name: str, timestamp: int, data_point: MetricDataPoint
     ) -> ThriftFlumeEvent:
         value_str = str(data_point.value)
+        report_tags = data_point.tags.copy()
+        # Runtime identity is authoritative after restore. Metric instances can
+        # predate the restore and therefore still contain seed identity tags.
+        report_tags.update(self._runtime_tags)
         tag_str: str = " ".join(
-            ["=".join([k, v]) for (k, v) in list(data_point.tags.items())]
+            ["=".join([k, v]) for (k, v) in list(report_tags.items())]
         )
         report_message: bytes = " ".join(
             [metric_name, str(timestamp), value_str, tag_str]
@@ -115,6 +132,9 @@ class ReportWorker(object):
         logging.warn("kmonitor report process exited.")
 
     def start(self) -> None:
+        if self._report_thread is not None and self._report_thread.is_alive():
+            self.started = True
+            return
         self.started = True
         report_thread = Thread(target=self.report_cycle)
         report_thread.daemon = True
@@ -123,6 +143,31 @@ class ReportWorker(object):
 
     def stop(self) -> None:
         self.started = False
+
+    def _activate_hippo_transport(self, *, refresh_identity: bool = True) -> None:
+        if refresh_identity:
+            self._runtime_tags = HippoHelper.refresh_runtime_identity()
+            # KMonitor instances retain this dict by reference. Update it in
+            # place so metrics registered after restore also use fresh tags.
+            self.init_tags.clear()
+            self.init_tags.update(self._runtime_tags)
+            self.init_tags.update(self._configured_tags)
+        report_host = os.environ.get("HIPPO_SLAVE_IP", "localhost")
+        if self.flume is not None:
+            self.flume.close()
+        self.flume = FlumeClient(
+            report_host,
+            _ReportWorker__REPORT_PORT,
+            timeout=_ReportWorker__FLUME_CLIENT_TIMEOUT_MS,
+        )
+        self._transport_deferred = False
+        self.start()
+        logging.info(
+            "hippo role [%s] at host [%s-%s] started reporting kmonitor",
+            HippoHelper.role,
+            HippoHelper.host_ip,
+            HippoHelper.container_ip,
+        )
 
     def pause_for_checkpoint(self) -> bool:
         was_started = self.started
@@ -142,7 +187,9 @@ class ReportWorker(object):
         return was_started
 
     def resume_after_checkpoint(self, was_started: bool) -> None:
-        if was_started:
+        if HippoHelper.is_hippo_env() and (was_started or self._transport_deferred):
+            self._activate_hippo_transport()
+        elif was_started:
             try:
                 if self.flume is not None:
                     self.flume.reconnect()

--- a/rtp_llm/aios/kmonitor/python_client/kmonitor/utils/hippo_helper.py
+++ b/rtp_llm/aios/kmonitor/python_client/kmonitor/utils/hippo_helper.py
@@ -13,7 +13,7 @@ class HippoHelper:
         # 获取主机 IP 地址
         container_ip = socket.gethostbyname(hostname)
         logging.info(f"get container_ip from socket:{container_ip}")
-    except Exception as e:
+    except Exception:
         container_ip = host_ip
         logging.info(
             f"get container_ip from socket failed, use host_ip:{host_ip} as container_ip"
@@ -22,6 +22,33 @@ class HippoHelper:
     app = os.environ.get("HIPPO_APP", "")
     group = os.environ.get("HIPPO_SERVICE_NAME", "")
     app_workdir = os.environ.get("HIPPO_APP_WORKDIR", "")
+
+    @staticmethod
+    def refresh_runtime_identity() -> Dict[str, str]:
+        """Refresh Hippo identity after SCR restores into a new Pod."""
+
+        HippoHelper.host_ip = os.environ.get("HIPPO_SLAVE_IP", "")
+        try:
+            hostname = socket.gethostname()
+            HippoHelper.container_ip = socket.gethostbyname(hostname)
+            logging.info(
+                "refreshed container_ip from socket:%s", HippoHelper.container_ip
+            )
+        except Exception:
+            HippoHelper.container_ip = os.environ.get(
+                "RequestedIP", HippoHelper.host_ip
+            )
+            logging.info(
+                "refresh container_ip from socket failed, use runtime identity:%s",
+                HippoHelper.container_ip,
+            )
+        HippoHelper.role = os.environ.get(
+            "HIPPO_ROLE_SHORT_NAME", os.environ.get("HIPPO_ROLE", "")
+        )
+        HippoHelper.app = os.environ.get("HIPPO_APP", "")
+        HippoHelper.group = os.environ.get("HIPPO_SERVICE_NAME", "")
+        HippoHelper.app_workdir = os.environ.get("HIPPO_APP_WORKDIR", "")
+        return HippoHelper.get_hippo_tags()
 
     @staticmethod
     def is_hippo_env() -> bool:

--- a/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
+++ b/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
@@ -1,7 +1,6 @@
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
 #include "autil/EnvUtil.h"
 #include "rtp_llm/cpp/utils/Logger.h"
-#include "kmonitor/client/KMonitor.h"
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
@@ -1167,18 +1166,6 @@ void fillKmonitorConfig(kmonitor::MetricsConfig& metricsConfig, const KmonParam&
     setHippoTags(metricsConfig);
 }
 
-void refreshRegisteredKmonitorTags(const kmonitor::MetricsConfig& config) {
-    auto tags = config.global_tags()->GetTagsMap();
-    for (const auto& pair : config.CommonTags()) {
-        tags[pair.first] = pair.second;
-    }
-    for (const auto& monitorPair : *kmonitor::KMonitorFactory::GetKMonitorMap()) {
-        for (const auto& tagPair : tags) {
-            monitorPair.second->AddTag(tagPair.first, tagPair.second);
-        }
-    }
-}
-
 }  // namespace
 
 bool initKmonitorFactory() {
@@ -1279,7 +1266,6 @@ bool resumeKmonitorAfterScr() {
     auto* system = worker->getMetricsSystem();
     if (kmonitorTransportDeferred) {
         worker->addCommonTags();
-        refreshRegisteredKmonitorTags(*factoryConfig);
         kmonitor::KMonitorFactory::Start();
         if (!system->Started()) {
             return false;
@@ -1290,7 +1276,6 @@ bool resumeKmonitorAfterScr() {
     }
     system->Stop();
     worker->addCommonTags();
-    refreshRegisteredKmonitorTags(*factoryConfig);
     system->Init(factoryConfig);
     if (!system->Started()) {
         return false;

--- a/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
+++ b/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
@@ -1,6 +1,7 @@
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
 #include "autil/EnvUtil.h"
 #include "rtp_llm/cpp/utils/Logger.h"
+#include "kmonitor/client/KMonitor.h"
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
@@ -1136,6 +1137,50 @@ void RtpLLMDiskCacheMetrics::report(const kmonitor::MetricsTags*           tags,
 #undef REPORT_QPS
 #undef REPORT_GAUGE
 
+namespace {
+
+bool kmonitorTransportDeferred = false;
+
+bool deferKmonitorTransportForScr() {
+    const auto phase = autil::EnvUtil::getEnv("SCR_PHASE", "");
+    const bool enabled = autil::EnvUtil::getEnv("RTPLLM_ENABLE_SCR", false)
+                         || autil::EnvUtil::getEnv("RTP_LLM_ENABLE_SCR", false)
+                         || autil::EnvUtil::getEnv("SCR_ENABLE", false);
+    return enabled && (phase == "checkpoint" || phase == "restore");
+}
+
+void fillKmonitorConfig(kmonitor::MetricsConfig& metricsConfig, const KmonParam& param, bool manuallyMode) {
+    metricsConfig.set_tenant_name(param.kmonitorTenant);
+    metricsConfig.set_service_name(param.kmonitorServiceName);
+    std::string sink_address = param.kmonitorSinkAddress;
+    if (!param.kmonitorPort.empty()) {
+        sink_address += ":" + param.kmonitorPort;
+    }
+    metricsConfig.set_sink_address(sink_address.c_str());
+    metricsConfig.set_enable_log_file_sink(param.kmonitorEnableLogFileSink);
+    metricsConfig.set_manually_mode(manuallyMode);
+    metricsConfig.set_inited(true);
+    metricsConfig.AddGlobalTag("hippo_slave_ip", param.hippoSlaveIp);
+    for (const auto& pair : param.kmonitorTags) {
+        metricsConfig.AddGlobalTag(pair.first, pair.second);
+    }
+    setHippoTags(metricsConfig);
+}
+
+void refreshRegisteredKmonitorTags(const kmonitor::MetricsConfig& config) {
+    auto tags = config.global_tags()->GetTagsMap();
+    for (const auto& pair : config.CommonTags()) {
+        tags[pair.first] = pair.second;
+    }
+    for (const auto& monitorPair : *kmonitor::KMonitorFactory::GetKMonitorMap()) {
+        for (const auto& tagPair : tags) {
+            monitorPair.second->AddTag(tagPair.first, tagPair.second);
+        }
+    }
+}
+
+}  // namespace
+
 bool initKmonitorFactory() {
     KmonParam param;
     param.init();
@@ -1155,41 +1200,37 @@ bool initKmonitorFactory() {
     }
 
     kmonitor::MetricsConfig metricsConfig;
-    metricsConfig.set_tenant_name(param.kmonitorTenant);
-    metricsConfig.set_service_name(param.kmonitorServiceName);
-    std::string sink_address = param.kmonitorSinkAddress;
-    if (!param.kmonitorPort.empty()) {
-        sink_address += ":" + param.kmonitorPort;
-    }
-    metricsConfig.set_sink_address(sink_address.c_str());
-    metricsConfig.set_enable_log_file_sink(param.kmonitorEnableLogFileSink);
-    // metricsConfig.set_enable_prometheus_sink(param.kmonitorEnablePrometheusSink);
-    metricsConfig.set_manually_mode(param.kmonitorManuallyMode);
-    metricsConfig.set_inited(true);
-    metricsConfig.AddGlobalTag("hippo_slave_ip", param.hippoSlaveIp);
-    for (auto& pair : param.kmonitorTags) {
-        metricsConfig.AddGlobalTag(pair.first, pair.second);
-    }
-    setHippoTags(metricsConfig);
+    const bool deferTransport = deferKmonitorTransportForScr();
+    fillKmonitorConfig(metricsConfig, param, deferTransport || param.kmonitorManuallyMode);
     if (!kmonitor::KMonitorFactory::Init(metricsConfig)) {
         RTP_LLM_LOG_ERROR("init kmonitor factory failed with");
         return false;
     }
+    kmonitorTransportDeferred = deferTransport;
 
     // registerBuildInMetrics to refresh sg_buildin_kmonitor for KMonitorWorker::Start
     kmonitor::KMonitorFactory::registerBuildInMetrics(nullptr, param.kmonitorMetricsPrefix);
     RTP_LLM_LOG_INFO("KMonitorFactory::registerBuildInMetrics() finished");
 
+    if (deferTransport) {
+        RTP_LLM_LOG_INFO("KMonitor transport deferred until SCR steady-point returns");
+        return true;
+    }
     kmonitor::KMonitorFactory::Start();
     RTP_LLM_LOG_INFO("KMonitorFactory::Start() finished");
     return true;
 }
 
 void stopKmonitorFactory() {
+    kmonitorTransportDeferred = false;
     kmonitor::KMonitorFactory::Shutdown();
 }
 
 bool pauseKmonitorForScr() {
+    if (kmonitorTransportDeferred) {
+        RTP_LLM_LOG_INFO("SCR native Kmonitor transport is already deferred");
+        return true;
+    }
     if (!kmonitor::KMonitorFactory::IsStarted()) {
         return false;
     }
@@ -1222,24 +1263,39 @@ bool pauseKmonitorForScr() {
 }
 
 bool resumeKmonitorAfterScr() {
-    if (!kmonitor::KMonitorFactory::IsStarted()) {
+    if (!kmonitorTransportDeferred && !kmonitor::KMonitorFactory::IsStarted()) {
         return false;
     }
     auto* worker = kmonitor::KMonitorFactory::GetWorker();
-    if (worker == nullptr || worker->getMetricsSystem() == nullptr) {
+    auto* factoryConfig = kmonitor::KMonitorFactory::GetConfig();
+    if (worker == nullptr || worker->getMetricsSystem() == nullptr || factoryConfig == nullptr) {
         return false;
     }
-    auto* config = kmonitor::KMonitorFactory::GetConfig();
-    if (config == nullptr) {
-        return false;
-    }
+    KmonParam param;
+    param.init();
+    kmonitor::MetricsConfig resumedConfig;
+    fillKmonitorConfig(resumedConfig, param, param.kmonitorManuallyMode);
+    *factoryConfig = resumedConfig;
     auto* system = worker->getMetricsSystem();
+    if (kmonitorTransportDeferred) {
+        worker->addCommonTags();
+        refreshRegisteredKmonitorTags(*factoryConfig);
+        kmonitor::KMonitorFactory::Start();
+        if (!system->Started()) {
+            return false;
+        }
+        kmonitorTransportDeferred = false;
+        RTP_LLM_LOG_INFO("SCR native Kmonitor activated with refreshed runtime identity");
+        return true;
+    }
     system->Stop();
-    system->Init(config);
+    worker->addCommonTags();
+    refreshRegisteredKmonitorTags(*factoryConfig);
+    system->Init(factoryConfig);
     if (!system->Started()) {
         return false;
     }
-    RTP_LLM_LOG_INFO("SCR native Kmonitor resumed");
+    RTP_LLM_LOG_INFO("SCR native Kmonitor activated with refreshed runtime identity");
     return true;
 }
 

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -86,6 +86,22 @@ TEST_F(ScrKmonitorLifecycleTest, RetainsRegisteredMetricsAndReleasesOldSink) {
     }
 }
 
+TEST_F(ScrKmonitorLifecycleTest, DeferredDefaultModeStartsAutomaticReporter) {
+    autil::EnvGuard scrEnabled("RTPLLM_ENABLE_SCR", "1");
+    autil::EnvGuard scrPhase("SCR_PHASE", "checkpoint");
+    autil::EnvGuard manualMode("kmonitorManuallyMode", "false");
+
+    ASSERT_TRUE(initKmonitorFactory());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_TRUE(pauseKmonitorForScr());
+    resumeKmonitorAfterScr();
+
+    EXPECT_TRUE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
+}
+
 TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     autil::EnvGuard scrEnabled("RTPLLM_ENABLE_SCR", "1");
     autil::EnvGuard scrPhase("SCR_PHASE", "checkpoint");
@@ -93,6 +109,9 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     autil::EnvGuard oldRequestedIp("RequestedIP", "10.1.0.1");
     autil::EnvGuard hippoRole("HIPPO_ROLE", "rtp_role");
     autil::EnvGuard serviceName("kmonitorServiceName", "scr_service");
+    // Keep the sampling threads disabled so ManuallySnapshot observes exactly
+    // the record produced below. Automatic-mode activation is covered above.
+    autil::EnvGuard manualMode("kmonitorManuallyMode", "true");
 
     ASSERT_TRUE(initKmonitorFactory());
     EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
@@ -126,7 +145,7 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     EXPECT_TRUE(kmonitor::KMonitorFactory::IsStarted());
     EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
     EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
-    EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
     EXPECT_EQ(kmonitor::KMonitorFactory::GetConfig()->sink_address(), "10.0.0.2:4141");
     EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_deferred"));
     auto* system = kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem();

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -4,12 +4,49 @@
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
+#include "kmonitor/client/core/MetricsCollector.h"
+#include "kmonitor/client/core/MetricsRecord.h"
 #include "kmonitor/client/core/MetricsSystem.h"
 #include "kmonitor/client/core/MetricsTags.h"
+#include "kmonitor/client/sink/Sink.h"
 #include "gtest/gtest.h"
+#include <map>
 #include <memory>
+#include <set>
+#include <string>
 
 namespace rtp_llm {
+
+class RecordingSink: public kmonitor::Sink {
+public:
+    explicit RecordingSink(const std::string& metricName): Sink("FlumeSink"), metricName_(metricName) {}
+
+    bool Init() override {
+        return true;
+    }
+
+    void PutMetrics(kmonitor::MetricsRecord* record) override {
+        if (record->Name() == metricName_ && !record->Values().empty()) {
+            sawMetric_ = true;
+            tags_      = record->Tags()->GetTagsMap();
+        }
+    }
+
+    void Flush() override {}
+
+    bool sawMetric() const {
+        return sawMetric_;
+    }
+
+    const std::map<std::string, std::string>& tags() const {
+        return tags_;
+    }
+
+private:
+    std::string                        metricName_;
+    bool                               sawMetric_ = false;
+    std::map<std::string, std::string> tags_;
+};
 
 class ScrKmonitorLifecycleTest: public ::testing::Test {
 protected:
@@ -55,6 +92,7 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     autil::EnvGuard oldHost("HIPPO_SLAVE_IP", "10.0.0.1");
     autil::EnvGuard oldRequestedIp("RequestedIP", "10.1.0.1");
     autil::EnvGuard hippoRole("HIPPO_ROLE", "rtp_role");
+    autil::EnvGuard serviceName("kmonitorServiceName", "scr_service");
 
     ASSERT_TRUE(initKmonitorFactory());
     EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
@@ -64,6 +102,21 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     auto* monitor = kmonitor::KMonitorFactory::GetKMonitor("scr_deferred");
     ASSERT_NE(monitor, nullptr);
     monitor->Register("retained", kmonitor::GAUGE);
+    auto* retainedMetric = monitor->DeclareMetric("retained", nullptr);
+    ASSERT_NE(retainedMetric, nullptr);
+    monitor->Report(retainedMetric, 1.0);
+    kmonitor::MetricsCollector seedCollector;
+    monitor->GetMetrics(&seedCollector, {kmonitor::NORMAL}, 1);
+    bool sawSeedMetric = false;
+    for (auto* record : seedCollector.GetRecords().getRecords()) {
+        if (record->Name() == "scr_service.retained" && !record->Values().empty()) {
+            sawSeedMetric = true;
+            EXPECT_EQ(record->Tags()->FindTag("hippo_slave_ip"), "10.0.0.1");
+            EXPECT_EQ(record->Tags()->FindTag("host_ip"), "10.0.0.1");
+            EXPECT_EQ(record->Tags()->FindTag("container_ip"), "10.1.0.1");
+        }
+    }
+    EXPECT_TRUE(sawSeedMetric);
     EXPECT_TRUE(pauseKmonitorForScr());
 
     autil::EnvGuard newHost("HIPPO_SLAVE_IP", "10.0.0.2");
@@ -76,10 +129,22 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
     EXPECT_EQ(kmonitor::KMonitorFactory::GetConfig()->sink_address(), "10.0.0.2:4141");
     EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_deferred"));
-    const auto tags = monitor->GetMetricsTags({})->GetTagsMap();
-    EXPECT_EQ(tags.at("hippo_slave_ip"), "10.0.0.2");
-    EXPECT_EQ(tags.at("host_ip"), "10.0.0.2");
-    EXPECT_EQ(tags.at("container_ip"), "10.1.0.2");
+    auto* system = kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem();
+    system->Stop();
+    auto recordingSink = std::make_shared<RecordingSink>("scr_service.retained");
+    ASSERT_TRUE(recordingSink->Init());
+    ASSERT_TRUE(system->AddSink(recordingSink));
+    monitor->Report(retainedMetric, 2.0);
+    system->ManuallySnapshot();
+    ASSERT_TRUE(recordingSink->sawMetric());
+    EXPECT_EQ(recordingSink->tags().at("hippo_slave_ip"), "10.0.0.2");
+    EXPECT_EQ(recordingSink->tags().at("host_ip"), "10.0.0.2");
+    EXPECT_EQ(recordingSink->tags().at("container_ip"), "10.1.0.2");
+    for (const auto& tag : recordingSink->tags()) {
+        EXPECT_NE(tag.second, "10.0.0.1");
+        EXPECT_NE(tag.second, "10.1.0.1");
+    }
+    EXPECT_TRUE(monitor->UndeclareMetric(retainedMetric));
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -1,9 +1,11 @@
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
+#include "autil/EnvUtil.h"
 #include "kmonitor/client/KMonitor.h"
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
 #include "kmonitor/client/core/MetricsSystem.h"
+#include "kmonitor/client/core/MetricsTags.h"
 #include "gtest/gtest.h"
 #include <memory>
 
@@ -45,6 +47,39 @@ TEST_F(ScrKmonitorLifecycleTest, RetainsRegisteredMetricsAndReleasesOldSink) {
         EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
         EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_lifecycle"));
     }
+}
+
+TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
+    autil::EnvGuard scrEnabled("RTPLLM_ENABLE_SCR", "1");
+    autil::EnvGuard scrPhase("SCR_PHASE", "checkpoint");
+    autil::EnvGuard oldHost("HIPPO_SLAVE_IP", "10.0.0.1");
+    autil::EnvGuard oldRequestedIp("RequestedIP", "10.1.0.1");
+    autil::EnvGuard hippoRole("HIPPO_ROLE", "rtp_role");
+
+    ASSERT_TRUE(initKmonitorFactory());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
+    auto* monitor = kmonitor::KMonitorFactory::GetKMonitor("scr_deferred");
+    ASSERT_NE(monitor, nullptr);
+    monitor->Register("retained", kmonitor::GAUGE);
+    EXPECT_TRUE(pauseKmonitorForScr());
+
+    autil::EnvGuard newHost("HIPPO_SLAVE_IP", "10.0.0.2");
+    autil::EnvGuard newRequestedIp("RequestedIP", "10.1.0.2");
+    resumeKmonitorAfterScr();
+
+    EXPECT_TRUE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_EQ(kmonitor::KMonitorFactory::GetConfig()->sink_address(), "10.0.0.2:4141");
+    EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_deferred"));
+    const auto tags = monitor->GetMetricsTags({})->GetTagsMap();
+    EXPECT_EQ(tags.at("hippo_slave_ip"), "10.0.0.2");
+    EXPECT_EQ(tags.at("host_ip"), "10.0.0.2");
+    EXPECT_EQ(tags.at("container_ip"), "10.1.0.2");
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -60,6 +60,19 @@ TEST_F(ScrKmonitorLifecycleTest, InactiveFactoryStaysInactive) {
     EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
 }
 
+TEST_F(ScrKmonitorLifecycleTest, RebuiltConfigurationDiscardsSeedCommonTags) {
+    kmonitor::MetricsConfig seedConfig;
+    seedConfig.AddCommonTag("host", "10.1.0.1");
+    seedConfig.AddCommonTag("hippo_app", "seed_app");
+    kmonitor::MetricsConfig resumedConfig;
+    seedConfig = resumedConfig;
+    // addCommonTags uses emplace: a seed entry must be removed before a fresh
+    // runtime identity can be inserted into the rebuilt factory config.
+    seedConfig.AddCommonTag("host", "10.1.0.2");
+    EXPECT_EQ(seedConfig.CommonTags().at("host"), "10.1.0.2");
+    EXPECT_EQ(seedConfig.CommonTags().count("hippo_app"), 0);
+}
+
 TEST_F(ScrKmonitorLifecycleTest, RetainsRegisteredMetricsAndReleasesOldSink) {
     kmonitor::MetricsConfig config;
     config.set_inited(true);

--- a/rtp_llm/ops/fused_rope_kvcache_op.py
+++ b/rtp_llm/ops/fused_rope_kvcache_op.py
@@ -1,3 +1,4 @@
+import inspect
 from dataclasses import dataclass
 from functools import cache
 from typing import Optional
@@ -16,6 +17,17 @@ def _get_fused_rope_kvcache():
     from rtp_kernel import fused_rope_kvcache
 
     return fused_rope_kvcache
+
+
+@cache
+def _uses_position_ids_api():
+    return (
+        "cu_seqlens"
+        in inspect.signature(
+            _get_fused_rope_kvcache().decode_fused_rope_kvcache
+        ).parameters
+    )
+
 
 @dataclass
 class FusedRopeAttnParams:
@@ -113,7 +125,11 @@ class FusedRopeKVCachePrefillOpBase:
                 rope_cache.data if check_rope_cache(rope_config, rope_cache) else None
             ),
             padding_offset=params.padding_offset,
-            cp_position_ids=params.cp_position_ids,
+            **{
+                (
+                    "position_ids" if _uses_position_ids_api() else "cp_position_ids"
+                ): params.cp_position_ids
+            },
             use_logn_attn=self.attn_configs.use_logn_attn,
             rope_style=rope_config.style,
             rope_dim=rope_config.dim,
@@ -185,7 +201,11 @@ class FusedRopeKVCacheDecodeOp:
         assert params.sequence_lengths.is_cuda, "sequence_lengths must be a CUDA tensor"
         return _get_fused_rope_kvcache().decode_fused_rope_kvcache(
             qkv,
-            params.sequence_lengths,
+            *(
+                (None, params.sequence_lengths)
+                if _uses_position_ids_api()
+                else (params.sequence_lengths,)
+            ),
             params.sequence_lengths.size(0),
             self.attn_configs.head_num,
             self.attn_configs.kv_head_num,

--- a/rtp_llm/server/backend_manager.py
+++ b/rtp_llm/server/backend_manager.py
@@ -151,7 +151,7 @@ class BackendManager(object):
             distributed_server=self._distributed_server,
         )
         phase = os.environ.get("SCR_PHASE", "").strip().lower()
-        role_type = self.py_env_configs.pd_sep_config.role_type
+        role_type = self.py_env_configs.role_config.role_type
         pd_role = str(getattr(role_type, "name", role_type)).lower() in {
             "prefill",
             "decode",

--- a/rtp_llm/start_server.py
+++ b/rtp_llm/start_server.py
@@ -27,7 +27,7 @@ from rtp_llm.utils.process_manager import (
 )
 from rtp_llm.utils.scr_template_utils import (
     ScrParticipantManifest,
-    arrive_scr_checkpoint_barrier,
+    arrive_scr_template_barrier as arrive_scr_checkpoint_barrier,
     build_scr_participant_manifest,
     configure_scr_environment,
     is_scr_template_phase_active,

--- a/rtp_llm/test/start_backend_scr_integration_test.py
+++ b/rtp_llm/test/start_backend_scr_integration_test.py
@@ -16,6 +16,38 @@ from rtp_llm.ops import RoleType, VitSeparation
 
 
 class BackendScrIntegrationTest(unittest.TestCase):
+    def test_parent_arrival_runs_template_lifecycle_hooks(self):
+        from rtp_llm.utils import scr_template_utils as scr
+        from rtp_llm.utils.scr_template_lifecycle import CallbackHook, TemplateLifecycle
+
+        order = []
+        lifecycle = TemplateLifecycle()
+        lifecycle.register(
+            "parent-reporter",
+            CallbackHook(
+                prepare=lambda generation: order.append("prepare"),
+                fixup=lambda generation: order.append("fixup"),
+                release=lambda generation: order.append("release"),
+            ),
+        )
+        manifest = SimpleNamespace(
+            worker_id=lambda role, instance: 0,
+            worker_num=1,
+            generation="parent-generation",
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"RTPLLM_ENABLE_SCR": "1", "SCR_PHASE": "checkpoint"},
+        ), mock.patch.object(
+            scr, "get_template_lifecycle", return_value=lifecycle
+        ), mock.patch.object(
+            scr, "arrive_scr_checkpoint_barrier",
+            side_effect=lambda **kwargs: order.append("barrier") or 0,
+        ):
+            self.assertEqual(launcher._start_parent_scr_arrival(manifest), 0)
+        self.assertEqual(order, ["prepare", "barrier", "fixup", "release"])
+        self.assertFalse(lifecycle.active)
+
     def _config(self, local_rank=1, world_rank=5):
         return SimpleNamespace(
             parallelism_config=SimpleNamespace(

--- a/rtp_llm/utils/scr_template_utils.py
+++ b/rtp_llm/utils/scr_template_utils.py
@@ -20,6 +20,7 @@ import importlib
 import inspect
 import logging
 import os
+import socket
 import sys
 import threading
 import time
@@ -73,6 +74,16 @@ class _NativeKmonitorTemplateHook:
             return
         extension = self._extension()
         resume = getattr(extension, "resume_kmonitor_after_scr", None) if extension else None
+        # CRIU preserves seed environment values. Resolve the current namespace
+        # identity before native Kmonitor rebuilds its configuration.
+        if os.environ.get("HIPPO_ROLE"):
+            try:
+                os.environ["RequestedIP"] = socket.gethostbyname(socket.gethostname())
+            except OSError:
+                LOGGER.warning(
+                    "Cannot resolve current container IP for native Kmonitor",
+                    exc_info=True,
+                )
         if resume is None or not resume():
             raise RuntimeError("native Kmonitor did not resume after SCR")
         self._paused = False

--- a/rtp_llm/utils/scr_template_utils.py
+++ b/rtp_llm/utils/scr_template_utils.py
@@ -159,7 +159,7 @@ class _BackendVisitorTemplateHook:
             self.configs.distribute_config,
             self.configs.parallelism_config,
         )
-        role = getattr(self.configs.pd_sep_config, "role_type", "")
+        role = self.configs.role_config.role_type
         role_name = str(getattr(role, "name", role)).lower()
         world_info = resolve_world_info(
             current,

--- a/rtp_llm/utils/test/scr_endpoint_config_test.py
+++ b/rtp_llm/utils/test/scr_endpoint_config_test.py
@@ -1,0 +1,86 @@
+"""Exercise endpoint restore hooks with the production configuration schema."""
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from rtp_llm.config.py_config_modules import PyEnvConfigs
+from rtp_llm.server.backend_manager import BackendManager
+from rtp_llm.utils.scr_template_utils import _BackendVisitorTemplateHook
+
+
+class ScrEndpointConfigTest(unittest.TestCase):
+    def test_visitor_uses_real_config_and_preserves_endpoint_requirements(self):
+        for role, nodes, phase, required in [
+            ("PREFILL", 1, "restore", True),
+            ("DECODE", 1, "restore", True),
+            ("PDFUSION", 2, "restore", True),
+            ("PDFUSION", 1, "restore", False),
+            ("PREFILL", 1, "checkpoint", False),
+        ]:
+            with self.subTest(role=role, nodes=nodes, phase=phase):
+                configs = PyEnvConfigs()
+                configs.role_config.role_type = role
+                current = SimpleNamespace(num_nodes=nodes)
+                restored = object()
+                visitor = Mock()
+                hook = _BackendVisitorTemplateHook(visitor, configs)
+                with patch.dict(os.environ, {"SCR_PHASE": phase}), patch(
+                    "rtp_llm.distribute.distributed_server.get_world_info", return_value=current
+                ), patch(
+                    "rtp_llm.distribute.distributed_server.get_dp_addrs_from_world_info",
+                    return_value=["192.0.2.20:9001"],
+                ), patch(
+                    "rtp_llm.utils.scr_endpoint_provider.resolve_world_info", return_value=restored
+                ) as resolve:
+                    hook.restore_fixup("generation-2")
+                resolve.assert_called_once_with(
+                    current, generation="generation-2", require_manifest=required,
+                    require_transport=required,
+                )
+                visitor.update_addresses.assert_called_once_with(["192.0.2.20:9001"])
+
+    def test_backend_uses_real_config_and_refreshes_engine_endpoints(self):
+        for role, nodes, phase, required in [
+            ("PREFILL", 1, "restore", True),
+            ("DECODE", 1, "restore", True),
+            ("PDFUSION", 2, "restore", True),
+            ("PDFUSION", 1, "restore", False),
+            ("PREFILL", 1, "checkpoint", False),
+        ]:
+            with self.subTest(role=role, nodes=nodes, phase=phase):
+                configs = PyEnvConfigs()
+                configs.role_config.role_type = role
+                backend = BackendManager.__new__(BackendManager)
+                backend.py_env_configs = configs
+                backend._distributed_server = Mock()
+                backend._engine_config = SimpleNamespace(
+                    runtime_config=object(), parallelism_config=configs.parallelism_config
+                )
+                backend._world_info = object()
+                backend.engine = Mock()
+                current = SimpleNamespace(num_nodes=nodes)
+                restored = object()
+                with patch.dict(os.environ, {"SCR_PHASE": phase}), patch(
+                    "rtp_llm.server.backend_manager.get_world_info", return_value=current
+                ), patch(
+                    "rtp_llm.server.backend_manager.resolve_world_info", return_value=restored
+                ) as resolve, patch(
+                    "rtp_llm.server.backend_manager.update_worker_addrs"
+                ) as update:
+                    backend.restore_fixup("generation-2")
+                resolve.assert_called_once_with(
+                    current, generation="generation-2", require_manifest=required,
+                    require_transport=required,
+                )
+                update.assert_called_once_with(
+                    backend._engine_config.runtime_config, configs.parallelism_config, restored
+                )
+                self.assertIs(backend._world_info, restored)
+                backend.engine.update_runtime_endpoints.assert_called_once_with(
+                    backend._engine_config.runtime_config, restored
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
+++ b/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
@@ -17,6 +17,43 @@ reporters = importlib.import_module(
 
 
 class ScrKmonitorLifecycleTest(unittest.TestCase):
+    def test_native_resume_sees_resolved_ip_with_stale_seed_environment(self):
+        observed = []
+        native = SimpleNamespace(
+            resume_kmonitor_after_scr=lambda: observed.append(
+                os.getenv("RequestedIP")
+            ) or True
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"HIPPO_ROLE": "rtp_role", "RequestedIP": "10.1.0.1"},
+        ), mock.patch.object(
+            socket, "gethostname", return_value="restored-pod"
+        ), mock.patch.object(
+            socket, "gethostbyname", return_value="10.1.0.2"
+        ) as resolve:
+            hook = scr._NativeKmonitorTemplateHook()
+            hook._paused = True
+            with mock.patch.dict(sys.modules, {"libth_transformer": native}):
+                hook.release_template("restored-generation")
+            resolve.assert_called_once_with("restored-pod")
+            self.assertEqual(observed, ["10.1.0.2"])
+
+    def test_native_resume_still_runs_if_hostname_resolution_fails(self):
+        native = SimpleNamespace(resume_kmonitor_after_scr=mock.Mock(return_value=True))
+        with mock.patch.dict(
+            os.environ,
+            {"HIPPO_ROLE": "rtp_role", "RequestedIP": "10.1.0.1"},
+        ), mock.patch.object(
+            socket, "gethostbyname", side_effect=OSError("resolution failed")
+        ):
+            hook = scr._NativeKmonitorTemplateHook()
+            hook._paused = True
+            with mock.patch.dict(sys.modules, {"libth_transformer": native}):
+                hook.release_template("restored-generation")
+            self.assertEqual(os.getenv("RequestedIP"), "10.1.0.1")
+        native.resume_kmonitor_after_scr.assert_called_once_with()
+
     def test_non_scr_hippo_transport_still_starts_eagerly(self):
         with mock.patch.object(
             reporters.HippoHelper, "is_hippo_env", return_value=True

--- a/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
+++ b/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
@@ -1,6 +1,7 @@
 """Exercise reporter sockets and both SCR lifecycle hooks without a GPU."""
 
 import importlib
+import os
 import socket
 import sys
 import unittest
@@ -16,6 +17,85 @@ reporters = importlib.import_module(
 
 
 class ScrKmonitorLifecycleTest(unittest.TestCase):
+    def test_non_scr_hippo_transport_still_starts_eagerly(self):
+        with mock.patch.object(
+            reporters.HippoHelper, "is_hippo_env", return_value=True
+        ), mock.patch.object(
+            reporters.HippoHelper,
+            "get_hippo_tags",
+            return_value={"host_ip": "10.0.0.1"},
+        ), mock.patch.object(
+            reporters.HippoHelper, "refresh_runtime_identity"
+        ) as refresh, mock.patch.object(
+            reporters.ReportWorker, "start"
+        ) as start, mock.patch.object(
+            reporters, "FlumeClient"
+        ) as flume_cls, mock.patch.dict(
+            os.environ,
+            {"HIPPO_SLAVE_IP": "10.0.0.1"},
+            clear=True,
+        ):
+            worker = reporters.ReportWorker()
+
+        self.assertFalse(worker._transport_deferred)
+        flume_cls.assert_called_once_with("10.0.0.1", 4141, timeout=1000)
+        start.assert_called_once_with()
+        refresh.assert_not_called()
+
+    def test_scr_defers_transport_and_activates_with_fresh_identity(self):
+        old_tags = {"host_ip": "10.0.0.1", "container_ip": "10.1.0.1"}
+        new_tags = {"host_ip": "10.0.0.2", "container_ip": "10.1.0.2"}
+        with mock.patch.object(
+            reporters.HippoHelper, "is_hippo_env", return_value=True
+        ), mock.patch.object(
+            reporters.HippoHelper, "get_hippo_tags", return_value=old_tags
+        ), mock.patch.object(
+            reporters.HippoHelper,
+            "refresh_runtime_identity",
+            return_value=new_tags,
+        ), mock.patch.object(
+            reporters, "FlumeClient"
+        ) as flume_cls, mock.patch.dict(
+            os.environ,
+            {
+                "RTPLLM_ENABLE_SCR": "1",
+                "SCR_PHASE": "checkpoint",
+                "HIPPO_SLAVE_IP": "10.0.0.2",
+            },
+            clear=False,
+        ):
+            worker = reporters.ReportWorker()
+            self.assertTrue(worker._transport_deferred)
+            self.assertFalse(worker.started)
+            flume_cls.assert_not_called()
+
+            tags_ref = worker.init_tags
+            with mock.patch.object(worker, "start") as start:
+                worker.resume_after_checkpoint(False)
+
+            flume_cls.assert_called_once_with("10.0.0.2", 4141, timeout=1000)
+            self.assertIs(worker.init_tags, tags_ref)
+            self.assertEqual(worker.init_tags["container_ip"], "10.1.0.2")
+            start.assert_called_once_with()
+            event = worker.render_event(
+                "scr.metric",
+                1,
+                reporters.MetricDataPoint(
+                    2,
+                    {
+                        "host_ip": "10.0.0.1",
+                        "container_ip": "10.1.0.1",
+                        "custom": "kept",
+                    },
+                ),
+            )
+            message = event.body.decode("utf-8")
+            self.assertIn("host_ip=10.0.0.2", message)
+            self.assertIn("container_ip=10.1.0.2", message)
+            self.assertIn("custom=kept", message)
+            self.assertNotIn("10.0.0.1", message)
+            self.assertNotIn("10.1.0.1", message)
+
     def test_live_socket_closes_and_reconnects_without_losing_metrics(self):
         with mock.patch.object(
             reporters.HippoHelper, "is_hippo_env", return_value=False


### PR DESCRIPTION
SCR template participants could establish metrics transport before the checkpoint barrier, and restored native metrics could retain the seed address in cached tags. This change defers Python/native transport until template release, refreshes runtime identity before native restart, and updates cached tags when publishing retained metric handles.

Rebased onto `feat/dsv4_on_dev_scr` at `888476cf150c924b249d62b52afcd41753430e6b`. Preserves upstream TemplateLifecycle, EndpointProvider, control-plane-owned checkpoint/restore, pre-service snapshot ordering, and the boolean native lifecycle ABI. Routes the main parent through the same template lifecycle as its children. Earlier local-communication fixes already present upstream are not replayed. Retains fused RoPE compatibility with both supported kernel wrapper signatures.

Actual restore testing also exposed two endpoint hooks reading an EngineConfig-only field from PyEnvConfigs. Both now use `role_config.role_type`. Added tests construct real PyEnvConfigs and cover both hooks across five role/topology/phase combinations, without changing endpoint manifest or transport requirements. The first rebased image reproduced the error after container restore and was rejected; the corrected full image was rebuilt and tested independently.

Validation for `7b466603e4dd332f5f53b115f9ed7b637591075b`:

- Complete source-built image with no runtime product-code overlays passed normal → pre-service seed → real checkpoint → new Pod/container restore.
- Normal and restored serving both passed 13 warmup request sizes and the same deterministic 31-token response; output hashes matched.
- Six seed participants reached the barrier with no worker-owned external established TCP connections; all five checkpoint and seven restore stages passed.
- ContainerCheckpoint naturally reached Completed; all five restored containers remained Ready with zero restarts for over 120 seconds.
- Actual Python and native monitoring traffic used the restored identity with no seed address remaining in tags. Natural log file descriptors and per-Pod NAS/CacheFS mounts were verified.
- 58 main image regression tests plus 22 CUDA arrival tests executed successfully, with no skips. CI executed 16 Python tests; its native test result was a cache hit, not a fresh execution. Python syntax and diff checks passed.

Acceptance scope: one reserved node, two GPUs, DeepSeek V4 Flash PREFILL TP2/EP2 with MTP, using the upstream pre-service snapshot lifecycle. Multi-node, Decode/PD, throughput and the older post-warmup snapshot mode are not qualified by this run.
