### PR TITLE
fix: fuse SM120 masked MoE FP8 quantization and scale packing

### DIFF
--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_hybrid_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_hybrid_executor.py
@@ -41,6 +41,12 @@ from rtp_llm.models_py.triton_kernels.common.activation import (
     silu_and_mul_masked_post_quant_packed_fwd,
     silu_mul_masked_fp8_post_quant_fwd,
 )
+from rtp_llm.models_py.triton_kernels.common.silu_mul_masked_packed_sm120 import (
+    create_packed_scale_tensor as create_sm120_packed_scale_tensor,
+)
+from rtp_llm.models_py.triton_kernels.common.silu_mul_masked_packed_sm120 import (
+    silu_and_mul_masked_post_quant_packed_fwd as silu_mul_masked_packed_sm120,
+)
 from rtp_llm.models_py.triton_kernels.moe.ep_kernels import (
     ep_gather,
     ep_scatter,
@@ -550,10 +556,26 @@ class DeepGemmHybridExecutor(FusedMoeExpertExecutor):
                 dtype=torch.float8_e4m3fn,
             )
 
-            # SM100 (compute capability 10.x) uses fused packed kernel for better performance
-            # when UE8M0 scale format is enabled
+            # Emit packed UE8M0 scales directly on supported Blackwell paths.
             sm_major = torch.cuda.get_device_capability()[0]
