### PR TITLE
perf(decode): keep RoPE positions on device

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -1275,6 +1275,7 @@ class PyFlashinferDecodeImpl(FMHAImplBase):
         self.fmha_impl.prepare_for_cuda_graph_replay(attn_inputs)
         # Update rope params for correct position encoding during cuda graph replay
         new_rope_params = self.rope_impl.prepare(attn_inputs)
+        self.rope_params.positions_device = new_rope_params.positions_device
         common.copy_kv_cache_offset(
             self.rope_params.kv_cache_offset, new_rope_params.kv_cache_offset
         )

--- a/rtp_llm/ops/fused_rope_kvcache_op.py
+++ b/rtp_llm/ops/fused_rope_kvcache_op.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import cache
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 
@@ -37,6 +37,8 @@ class FusedRopeAttnParams:
     context_total_kv_length: int
     decode_plan: bool
     attn_type: torch.dtype
+    # Device-resident mirror of sequence_lengths for kernels that index it per CTA.
+    positions_device: Optional[torch.Tensor] = None
 
 
 class FusedRopeKVCachePrefillOpBase:
@@ -177,6 +179,19 @@ class FusedRopeKVCacheDecodeOp:
     def __init__(self, attn_configs: AttentionConfigs) -> None:
         self.attn_configs = attn_configs
         self._dummy_scale: Optional[torch.Tensor] = None
+        self._positions_device: Dict[int, torch.Tensor] = {}
+
+    def _device_positions(self, sequence_lengths: torch.Tensor) -> torch.Tensor:
+        # Keep one stable device pointer per captured CUDA Graph batch size.
+        if sequence_lengths.is_cuda or sequence_lengths.numel() == 0:
+            return sequence_lengths
+        count = sequence_lengths.numel()
+        buffer = self._positions_device.get(count)
+        if buffer is None:
+            buffer = torch.empty(count, dtype=sequence_lengths.dtype, device="cuda")
+            self._positions_device[count] = buffer
+        buffer.copy_(sequence_lengths, non_blocking=True)
+        return buffer
 
     def _get_kv_scale(self, kv_cache: LayerKVCache) -> Optional[torch.Tensor]:
         # FP8 KV cache uses direct cast (no dynamic scaling), so the kernel always writes
@@ -214,7 +229,9 @@ class FusedRopeKVCacheDecodeOp:
         return _get_fused_rope_kvcache().decode_fused_rope_kvcache(
             qkv,
             params.position_ids,
-            params.sequence_lengths,
+            params.positions_device
+            if params.positions_device is not None
+            else params.sequence_lengths,
             params.sequence_lengths.size(0),
             self.attn_configs.head_num,
             self.attn_configs.kv_head_num,
@@ -269,4 +286,5 @@ class FusedRopeKVCacheDecodeOp:
             attn_inputs.context_total_kv_length,
             True,
             get_scalar_type(attn_inputs.dtype),
+            self._device_positions(attn_inputs.sequence_lengths),
         )


### PR DESCRIPTION
Avoid per-CTA PCIe reads of pinned sequence lengths while preserving stable pointers for each CUDA Graph batch size.