-            if (
+            if sm_major == 12 and is_deep_gemm_e8m0_used():
+                # SM120 emits complete packed scales, including partial packs
+                # (e.g. Qwen3 H=768) and all masked/TMA padding rows.
+                down_input_scale = create_sm120_packed_scale_tensor(
+                    expert_num=self.num_experts_per_partition,
+                    token_num_padded=alignment,
+                    hidden_dim=self.N,
+                    quant_group_size=self.DEEPGEMM_BLOCK_SHAPE[0],
+                    device=down_input.device,
+                )
+                silu_mul_masked_packed_sm120(
+                    upgate_output,
+                    down_input,
+                    down_input_scale,
+                    self.DEEPGEMM_BLOCK_SHAPE[0],
+                    num_recv_tokens_per_expert,
+                )
+            elif (
                 sm_major == 10
                 and is_deep_gemm_e8m0_used()
                 and self.N % (self.DEEPGEMM_BLOCK_SHAPE[0] * 2 * 4) == 0

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_masked_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_masked_executor.py
@@ -28,6 +28,12 @@ from rtp_llm.models_py.triton_kernels.common.activation import (
     silu_mul_masked_bf16_no_post_quant_fwd,
     silu_mul_masked_fp8_post_quant_fwd,
 )
+from rtp_llm.models_py.triton_kernels.common.silu_mul_masked_packed_sm120 import (
+    create_packed_scale_tensor as create_sm120_packed_scale_tensor,
+)
+from rtp_llm.models_py.triton_kernels.common.silu_mul_masked_packed_sm120 import (
+    silu_and_mul_masked_post_quant_packed_fwd as silu_mul_masked_packed_sm120,
+)
 from rtp_llm.models_py.utils.arch import get_num_device_sms, get_sm
 from rtp_llm.models_py.utils.memory import dispose_tensor
 from rtp_llm.utils.model_weight import W
@@ -214,10 +220,26 @@ class DeepGemmMaskedExecutor(FusedMoeExpertExecutor):
                     dtype=torch.float8_e4m3fn,
                 )
 
-                # SM100 (compute capability 10.x) uses fused packed kernel for better performance
-                # when UE8M0 scale format is enabled
+                # Emit packed UE8M0 scales directly on supported Blackwell paths.
                 sm_major = torch.cuda.get_device_capability()[0]
-                if (
+                if sm_major == 12 and is_deep_gemm_e8m0_used():
+                    # SM120 emits complete packed scales, including partial packs
+                    # (e.g. Qwen3 H=768) and all masked/TMA padding rows.
+                    down_input_scale = create_sm120_packed_scale_tensor(
+                        expert_num=num_slice_experts,
+                        token_num_padded=num_tokens,
+                        hidden_dim=self._N,
+                        quant_group_size=self.DEEPGEMM_BLOCK_SHAPE[0],
+                        device=down_input.device,
+                    )
+                    silu_mul_masked_packed_sm120(
+                        upgate_output,
+                        down_input,
+                        down_input_scale,
+                        self.DEEPGEMM_BLOCK_SHAPE[0],
+                        masked_m[start_idx:end_idx],
+                    )
+                elif (
                     sm_major == 10
                     and is_deep_gemm_e8m0_used()
                     and self._N % (self.DEEPGEMM_BLOCK_SHAPE[0] * 2 * 4) == 0

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/test/deepep_normal_executor_sm120_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/test/deepep_normal_executor_sm120_test.py
@@ -1,4 +1,7 @@
 import unittest
+from unittest.mock import patch
+
+import torch
 
 from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
     has_deep_gemm,
@@ -32,6 +35,67 @@ class DeepGemmHybridExecutorQwen35ShapeSM120Test(
     DeepGemmHybridExecutorQwen35ShapeTestBase, unittest.TestCase
 ):
     pass
+
+
+class DeepGemmHybridMaskedQwenSM120Test(
+    DeepGemmHybridExecutorTestBase, unittest.TestCase
+):
+    # Keep routed tokens below the masked threshold; exercise the actual hybrid
+    # dispatch with the six-scale Qwen shape, including gather/combine.
+    MAX_GENERATE_BATCH_SIZE = 1
+    M = 4
+    # The safe ordinary FP8 pipeline has ~0.00322 error against unquantized
+    # weights for this small shape. Check fused-vs-ordinary EXACTLY below too.
+    DIFF_THRESHOLD = 0.004
+
+    def _execute(self, executor, payload, enable_cuda_graph):
+        self.assertFalse(enable_cuda_graph)
+        self.assertLessEqual(payload.expert_x.shape[0], executor.masked_max_token_num)
+        from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
+            pack_ue8m0_kernel_launcher,
+        )
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors import (
+            deepgemm_hybrid_executor,
+        )
+        from rtp_llm.models_py.triton_kernels.common.activation import (
+            silu_mul_masked_fp8_post_quant_fwd,
+        )
+
+        def ordinary_packed(x, out, scales, group_size, counts):
+            # A real, safe reference pipeline injected only at the producer
+            # boundary. Routing, both GEMMs and gather still execute normally.
+            sf = torch.zeros((*x.shape[:2], x.shape[-1] // 256), device=x.device)
+            silu_mul_masked_fp8_post_quant_fwd(
+                x, out, sf, group_size, counts, 1, scale_ue8m0=True
+            )
+            scales.copy_(pack_ue8m0_kernel_launcher(sf, 1))
+
+        with patch.object(
+            deepgemm_hybrid_executor,
+            "silu_mul_masked_packed_sm120",
+            side_effect=ordinary_packed,
+        ) as reference_producer:
+            reference = (
+                super()
+                ._execute(executor, payload, enable_cuda_graph)
+                .fused_expert_output.clone()
+            )
+            reference_producer.assert_called_once()
+        with patch.object(
+            deepgemm_hybrid_executor,
+            "silu_mul_masked_packed_sm120",
+            wraps=deepgemm_hybrid_executor.silu_mul_masked_packed_sm120,
+        ) as fused_producer:
+            actual = super()._execute(executor, payload, enable_cuda_graph)
+            fused_producer.assert_called_once()
+        torch.testing.assert_close(
+            actual.fused_expert_output, reference, rtol=0, atol=0
+        )
+        return actual
+
+    def test_empty_local_experts_eager(self):
+        # The inherited test explicitly selects the contiguous empty fast path.
+        self.skipTest("Covered by the contiguous executor tests")
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/triton_kernels/common/silu_mul_masked_packed_sm120.py
+++ b/rtp_llm/models_py/triton_kernels/common/silu_mul_masked_packed_sm120.py
@@ -1,0 +1,145 @@
+"""Masked SiLU/FP8 quantization producing MN-major UE8M0 scales on SM120.
+
+Each program owns complete packed words (four block-128 scales). Padding
+scale words, including TMA alignment rows and incomplete K packs, are written
+on every invocation. FP8 padding rows remain unspecified and consumers must
+respect masked_m. The FP32 arithmetic follows the ordinary masked SiLU kernel,
+not the intermediate BF16 rounding used by the SM100 packed implementation.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _silu_mul_masked_packed(
+    x,
+    out,
+    scales,
+    counts,
+    M: tl.constexpr,
+    H: tl.constexpr,
+    ALIGNED_M: tl.constexpr,
+    PACKED_G: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_PAD: tl.constexpr,
+):
+    pack_id = tl.program_id(0)
+    worker = tl.program_id(1)
+    expert = tl.program_id(2)
+    workers = tl.num_programs(1)
+    count = tl.load(counts + expert)
+    tl.device_assert((count >= 0) & (count <= M), "masked_m outside capacity")
+    groups = pack_id * 4 + tl.arange(0, 4)
+    cols = groups[:, None] * 128 + tl.arange(0, 128)[None, :]
+    x_base = x + expert.to(tl.int64) * M * (2 * H)
+    out_base = out + expert.to(tl.int64) * M * H
+    scale_base = scales + (expert.to(tl.int64) * PACKED_G + pack_id) * ALIGNED_M
+
+    for start in range(worker * BLOCK_T, count, workers * BLOCK_T):
+        rows = start + tl.arange(0, BLOCK_T)
+        valid = (rows[:, None, None] < count) & (cols[None, :, :] < H)
+        offsets = rows[:, None, None].to(tl.int64) * (2 * H) + cols[None, :, :]
+        up = tl.load(x_base + offsets, mask=valid, other=0).to(tl.float32)
+        gate = tl.load(x_base + offsets + H, mask=valid, other=0).to(tl.float32)
+        gate = gate / (1 + tl.exp(-gate))
+        values = up * gate
+        amax = tl.maximum(tl.max(tl.abs(values), axis=2), 1e-10)
+        scale = amax / 448.0
+        scale = tl.exp2(tl.ceil(tl.log2(tl.abs(scale))))
+        quant = tl.minimum(tl.maximum(values / scale[:, :, None], -448.0), 448.0)
+        tl.store(
+            out_base + rows[:, None, None].to(tl.int64) * H + cols[None, :, :],
+            quant.to(out.dtype.element_ty),
+            mask=valid,
+        )
+        exponent = (scale.to(tl.int32, bitcast=True) >> 23) & 255
+        exponent = tl.where(groups[None, :] < H // 128, exponent, 0)
+        packed = tl.sum(exponent << (tl.arange(0, 4)[None, :] * 8), axis=1).to(tl.int32)
+        tl.store(scale_base + rows, packed, mask=rows < count)
+
+    # Vectorized scale-only writes; no input loads or quantization for padding.
+    # These rows never overlap the valid stores, even if counts change at replay.
+    for start in range(count + worker * BLOCK_PAD, ALIGNED_M, workers * BLOCK_PAD):
+        rows = start + tl.arange(0, BLOCK_PAD)
+        tl.store(scale_base + rows, 0, mask=rows < ALIGNED_M)
+
+
+def create_packed_scale_tensor(
+    expert_num: int,
+    token_num_padded: int,
+    hidden_dim: int,
+    quant_group_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Allocate [E, M, ceil(G/4)] scales with 16-byte MN alignment.
+
+    hidden_dim is the concatenated up/gate dimension (2H). G=H/128
+    need not be divisible by four. Storage, including hidden alignment rows,
+    is initialized by silu_and_mul_masked_post_quant_packed_fwd, not here.
+    """
+    assert quant_group_size == 128
+    assert hidden_dim > 0 and hidden_dim % (2 * quant_group_size) == 0
+    assert expert_num >= 0 and token_num_padded >= 0
+    groups = hidden_dim // 2 // quant_group_size
+    packed_groups = triton.cdiv(groups, 4)
+    aligned_m = triton.cdiv(token_num_padded, 4) * 4
+    storage = torch.empty(
+        (expert_num, packed_groups, aligned_m), device=device, dtype=torch.int32
+    )
+    return storage.transpose(1, 2)[:, :token_num_padded, :]
+
+
+def silu_and_mul_masked_post_quant_packed_fwd(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    output_scale: torch.Tensor,
+    quant_group_size: int,
+    masked_m: torch.Tensor,
+) -> None:
+    """Write valid FP8 rows and ALL packed scale storage without a pack pass.
+
+    output_scale must be allocated by create_packed_scale_tensor. Counts are
+    device-resident runtime inputs, so changing routes is CUDA Graph safe.
+    """
+    assert input.is_cuda and input.dtype == torch.bfloat16 and input.is_contiguous()
+    assert input.ndim == 3 and quant_group_size == 128
+    experts, capacity, hidden_dim = input.shape
+    assert hidden_dim > 0 and hidden_dim % 256 == 0
+    h = hidden_dim // 2
+    packed_groups = triton.cdiv(h // 128, 4)
+    aligned_m = triton.cdiv(capacity, 4) * 4
+    assert output.shape == (experts, capacity, h)
+    assert output.dtype == torch.float8_e4m3fn and output.is_contiguous()
+    assert output_scale.dtype == torch.int32
+    assert output_scale.shape == (experts, capacity, packed_groups)
+    assert masked_m.shape == (experts,) and masked_m.dtype == torch.int32
+    assert masked_m.is_contiguous()
+    assert output.device == output_scale.device == masked_m.device == input.device
+    if experts == 0 or capacity == 0:
+        return
+    assert output_scale.stride() == (packed_groups * aligned_m, 1, aligned_m)
+    # A matching strided view need not own the final TMA padding rows (e.g.
+    # empty_strided allocates only up to the final logical element).
+    required_words = output_scale.storage_offset() + experts * packed_groups * aligned_m
+    assert (
+        required_words * output_scale.element_size()
+        <= output_scale.untyped_storage().nbytes()
+    )
+    # Enough independent workers for skew/full experts, without launching a
+    # CTA for every capacity row. Selected with sparse/skew/full SM120 sweeps.
+    workers = min(32 if experts < 64 else 16, triton.cdiv(capacity, 4))
+    _silu_mul_masked_packed[(packed_groups, workers, experts)](
+        input,
+        output,
+        output_scale,
+        masked_m,
+        M=capacity,
+        H=h,
+        ALIGNED_M=aligned_m,
+        PACKED_G=packed_groups,
+        BLOCK_T=4,
+        BLOCK_PAD=128,
+        num_warps=4,
+    )

--- a/rtp_llm/models_py/triton_kernels/common/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/common/test/BUILD
@@ -41,3 +41,21 @@ py_test(
     tags = ["H20"],
     exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
 )
+
+py_test(
+    name = "silu_mul_masked_packed_sm120_test",
+    srcs = ["silu_mul_masked_packed_sm120_test.py"],
+    deps = ["//rtp_llm/models_py/standalone:py_standalone_testlib"],
+    env = {"GPU_COUNT": "1"},
+    tags = ["RTX_5000_PRO"],
+    exec_properties = {"gpu": "RTX_5000_PRO", "gpu_count": "1"},
+)
+
+py_test(
+    name = "silu_mul_masked_packed_sm120_benchmark",
+    srcs = ["silu_mul_masked_packed_sm120_benchmark.py"],
+    deps = ["//rtp_llm/models_py/standalone:py_standalone_testlib"],
+    env = {"GPU_COUNT": "1"},
+    tags = ["manual", "open_skip", "RTX_5000_PRO"],
+    exec_properties = {"gpu": "RTX_5000_PRO", "gpu_count": "1"},
+)

--- a/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_sm120_benchmark.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_sm120_benchmark.py
@@ -1,0 +1,397 @@
+"""Reproducible SM120 masked SiLU/FP8/packed-UE8M0 CUDA-graph benchmark.
+
+Run from the source root after checking develop/pro5000-opt and rebuilding the
+installed wheel to that baseline (see workspace AGENTS.md)::
+
+    python -m rtp_llm.models_py.triton_kernels.common.test.silu_mul_masked_packed_sm120_benchmark \
+        --output /tmp/sm120-packed.json
+    # Include the real masked Down GEMM, with a Qwen-sized output dimension:
+    python -m rtp_llm.models_py.triton_kernels.common.test.silu_mul_masked_packed_sm120_benchmark \
+        --shape 128,128,768 --down-hidden 2048 --output /tmp/sm120-down.json
+
+E,M,H describe expert count, per-expert token capacity and SiLU output width.
+Inputs, activation outputs, FP32 scales and fused packed scales are preallocated.
+Every baseline call zeroes the whole FP32 scale, invokes the existing activation,
+then calls the public pack launcher, including its packed-storage zeroing. Its
+allocations become fixed graph-owned allocations on replay. Thus timings include
+all device initialization and conversion work, but exclude Python dispatch and
+host allocator overhead. Fused output scales are completely overwritten by the
+kernel; they do not need an extra initialization pass. Activation output padding
+is initialized once outside timing and does not contribute to valid Down GEMM
+outputs; hardware may still load padding as part of a complete tile.
+
+Default counts are fixed during each measurement. This is a steady-state device
+microbenchmark, not request latency or changing-routing performance. Compilation,
+input generation, weight packing, validation and graph capture are outside timing.
+"""
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_shape(value):
+    try:
+        expert_num, capacity, hidden = map(int, value.split(","))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("shape must be E,M,H") from exc
+    if min(expert_num, capacity, hidden) <= 0 or hidden % 128:
+        raise argparse.ArgumentTypeError(
+            "E,M,H must be positive and H divisible by 128"
+        )
+    return expert_num, capacity, hidden
+
+
+def make_counts(expert_num, capacity, profile):
+    if profile == "full":
+        return [capacity] * expert_num
+    if profile == "sparse":
+        return [
+            min(1 + (i // 8) % 8, capacity) if i % 8 == 0 else 0
+            for i in range(expert_num)
+        ]
+    if expert_num == 1:
+        return [max(1, capacity - 1)]
+    return [
+        capacity if i == 0 else capacity // 2 if i == 1 else int(i % 8 == 0)
+        for i in range(expert_num)
+    ]
+
+
+def capture(torch, function, warmup, inner_repeats):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(warmup):
+            function()
+    stream.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        for _ in range(inner_repeats):
+            function()
+    graph.replay()
+    torch.cuda.synchronize()
+    return graph
+
+
+def time_pair(torch, functions, args):
+    graphs = {
+        name: capture(torch, fn, args.warmup, args.inner_repeats)
+        for name, fn in functions.items()
+    }
+    samples = {name: [] for name in functions}
+    events = [torch.cuda.Event(enable_timing=True) for _ in range(2)]
+    for round_index in range(args.rounds):
+        # Alternate order to reduce systematic thermal/order bias.
+        order = list(graphs)
+        if round_index % 2:
+            order.reverse()
+        for name in order:
+            events[0].record()
+            for _ in range(args.replays):
+                graphs[name].replay()
+            events[1].record()
+            events[1].synchronize()
+            samples[name].append(
+                events[0].elapsed_time(events[1])
+                * 1000
+                / (args.inner_repeats * args.replays)
+            )
+    result = {
+        name: {
+            "median_us": statistics.median(values),
+            "min_us": min(values),
+            "max_us": max(values),
+            "round_us": values,
+        }
+        for name, values in samples.items()
+    }
+    result["speedup"] = result["baseline"]["median_us"] / result["fused"]["median_us"]
+    return result
+
+
+def benchmark_case(torch, wrapper, activation, fused, shape, profile, args):
+    expert_num, capacity, hidden = shape
+    counts_host = make_counts(expert_num, capacity, profile)
+    expected_m = max(1, (sum(counts_host) + expert_num - 1) // expert_num)
+    counts = torch.tensor(counts_host, dtype=torch.int32, device="cuda")
+    x = torch.randn(
+        (expert_num, capacity, 2 * hidden), device="cuda", dtype=torch.bfloat16
+    )
+    baseline_out = torch.zeros(
+        (expert_num, capacity, hidden), device="cuda", dtype=torch.float8_e4m3fn
+    )
+    fused_out = torch.zeros_like(baseline_out)
+    fp32_scale = torch.zeros(
+        (expert_num, capacity, hidden // 128), device="cuda", dtype=torch.float32
+    )
+    fused_scale = fused.create_packed_scale_tensor(
+        expert_num, capacity, 2 * hidden, 128, x.device
+    )
+    aligned_capacity = fused_scale.stride(2)
+    fused_scale_storage = fused_scale.as_strided(
+        (expert_num, aligned_capacity, fused_scale.shape[2]), fused_scale.stride()
+    )
+    # Poison physical TMA padding as well as logical rows before validation.
+    fused_scale_storage.fill_(-1)
+    baseline_state = {}
+
+    def baseline():
+        fp32_scale.zero_()
+        activation.silu_mul_masked_fp8_post_quant_fwd(
+            x,
+            baseline_out,
+            fp32_scale,
+            128,
+            counts,
+            expected_m,
+            input_layout=activation.MaskedSiluInputLayout.PER_EXPERT_CAPACITY,
+            scale_ue8m0=True,
+        )
+        baseline_state["scale"] = wrapper.pack_ue8m0_kernel_launcher(fp32_scale, 1)
+
+    def fused_call():
+        fused.silu_and_mul_masked_post_quant_packed_fwd(
+            x, fused_out, fused_scale, 128, counts
+        )
+
+    baseline()
+    fused_call()
+    valid = torch.arange(capacity, device="cuda")[None, :] < counts[:, None]
+    old_values = baseline_out.float()[valid]
+    new_values = fused_out.float()[valid]
+    old_bits = baseline_out.view(torch.uint8)[valid]
+    new_bits = fused_out.view(torch.uint8)[valid]
+    baseline_scale = baseline_state["scale"]
+    baseline_scale_storage = baseline_scale.as_strided(
+        (expert_num, aligned_capacity, baseline_scale.shape[2]),
+        baseline_scale.stride(),
+    )
+    # Include invalid rows, unused tail bytes and physical TMA padding. The
+    # public pack launcher zero-initializes the complete baseline allocation.
+    torch.testing.assert_close(
+        fused_scale_storage, baseline_scale_storage, rtol=0, atol=0
+    )
+    torch.testing.assert_close(new_bits, old_bits, rtol=0, atol=0)
+    validation = {
+        "packed_scales_exact": True,
+        "packed_physical_storage_exact": True,
+        "physical_padding_rows_per_expert": aligned_capacity - capacity,
+        "active_fp8_exact": True,
+        "active_fp8_mismatch_count": int((old_bits != new_bits).sum().item()),
+        "active_fp8_max_abs_difference": float(
+            (old_values - new_values).abs().max().item()
+        ),
+        "fp8_comparison": "bitwise_uint8",
+    }
+    result = {
+        "experts": expert_num,
+        "capacity": capacity,
+        "hidden": hidden,
+        "profile": profile,
+        "counts": counts_host,
+        "active_tokens": sum(counts_host),
+        "expected_m": expected_m,
+        "packed_scale_shape": list(fused_scale.shape),
+        "packed_scale_stride": list(fused_scale.stride()),
+        "validation": validation,
+        "activation_pack": time_pair(
+            torch, {"baseline": baseline, "fused": fused_call}, args
+        ),
+    }
+
+    if args.down_hidden:
+        # Finite FP8 values with legal, exact power-of-two unit scales. Pack
+        # weights once, outside timing, so only the activation producer differs.
+        weight = torch.randn(
+            (expert_num, args.down_hidden, hidden), device="cuda", dtype=torch.bfloat16
+        )
+        weight = weight.clamp_(-2, 2).to(torch.float8_e4m3fn)
+        weight_scale = wrapper.pack_ue8m0_kernel_launcher(
+            torch.ones(
+                (expert_num, args.down_hidden // 128, hidden // 128), device="cuda"
+            ),
+            128,
+        )
+        old_down = torch.zeros(
+            (expert_num, capacity, args.down_hidden),
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        new_down = torch.zeros_like(old_down)
+
+        def baseline_down():
+            baseline()
+            wrapper.m_grouped_fp8_gemm_nt_masked(
+                (baseline_out, baseline_state["scale"]),
+                (weight, weight_scale),
+                old_down,
+                counts,
+                expected_m,
+                disable_ue8m0_cast=False,
+            )
+
+        def fused_down():
+            fused_call()
+            wrapper.m_grouped_fp8_gemm_nt_masked(
+                (fused_out, fused_scale),
+                (weight, weight_scale),
+                new_down,
+                counts,
+                expected_m,
+                disable_ue8m0_cast=False,
+            )
+
+        baseline_down()
+        fused_down()
+        old_valid = old_down.float()[valid]
+        new_valid = new_down.float()[valid]
+        if (
+            not torch.isfinite(old_valid).all().item()
+            or not torch.isfinite(new_valid).all().item()
+        ):
+            raise AssertionError("Down GEMM produced non-finite active output")
+        normalized_rmse = (
+            (old_valid - new_valid).square().mean().sqrt()
+            / old_valid.square().mean().sqrt().clamp_min(1e-12)
+        ).item()
+        torch.testing.assert_close(
+            new_down.view(torch.int16)[valid],
+            old_down.view(torch.int16)[valid],
+            rtol=0,
+            atol=0,
+        )
+        result["down_hidden"] = args.down_hidden
+        result["validation"]["down_active_bitwise_exact"] = True
+        result["validation"]["down_normalized_rmse"] = normalized_rmse
+        result["validation"]["down_max_abs_difference"] = float(
+            (old_valid - new_valid).abs().max().item()
+        )
+        result["activation_pack_down"] = time_pair(
+            torch, {"baseline": baseline_down, "fused": fused_down}, args
+        )
+    torch.cuda.synchronize()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--shape",
+        type=parse_shape,
+        action="append",
+        help="repeatable E,M,H; H is output width",
+    )
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        choices=("sparse", "skew", "full"),
+        default=["sparse", "skew", "full"],
+    )
+    parser.add_argument(
+        "--down-hidden",
+        type=int,
+        default=0,
+        help="also benchmark Down GEMM with this output width (multiple of 128)",
+    )
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument(
+        "--inner-repeats",
+        type=int,
+        default=32,
+        help="pipeline calls captured per graph",
+    )
+    parser.add_argument(
+        "--replays", type=int, default=4, help="graph replays per timed round"
+    )
+    parser.add_argument("--rounds", type=int, default=7)
+    parser.add_argument("--seed", type=int, default=20260907)
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument(
+        "--output", type=Path, help="also write JSON here (stdout always receives JSON)"
+    )
+    args = parser.parse_args()
+    if min(args.warmup, args.inner_repeats, args.replays, args.rounds) < 1:
+        parser.error("warmup, inner-repeats, replays and rounds must be positive")
+    if args.down_hidden < 0 or args.down_hidden % 128:
+        parser.error("down-hidden must be zero or a positive multiple of 128")
+
+    # Lazy imports keep --help usable without an installed CUDA runtime.
+    import torch
+    import triton
+
+    torch.cuda.set_device(args.device)
+    if torch.cuda.get_device_capability()[0] != 12:
+        raise RuntimeError("This benchmark requires SM120/SM12x hardware")
+    from rtp_llm.models_py.kernels.cuda import deepgemm_wrapper as wrapper
+    from rtp_llm.models_py.triton_kernels.common import (
+        activation,
+    )
+    from rtp_llm.models_py.triton_kernels.common import (
+        silu_mul_masked_packed_sm120 as fused,
+    )
+
+    torch.manual_seed(args.seed)
+    shapes = args.shape or [
+        (128, 128, 768),
+        (128, 256, 768),
+        (1, 128, 384),
+        (1, 128, 512),
+        (1, 128, 1024),
+        (1, 128, 2048),
+    ]
+    source_root = Path(__file__).resolve().parents[5]
+
+    def git_output(*command):
+        run = subprocess.run(
+            ["git", "-C", str(source_root), *command], capture_output=True, text=True
+        )
+        return run.stdout.strip() if run.returncode == 0 else None
+
+    metadata = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "gpu": torch.cuda.get_device_name(),
+        "compute_capability": list(torch.cuda.get_device_capability()),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "triton": triton.__version__,
+        "source_head": git_output("rev-parse", "HEAD"),
+        "source_status": git_output("status", "--porcelain"),
+        "activation_module": activation.__file__,
+        "fused_module": fused.__file__,
+        "seed": args.seed,
+        "warmup_calls": args.warmup,
+        "calls_per_graph": args.inner_repeats,
+        "replays_per_round": args.replays,
+        "rounds": args.rounds,
+        "timing": "CUDA events around CUDA graph replay; microseconds per pipeline call",
+        "baseline_initialization": "FP32 scale zero each call; public pack launcher includes packed output zero",
+        "allocation": "preallocated buffers plus fixed graph-owned baseline pack outputs; host allocator excluded",
+        "routing": "fixed counts per case; steady-state device timing",
+        "down_weights": "synthetic finite clamped FP8, unit UE8M0 scales packed before timing",
+    }
+    report = {"metadata": metadata, "results": []}
+    for shape in shapes:
+        for profile in args.profiles:
+            print(
+                f"Benchmark E,M,H={shape} profile={profile}",
+                file=sys.stderr,
+                flush=True,
+            )
+            report["results"].append(
+                benchmark_case(torch, wrapper, activation, fused, shape, profile, args)
+            )
+            if args.output:
+                args.output.parent.mkdir(parents=True, exist_ok=True)
+                args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_sm120_test.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_sm120_test.py
@@ -1,0 +1,204 @@
+"""SM120 packed activation contract: tails and padding must not depend on memory."""
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.triton_kernels.common.activation import (
+    silu_mul_masked_fp8_post_quant_fwd,
+)
+from rtp_llm.models_py.triton_kernels.common.silu_mul_masked_packed_sm120 import (
+    create_packed_scale_tensor,
+    silu_and_mul_masked_post_quant_packed_fwd,
+)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class SiluMulMaskedPackedSM120Test(unittest.TestCase):
+    def setUp(self):
+        if torch.cuda.get_device_capability()[0] != 12:
+            self.skipTest("SM120 required")
+        torch.manual_seed(123)
+
+    def test_qwen_six_groups(self):
+        scale = create_packed_scale_tensor(3, 129, 1536, 128, torch.device("cuda"))
+        self.assertEqual(scale.shape, (3, 129, 2))
+        self.assertEqual(scale.stride(), (264, 1, 132))
+
+    def test_padding_is_overwritten(self):
+        x = torch.randn(2, 128, 1024, device="cuda", dtype=torch.bfloat16)
+        counts = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+        out = torch.empty((2, 128, 512), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(2, 128, 1024, 128, x.device)
+        scale.fill_(-1)
+        silu_and_mul_masked_post_quant_packed_fwd(x, out, scale, 128, counts)
+        self.assertTrue(torch.all(scale[0] == 0).item())
+        self.assertTrue(torch.all(scale[1, 1:] == 0).item())
+
+    @staticmethod
+    def _storage_view(scale, e, m, h):
+        aligned_m = (m + 3) // 4 * 4
+        packed_g = (h // 128 + 3) // 4
+        return scale.as_strided(
+            (e, aligned_m, packed_g), (packed_g * aligned_m, 1, aligned_m)
+        )
+
+    def _assert_reference(self, x, out, scale, counts, counts_cpu):
+        e, m, twice_h = x.shape
+        h = twice_h // 2
+        ref_out = torch.empty_like(out)
+        ref_scale = torch.zeros((e, m, h // 128), device=x.device)
+        silu_mul_masked_fp8_post_quant_fwd(
+            x,
+            ref_out,
+            ref_scale,
+            128,
+            counts,
+            expected_m=max(1, sum(counts_cpu) // e),
+            scale_ue8m0=True,
+        )
+        # Independent packing in torch, including physical alignment rows.
+        aligned_m = (m + 3) // 4 * 4
+        packed_g = (h // 128 + 3) // 4
+        exp = torch.zeros(
+            (e, aligned_m, packed_g * 4), device=x.device, dtype=torch.int64
+        )
+        exp[:, :m, : h // 128] = (
+            ref_scale.view(torch.int32).to(torch.int64) >> 23
+        ) & 255
+        exp = exp.view(e, aligned_m, packed_g, 4)
+        expected = sum(exp[..., i] << (8 * i) for i in range(4)).to(torch.int32)
+        torch.testing.assert_close(
+            self._storage_view(scale, e, m, h), expected, rtol=0, atol=0
+        )
+        for expert, n in enumerate(counts_cpu):
+            torch.testing.assert_close(
+                out[expert, :n].view(torch.uint8),
+                ref_out[expert, :n].view(torch.uint8),
+                rtol=0,
+                atol=0,
+            )
+
+    def test_tails_and_capacity_boundaries_match_unpacked(self):
+        # Six groups catches the Qwen3 shape; 1/2/3 cover TP-sized tail packs.
+        for h in (128, 256, 384, 512, 768, 1024, 2048):
+            for m in (1, 127, 128, 129, 257):
+                with self.subTest(h=h, m=m):
+                    counts_cpu = [0, 1, m]
+                    counts = torch.tensor(counts_cpu, device="cuda", dtype=torch.int32)
+                    x = torch.randn((3, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+                    x[0].fill_(float("nan"))
+                    x[1, 1:].fill_(float("nan"))
+                    out = torch.empty(
+                        (3, m, h), device="cuda", dtype=torch.float8_e4m3fn
+                    )
+                    scale = create_packed_scale_tensor(3, m, 2 * h, 128, x.device)
+                    self._storage_view(scale, 3, m, h).fill_(-1)
+                    silu_and_mul_masked_post_quant_packed_fwd(
+                        x, out, scale, 128, counts
+                    )
+                    self._assert_reference(x, out, scale, counts, counts_cpu)
+
+    def test_single_expert_zero_and_scale_boundaries(self):
+        h, m = 768, 128
+        x = torch.zeros((1, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+        # Unequal halves detect accidentally swapping gate and up. Sweep scales
+        # across powers of two and include the all-zero epsilon case.
+        x[:, 1:, :h] = torch.logspace(-9, 4, m - 1, base=2, device="cuda")[:, None]
+        x[:, 1:, h:] = 0.75
+        counts = torch.tensor([m], device="cuda", dtype=torch.int32)
+        out = torch.empty((1, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(1, m, 2 * h, 128, x.device)
+        self._storage_view(scale, 1, m, h).fill_(-1)
+        silu_and_mul_masked_post_quant_packed_fwd(x, out, scale, 128, counts)
+        self._assert_reference(x, out, scale, counts, [m])
+
+    def test_graph_replay_overwrites_previous_routes(self):
+        e, m, h = 3, 129, 768
+        x = torch.randn((e, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+        counts = torch.tensor([m, m, m], device="cuda", dtype=torch.int32)
+        out = torch.empty((e, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(e, m, 2 * h, 128, x.device)
+
+        def run():
+            silu_and_mul_masked_post_quant_packed_fwd(x, out, scale, 128, counts)
+
+        run()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run()
+        for counts_cpu in ([m, m, m], [1, 0, 127], [0, 0, 0], [m, 128, 1]):
+            counts.copy_(torch.tensor(counts_cpu, device="cuda", dtype=torch.int32))
+            self._storage_view(scale, e, m, h).fill_(-1)
+            graph.replay()
+            self._assert_reference(x, out, scale, counts, counts_cpu)
+
+    def test_masked_down_gemm_consumes_tail_packs(self):
+        import deep_gemm
+
+        for e in (1, 3):
+            m, h, n = 128, 768, 256
+            x = torch.randn((e, m, h * 2), device="cuda", dtype=torch.bfloat16)
+            counts_cpu = [1] if e == 1 else [0, 1, 127]
+            counts = torch.tensor(counts_cpu, device="cuda", dtype=torch.int32)
+            out = torch.empty((e, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+            scale = create_packed_scale_tensor(e, m, 2 * h, 128, x.device)
+            self._storage_view(scale, e, m, h).fill_(-1)
+            silu_and_mul_masked_post_quant_packed_fwd(x, out, scale, 128, counts)
+            w = (torch.randn((e, n, h), device="cuda") * 0.25).to(torch.float8_e4m3fn)
+            # Packed unit scales: no conversion kernel on either operand.
+            ws = torch.full(
+                (e, 2, n), 0x7F7F7F7F, device="cuda", dtype=torch.int32
+            ).transpose(1, 2)
+            d = torch.empty((e, m, n), device="cuda", dtype=torch.bfloat16)
+            deep_gemm.m_grouped_fp8_gemm_nt_masked(
+                (out, scale),
+                (w, ws),
+                d,
+                counts,
+                max(1, sum(counts_cpu) // e),
+                disable_ue8m0_cast=False,
+            )
+            # Reference dequantization is independent of the GEMM consumer.
+            exp = torch.stack(
+                [(scale.to(torch.int64) >> (8 * i)) & 255 for i in range(4)], dim=-1
+            ).flatten(-2)[..., : h // 128]
+            sf = torch.exp2(exp.float() - 127).repeat_interleave(128, dim=-1)
+            for expert, count in enumerate(counts_cpu):
+                if count:
+                    expected = (out[expert, :count].float() * sf[expert, :count]) @ w[
+                        expert
+                    ].float().T
+                    torch.testing.assert_close(
+                        d[expert, :count].float(), expected, rtol=0.01, atol=0.08
+                    )
+
+    def test_nonzero_offset_expert_slices(self):
+        e, m, h = 3, 129, 768
+        x = torch.randn((e, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+        out = torch.empty((e, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(e, m, 2 * h, 128, x.device)
+        counts = torch.tensor([m, 1, 127], device="cuda", dtype=torch.int32)
+        storage = self._storage_view(scale, e, m, h)
+        storage.fill_(-1)
+        silu_and_mul_masked_post_quant_packed_fwd(
+            x[1:], out[1:], scale[1:], 128, counts[1:]
+        )
+        self._assert_reference(x[1:], out[1:], scale[1:], counts[1:], [1, 127])
+        self.assertTrue(torch.all(storage[0] == -1).item())
+
+    def test_rejects_storage_missing_physical_padding(self):
+        x = torch.zeros((3, 129, 1536), device="cuda", dtype=torch.bfloat16)
+        out = torch.empty((3, 129, 768), device="cuda", dtype=torch.float8_e4m3fn)
+        counts = torch.tensor([0, 1, 129], device="cuda", dtype=torch.int32)
+        # Correct logical layout but only 789 words; kernel requires 792.
+        scale = torch.empty_strided(
+            (3, 129, 2), (264, 1, 132), device="cuda", dtype=torch.int32
+        )
+        with self.assertRaises(AssertionError):
+            silu_and_mul_masked_post_quant_packed_fwd(x, out, scale, 128, counts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

On SM120, masked MoE allocates Down GEMM FP32 scales with `torch.empty` but initializes only valid token rows. Packing uninitialized padding rows into UE8M0 can trigger a device assertion and surface as CUDA error 719.

The existing SM100 fused producer also requires the number of scale groups to be divisible by four, preventing direct reuse for shapes such as Qwen3-30B-A3B's H=768 (six groups).

## Changes

- Add an SM120 fused SiLU × up, FP8 quantization, and packed UE8M0 scale producer.
- Initialize all packed scale storage on every invocation, including masked rows, TMA alignment rows, and unused bytes in partial packs.
- Support block-128 widths whose scale group count is not divisible by four.
- Integrate the producer into both masked executors while preserving existing SM100 behavior and executor routing.

## Validation

- 18 regression tests passed; 2 expected skips.
- Compute Sanitizer: 8 kernel tests passed with zero errors.
- Covered poisoned padding, partial packs, expert slices, changing counts during CUDA Graph replay, and real masked Down GEMM.
- All 18 benchmark cases produced bitwise-identical valid FP8 and Down GEMM outputs against the safe ordinary pipeline, with no observed performance regression.
- Qwen3-30B-A3B-FP8 completed four 64-token generation requests on RTX PRO 5000, with the new kernel confirmed active.

Performance measurements are CUDA Graph device microbenchmarks against a baseline that initializes scales safely. They do not establish end-to-end TPOT improvements. Benefits apply when execution selects the SM120 masked path; multi-GPU TP/EP configurations have not been validated.