### PR TITLE
fix: share masked MoE FP8 scale packing across SM100 and SM120

### DIFF
--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_hybrid_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_hybrid_executor.py
@@ -550,30 +550,29 @@ class DeepGemmHybridExecutor(FusedMoeExpertExecutor):
                 dtype=torch.float8_e4m3fn,
             )
 
-            # SM100 (compute capability 10.x) uses fused packed kernel for better performance
-            # when UE8M0 scale format is enabled
+            # Emit packed UE8M0 scales directly on supported Blackwell paths.
             sm_major = torch.cuda.get_device_capability()[0]
-            if (
-                sm_major == 10
-                and is_deep_gemm_e8m0_used()
-                and self.N % (self.DEEPGEMM_BLOCK_SHAPE[0] * 2 * 4) == 0
-            ):
-                # Create packed scale tensor with proper layout for deep_gemm
-                # Shape: (E, T, G // 4) where G = hidden_dim // 2 // group_size
+            if sm_major in (10, 12) and is_deep_gemm_e8m0_used():
+                # Emit complete packed scales, including partial packs
+                # (e.g. Qwen3 H=768) and all masked/TMA padding rows.
                 down_input_scale = create_packed_scale_tensor(
                     expert_num=self.num_experts_per_partition,
                     token_num_padded=alignment,
                     hidden_dim=self.N,
                     quant_group_size=self.DEEPGEMM_BLOCK_SHAPE[0],
-                    device=hidden_states_fp8_device,
+                    device=down_input.device,
                 )
-                # Fused SiLU-and-mul + FP8 quantization with UE8M0 scale packing
                 silu_and_mul_masked_post_quant_packed_fwd(
                     upgate_output,
                     down_input,
                     down_input_scale,
                     self.DEEPGEMM_BLOCK_SHAPE[0],
                     num_recv_tokens_per_expert,
+                    # Only these shapes previously used rounded packed arithmetic.
+                    round_intermediate=(
+                        sm_major == 10
+                        and self.N % (self.DEEPGEMM_BLOCK_SHAPE[0] * 2 * 4) == 0
+                    ),
                 )
             else:
                 # Standard path for other SM versions

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_masked_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/deepgemm_masked_executor.py
@@ -214,30 +214,29 @@ class DeepGemmMaskedExecutor(FusedMoeExpertExecutor):
                     dtype=torch.float8_e4m3fn,
                 )
 
-                # SM100 (compute capability 10.x) uses fused packed kernel for better performance
-                # when UE8M0 scale format is enabled
+                # Emit packed UE8M0 scales directly on supported Blackwell paths.
                 sm_major = torch.cuda.get_device_capability()[0]
-                if (
-                    sm_major == 10
-                    and is_deep_gemm_e8m0_used()
-                    and self._N % (self.DEEPGEMM_BLOCK_SHAPE[0] * 2 * 4) == 0
-                ):
-                    # Create packed scale tensor with proper layout for deep_gemm
-                    # Shape: (E, T, G // 4) where G = hidden_dim // 2 // group_size
+                if sm_major in (10, 12) and is_deep_gemm_e8m0_used():
+                    # Emit complete packed scales, including partial packs
+                    # (e.g. Qwen3 H=768) and all masked/TMA padding rows.
                     down_input_scale = create_packed_scale_tensor(
                         expert_num=num_slice_experts,
                         token_num_padded=num_tokens,
                         hidden_dim=self._N,
                         quant_group_size=self.DEEPGEMM_BLOCK_SHAPE[0],
-                        device=device,
+                        device=down_input.device,
                     )
-                    # Fused SiLU-and-mul + FP8 quantization with UE8M0 scale packing
                     silu_and_mul_masked_post_quant_packed_fwd(
                         upgate_output,
                         down_input,
                         down_input_scale,
                         self.DEEPGEMM_BLOCK_SHAPE[0],
                         masked_m[start_idx:end_idx],
+                        # Only these shapes previously used rounded packed arithmetic.
+                        round_intermediate=(
+                            sm_major == 10
+                            and self._N % (self.DEEPGEMM_BLOCK_SHAPE[0] * 2 * 4) == 0
+                        ),
                     )
                 else:
                     # Standard path for other SM versions

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/test/deepep_normal_executor_sm120_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/executors/test/deepep_normal_executor_sm120_test.py
@@ -1,4 +1,7 @@
 import unittest
+from unittest.mock import patch
+
+import torch
 
 from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
     has_deep_gemm,
@@ -32,6 +35,68 @@ class DeepGemmHybridExecutorQwen35ShapeSM120Test(
     DeepGemmHybridExecutorQwen35ShapeTestBase, unittest.TestCase
 ):
     pass
+
+
+class DeepGemmHybridMaskedQwenSM120Test(
+    DeepGemmHybridExecutorTestBase, unittest.TestCase
+):
+    # Keep routed tokens below the masked threshold; exercise the actual hybrid
+    # dispatch with the six-scale Qwen shape, including gather/combine.
+    MAX_GENERATE_BATCH_SIZE = 1
+    M = 4
+    # The safe ordinary FP8 pipeline has ~0.00322 error against unquantized
+    # weights for this small shape. Check fused-vs-ordinary EXACTLY below too.
+    DIFF_THRESHOLD = 0.004
+
+    def _execute(self, executor, payload, enable_cuda_graph):
+        self.assertFalse(enable_cuda_graph)
+        self.assertLessEqual(payload.expert_x.shape[0], executor.masked_max_token_num)
+        from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
+            pack_ue8m0_kernel_launcher,
+        )
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors import (
+            deepgemm_hybrid_executor,
+        )
+        from rtp_llm.models_py.triton_kernels.common.activation import (
+            silu_mul_masked_fp8_post_quant_fwd,
+        )
+
+        def ordinary_packed(x, out, scales, group_size, counts, *, round_intermediate):
+            self.assertFalse(round_intermediate)
+            # A real, safe reference pipeline injected only at the producer
+            # boundary. Routing, both GEMMs and gather still execute normally.
+            sf = torch.zeros((*x.shape[:2], x.shape[-1] // 256), device=x.device)
+            silu_mul_masked_fp8_post_quant_fwd(
+                x, out, sf, group_size, counts, 1, scale_ue8m0=True
+            )
+            scales.copy_(pack_ue8m0_kernel_launcher(sf, 1))
+
+        with patch.object(
+            deepgemm_hybrid_executor,
+            "silu_and_mul_masked_post_quant_packed_fwd",
+            side_effect=ordinary_packed,
+        ) as reference_producer:
+            reference = (
+                super()
+                ._execute(executor, payload, enable_cuda_graph)
+                .fused_expert_output.clone()
+            )
+            reference_producer.assert_called_once()
+        with patch.object(
+            deepgemm_hybrid_executor,
+            "silu_and_mul_masked_post_quant_packed_fwd",
+            wraps=deepgemm_hybrid_executor.silu_and_mul_masked_post_quant_packed_fwd,
+        ) as fused_producer:
+            actual = super()._execute(executor, payload, enable_cuda_graph)
+            fused_producer.assert_called_once()
+        torch.testing.assert_close(
+            actual.fused_expert_output, reference, rtol=0, atol=0
+        )
+        return actual
+
+    def test_empty_local_experts_eager(self):
+        # The inherited test explicitly selects the contiguous empty fast path.
+        self.skipTest("Covered by the contiguous executor tests")
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/triton_kernels/common/activation.py
+++ b/rtp_llm/models_py/triton_kernels/common/activation.py
@@ -639,130 +639,73 @@ def silu_and_mul_masked_post_quant_fwd(
     return
 
 
-# Modified to integrate pack_ue8m0 logic for Blackwell with UE8M0 scale packing
 @triton.jit
 def _silu_and_mul_post_quant_packed_kernel(
-    input_ptr,
-    stride_input_0,
-    stride_input_1,
-    stride_input_2,
-    output_ptr,
-    stride_output_0,
-    stride_output_1,
-    stride_output_2,
-    output_scale_ptr,  # Packed int32 scales (UE8M0 format)
-    stride_output_scale_0,
-    stride_output_scale_1,
-    stride_output_scale_2,
-    masked_m_ptr,
-    size_n,
-    fp8_max,
-    fp8_min,
-    BLOCK_N: tl.constexpr,  # group_size (e.g., 128)
-    NUM_STAGE: tl.constexpr,
+    x,
+    out,
+    scales,
+    counts,
+    M: tl.constexpr,
+    H: tl.constexpr,
+    ALIGNED_M: tl.constexpr,
+    PACKED_G: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_PAD: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    GROUP_TILE: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    ROUND_INTERMEDIATE: tl.constexpr,
 ):
-    """
-    Fused SiLU-and-mul + FP8 quantization with UE8M0 scale packing.
+    pack_id = tl.program_id(0)
+    worker = tl.program_id(1)
+    expert = tl.program_id(2)
+    workers = tl.num_programs(1)
+    count = tl.load(counts + expert)
+    tl.device_assert((count >= 0) & (count <= M), "masked_m outside capacity")
+    x_base = x + expert.to(tl.int64) * M * (2 * H)
+    out_base = out + expert.to(tl.int64) * M * H
+    scale_base = scales + (expert.to(tl.int64) * PACKED_G + pack_id) * ALIGNED_M
 
-    This kernel processes 4 consecutive groups at once and packs their scales
-    into a single int32 in UE8M0 format (extracting exponent bits from float32).
-
-    Output scale format:
-    - 4 consecutive float32 scales are packed into 1 int32
-    - packed = exp0 | (exp1 << 8) | (exp2 << 16) | (exp3 << 24)
-    - Where exp_i = (float32_bits >> 23) & 0xFF
-    """
-    expert_id = tl.program_id(2)
-    token_id = tl.program_id(1)
-    # Now this index represents a "packed group" (4 groups packed together)
-    packed_group_index = tl.program_id(0)
-
-    block_num_per_expert = tl.num_programs(1)
-
-    token_num_cur_expert = tl.load(masked_m_ptr + expert_id)
-
-    stride_input_0 = tl.cast(stride_input_0, dtype=tl.int64)
-    stride_output_0 = tl.cast(stride_output_0, dtype=tl.int64)
-    stride_input_1 = tl.cast(stride_input_1, dtype=tl.int64)
-    stride_output_1 = tl.cast(stride_output_1, dtype=tl.int64)
-
-    # Base offset for this expert
-    input_base = input_ptr + expert_id * stride_input_0
-    output_base = output_ptr + expert_id * stride_output_0
-    output_scale_base = (
-        output_scale_ptr
-        + expert_id * stride_output_scale_0
-        + packed_group_index * stride_output_scale_2
-    )
-
-    # Process 4 groups at once (each group has BLOCK_N elements)
-    # Group indices: packed_group_index * 4 + [0, 1, 2, 3]
-    base_group_idx = packed_group_index * 4
-
-    for token_index in tl.range(
-        token_id, token_num_cur_expert, block_num_per_expert, num_stages=NUM_STAGE
+    for start in tl.range(
+        worker * BLOCK_T, count, workers * BLOCK_T, num_stages=NUM_STAGES
     ):
-        # Initialize packed scale value
-        packed_scale: tl.int32 = 0
-
-        # Process 4 groups
-        for g in tl.static_range(4):
-            group_idx = base_group_idx + g
-            offs_in_d = group_idx * BLOCK_N + tl.arange(0, BLOCK_N)
-
-            # Check if this group is within bounds
-            mask = offs_in_d < size_n
-
-            # Load gate and up values (our weights: first up, then gate)
-            gate = tl.load(
-                input_base + token_index * stride_input_1 + offs_in_d + size_n,
-                mask=mask,
-                other=0.0,
-            ).to(tl.float32)
-            up = tl.load(
-                input_base + token_index * stride_input_1 + offs_in_d,
-                mask=mask,
-                other=0.0,
-            )
-
-            # SiLU activation
+        rows = start + tl.arange(0, BLOCK_T)
+        packed = tl.full((BLOCK_T,), 0, tl.int32)
+        # SM100 retains serial group processing; SM120 vectorizes four groups.
+        # Both specializations use the same arithmetic and own complete words.
+        for group_start in tl.static_range(0, 4, GROUP_TILE):
+            byte_ids = group_start + tl.arange(0, GROUP_TILE)
+            groups = pack_id * 4 + byte_ids
+            cols = groups[:, None] * GROUP_SIZE + tl.arange(0, GROUP_SIZE)[None, :]
+            valid = (rows[:, None, None] < count) & (cols[None, :, :] < H)
+            offsets = rows[:, None, None].to(tl.int64) * (2 * H) + cols[None, :, :]
+            up = tl.load(x_base + offsets, mask=valid, other=0)
+            gate = tl.load(x_base + offsets + H, mask=valid, other=0).to(tl.float32)
             gate = gate / (1 + tl.exp(-gate))
-            gate = gate.to(input_ptr.dtype.element_ty)
-            gate_up = up * gate
-
-            # Compute scale with UE8M0 rounding (power of 2)
-            _absmax = tl.maximum(tl.max(tl.abs(gate_up)), 1e-10)
-            output_s = _absmax / fp8_max
-            # Round to power of 2 (UE8M0 format requires this)
-            output_s = tl.exp2(tl.ceil(tl.log2(tl.abs(output_s))))
-
-            # Quantize to FP8
-            output_q = tl.clamp(gate_up / output_s, fp8_min, fp8_max).to(
-                output_ptr.dtype.element_ty
-            )
-
-            # Store quantized output
+            if ROUND_INTERMEDIATE:
+                gate = gate.to(x.dtype.element_ty)
+            values = up * gate
+            amax = tl.maximum(tl.max(tl.abs(values), axis=2), 1e-10)
+            scale = amax / 448.0
+            scale = tl.exp2(tl.ceil(tl.log2(tl.abs(scale))))
+            quant = tl.minimum(tl.maximum(values / scale[:, :, None], -448.0), 448.0)
             tl.store(
-                output_base + token_index * stride_output_1 + offs_in_d,
-                output_q,
-                mask=mask,
+                out_base + rows[:, None, None].to(tl.int64) * H + cols[None, :, :],
+                quant.to(out.dtype.element_ty),
+                mask=valid,
             )
+            exponent = (scale.to(tl.int32, bitcast=True) >> 23) & 255
+            exponent = tl.where(groups[None, :] < H // GROUP_SIZE, exponent, 0)
+            packed = packed | tl.sum(exponent << (byte_ids[None, :] * 8), axis=1).to(
+                tl.int32
+            )
+        tl.store(scale_base + rows, packed, mask=rows < count)
 
-            # Extract exponent from float32 scale for UE8M0 packing
-            # float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits
-            # We extract the 8 exponent bits by bitcasting to int32 and shifting
-            scale_bits = output_s.to(tl.int32, bitcast=True)
-            exp_bits = (scale_bits >> 23) & 0xFF
-
-            # Pack this exponent into the appropriate byte position
-            # Little endian: exp0 at bits[0:7], exp1 at bits[8:15], etc.
-            packed_scale = packed_scale | (exp_bits << (g * 8))
-
-        # Store packed scale (one int32 containing 4 UE8M0 exponents)
-        tl.store(
-            output_scale_base + token_index * stride_output_scale_1,
-            packed_scale,
-        )
+    # Vectorized scale-only writes; no input loads or quantization for padding.
+    # These rows never overlap the valid stores, even if counts change at replay.
+    for start in range(count + worker * BLOCK_PAD, ALIGNED_M, workers * BLOCK_PAD):
+        rows = start + tl.arange(0, BLOCK_PAD)
+        tl.store(scale_base + rows, 0, mask=rows < ALIGNED_M)
 
 
 def create_packed_scale_tensor(
@@ -772,40 +715,22 @@ def create_packed_scale_tensor(
     quant_group_size: int,
     device: torch.device,
 ) -> torch.Tensor:
+    """Allocate [E, M, ceil(G/4)] scales with 16-byte MN alignment.
+
+    hidden_dim is the concatenated up/gate dimension (2H). G=H/group_size
+    need not be divisible by four. Storage, including hidden alignment rows,
+    is initialized by silu_and_mul_masked_post_quant_packed_fwd, not here.
     """
-    Create a properly-shaped output_scale tensor for UE8M0 packed format.
-
-    The tensor is created with column-major layout for the packed dimension
-    to be compatible with deep_gemm's expected scale format.
-
-    Args:
-        expert_num: Number of experts (E)
-        token_num_padded: Padded token count per expert (T)
-        hidden_dim: Hidden dimension (2*H, before split)
-        quant_group_size: Quantization group size (typically 128)
-        device: Target device
-
-    Returns:
-        output_scale: int32 tensor with shape (E, T, G // 4) in column-major layout
-                      where G = hidden_dim // 2 // quant_group_size
-    """
-    H = hidden_dim // 2
-    G = H // quant_group_size
-    assert G % 4 == 0, "Number of groups must be divisible by 4 for UE8M0 packing"
-    G_packed = G // 4
-
-    # Create storage in column-major layout for the packed dimension
-    # Storage shape: (E, G_packed, T) to get column-major K dimension
-    packed_storage = torch.empty(
-        (expert_num, G_packed, token_num_padded),
-        device=device,
-        dtype=torch.int32,
+    assert quant_group_size > 0 and quant_group_size & (quant_group_size - 1) == 0
+    assert hidden_dim > 0 and hidden_dim % (2 * quant_group_size) == 0
+    assert expert_num >= 0 and token_num_padded >= 0
+    groups = hidden_dim // 2 // quant_group_size
+    packed_groups = triton.cdiv(groups, 4)
+    aligned_m = triton.cdiv(token_num_padded, 4) * 4
+    storage = torch.empty(
+        (expert_num, packed_groups, aligned_m), device=device, dtype=torch.int32
     )
-    # Transpose to get (E, T, G_packed) view with column-major K strides
-    # This gives strides: (G_packed * T, 1, T) for (E, T, G_packed) shape
-    output_scale = packed_storage.transpose(1, 2)
-
-    return output_scale
+    return storage.transpose(1, 2)[:, :token_num_padded, :]
 
 
 def silu_and_mul_masked_post_quant_packed_fwd(
@@ -814,74 +739,68 @@ def silu_and_mul_masked_post_quant_packed_fwd(
     output_scale: torch.Tensor,
     quant_group_size: int,
     masked_m: torch.Tensor,
-):
-    """
-    Fused SiLU-and-mul + FP8 quantization with UE8M0 scale packing.
+    *,
+    round_intermediate: bool = True,
+) -> None:
+    """Write valid FP8 rows and ALL packed scale storage without a pack pass.
 
-    This function integrates the pack_ue8m0 logic directly into the quantization kernel,
-    eliminating the need for a separate packing pass.
-
-    Args:
-        input: shape [expert_num, token_num_padded, hidden_dim], dtype bf16/fp16
-        output: shape [expert_num, token_num_padded, hidden_dim // 2], dtype fp8
-        output_scale: shape [expert_num, token_num_padded, hidden_dim // 2 // group_size // 4],
-                      dtype int32 (packed UE8M0 format), use create_packed_scale_tensor() to create
-        quant_group_size: int, typically 128
-        masked_m: shape [expert_num], number of valid tokens per expert
+    output_scale must be allocated by create_packed_scale_tensor. Counts are
+    device-resident runtime inputs, so changing routes is CUDA Graph safe.
+    The default retains the original packed producer's input-dtype intermediate
+    rounding. False matches silu_mul_masked_fp8_post_quant_fwd's FP32 arithmetic.
+    These are compile-time policies, independent of the target architecture.
     """
+    assert input.is_cuda and input.dtype in (torch.bfloat16, torch.float16)
     assert input.is_contiguous()
-    assert output.dtype == torch.float8_e4m3fn
-    assert output.is_contiguous()
-    assert len(input.shape) == 3
-    assert input.shape[0] == masked_m.shape[0]
-    assert input.shape[-1] % 2 == 0
-
-    size_n = input.shape[-1] // 2
-    assert size_n % quant_group_size == 0
-
-    num_groups = size_n // quant_group_size
+    assert input.ndim == 3
+    assert quant_group_size > 0 and quant_group_size & (quant_group_size - 1) == 0
+    experts, capacity, hidden_dim = input.shape
+    assert hidden_dim > 0 and hidden_dim % (2 * quant_group_size) == 0
+    h = hidden_dim // 2
+    packed_groups = triton.cdiv(h // quant_group_size, 4)
+    aligned_m = triton.cdiv(capacity, 4) * 4
+    assert output.shape == (experts, capacity, h)
+    assert output.dtype == torch.float8_e4m3fn and output.is_contiguous()
+    assert output_scale.dtype == torch.int32
+    assert output_scale.shape == (experts, capacity, packed_groups)
+    assert masked_m.shape == (experts,) and masked_m.dtype == torch.int32
+    assert masked_m.is_contiguous()
+    assert output.device == output_scale.device == masked_m.device == input.device
+    if experts == 0 or capacity == 0:
+        return
+    assert output_scale.stride() == (packed_groups * aligned_m, 1, aligned_m)
+    # A matching strided view need not own the final TMA padding rows (e.g.
+    # empty_strided allocates only up to the final logical element).
+    required_words = output_scale.storage_offset() + experts * packed_groups * aligned_m
     assert (
-        num_groups % 4 == 0
-    ), "Number of groups must be divisible by 4 for UE8M0 packing"
-
-    num_packed_groups = num_groups // 4
-
-    expert_num = len(masked_m)
-
-    if expert_num < 4:
-        BLOCK_NUM_PER_EXPERT = 64
+        required_words * output_scale.element_size()
+        <= output_scale.untyped_storage().nbytes()
+    )
+    if torch.cuda.get_device_capability(input.device)[0] == 12:
+        # Selected with sparse/skew/full SM120 sweeps.
+        block_t, group_tile, stages = 4, 4, 1
+        workers = min(32 if experts < 64 else 16, triton.cdiv(capacity, block_t))
     else:
-        BLOCK_NUM_PER_EXPERT = 32
-
-    BLOCK_N = quant_group_size
-    num_warps = 1
-    NUM_STAGES = 6
-
-    grid = (
-        num_packed_groups,  # Each block processes 4 groups
-        BLOCK_NUM_PER_EXPERT,
-        expert_num,
-    )
-
-    finfo = torch.finfo(torch.float8_e4m3fn)
-    fp8_max = finfo.max
-    fp8_min = -fp8_max
-
-    _silu_and_mul_post_quant_packed_kernel[grid](
+        # Preserve the original packed producer's scheduling on SM100.
+        block_t, group_tile, stages = 1, 1, 6
+        workers = 64 if experts < 4 else 32
+    _silu_and_mul_post_quant_packed_kernel[(packed_groups, workers, experts)](
         input,
-        *input.stride(),
         output,
-        *output.stride(),
         output_scale,
-        *output_scale.stride(),
         masked_m,
-        size_n,
-        fp8_max,
-        fp8_min,
-        BLOCK_N=BLOCK_N,
-        NUM_STAGE=NUM_STAGES,
+        M=capacity,
+        H=h,
+        ALIGNED_M=aligned_m,
+        PACKED_G=packed_groups,
+        BLOCK_T=block_t,
+        BLOCK_PAD=128,
+        GROUP_SIZE=quant_group_size,
+        GROUP_TILE=group_tile,
+        NUM_STAGES=stages,
+        ROUND_INTERMEDIATE=round_intermediate,
+        num_warps=4,
     )
-    return
 
 
 _SKEW_HOT_LOAD_MULTIPLIER = 8

--- a/rtp_llm/models_py/triton_kernels/common/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/common/test/BUILD
@@ -41,3 +41,31 @@ py_test(
     tags = ["H20"],
     exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
 )
+
+py_test(
+    name = "silu_mul_masked_packed_test",
+    srcs = ["silu_mul_masked_packed_test.py"],
+    deps = ["//rtp_llm/models_py/standalone:py_standalone_testlib"],
+    env = {"GPU_COUNT": "1"},
+    tags = ["RTX_5000_PRO"],
+    exec_properties = {"gpu": "RTX_5000_PRO", "gpu_count": "1"},
+)
+
+py_test(
+    name = "silu_mul_masked_packed_benchmark",
+    srcs = ["silu_mul_masked_packed_benchmark.py"],
+    deps = ["//rtp_llm/models_py/standalone:py_standalone_testlib"],
+    env = {"GPU_COUNT": "1"},
+    tags = ["manual", "open_skip", "RTX_5000_PRO"],
+    exec_properties = {"gpu": "RTX_5000_PRO", "gpu_count": "1"},
+)
+
+py_test(
+    name = "silu_mul_masked_packed_sm100_test",
+    srcs = ["silu_mul_masked_packed_test.py"],
+    main = "silu_mul_masked_packed_test.py",
+    deps = ["//rtp_llm/models_py/standalone:py_standalone_testlib"],
+    env = {"GPU_COUNT": "1"},
+    tags = ["SM100_ARM"],
+    exec_properties = {"gpu": "SM100_ARM", "gpu_count": "1"},
+)

--- a/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_benchmark.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_benchmark.py
@@ -1,0 +1,411 @@
+"""Reproducible Blackwell masked SiLU/FP8/packed-UE8M0 CUDA-graph benchmark.
+
+Run from the source root after checking develop/pro5000-opt and rebuilding the
+installed wheel to that baseline (see workspace AGENTS.md)::
+
+    python -m rtp_llm.models_py.triton_kernels.common.test.silu_mul_masked_packed_benchmark \
+        --output /tmp/sm120-packed.json
+    # Include the real masked Down GEMM, with a Qwen-sized output dimension:
+    python -m rtp_llm.models_py.triton_kernels.common.test.silu_mul_masked_packed_benchmark \
+        --shape 128,128,768 --down-hidden 2048 --output /tmp/sm120-down.json
+
+E,M,H describe expert count, per-expert token capacity and SiLU output width.
+Inputs, activation outputs, FP32 scales and fused packed scales are preallocated.
+Every baseline call zeroes the whole FP32 scale, invokes the existing activation,
+then calls the public pack launcher, including its packed-storage zeroing. Its
+allocations become fixed graph-owned allocations on replay. Thus timings include
+all device initialization and conversion work, but exclude Python dispatch and
+host allocator overhead. Fused output scales are completely overwritten by the
+kernel; they do not need an extra initialization pass. Activation output padding
+is initialized once outside timing and does not contribute to valid Down GEMM
+outputs; hardware may still load padding as part of a complete tile.
+
+Use --round-intermediate to compare the original rounded packed arithmetic
+instead of the ordinary FP32 arithmetic used by SM120.
+
+Default counts are fixed during each measurement. This is a steady-state device
+microbenchmark, not request latency or changing-routing performance. Compilation,
+input generation, weight packing, validation and graph capture are outside timing.
+"""
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_shape(value):
+    try:
+        expert_num, capacity, hidden = map(int, value.split(","))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("shape must be E,M,H") from exc
+    if min(expert_num, capacity, hidden) <= 0 or hidden % 128:
+        raise argparse.ArgumentTypeError(
+            "E,M,H must be positive and H divisible by 128"
+        )
+    return expert_num, capacity, hidden
+
+
+def make_counts(expert_num, capacity, profile):
+    if profile == "full":
+        return [capacity] * expert_num
+    if profile == "sparse":
+        return [
+            min(1 + (i // 8) % 8, capacity) if i % 8 == 0 else 0
+            for i in range(expert_num)
+        ]
+    if expert_num == 1:
+        return [max(1, capacity - 1)]
+    return [
+        capacity if i == 0 else capacity // 2 if i == 1 else int(i % 8 == 0)
+        for i in range(expert_num)
+    ]
+
+
+def capture(torch, function, warmup, inner_repeats):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(warmup):
+            function()
+    stream.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        for _ in range(inner_repeats):
+            function()
+    graph.replay()
+    torch.cuda.synchronize()
+    return graph
+
+
+def time_pair(torch, functions, args):
+    graphs = {
+        name: capture(torch, fn, args.warmup, args.inner_repeats)
+        for name, fn in functions.items()
+    }
+    samples = {name: [] for name in functions}
+    events = [torch.cuda.Event(enable_timing=True) for _ in range(2)]
+    for round_index in range(args.rounds):
+        # Alternate order to reduce systematic thermal/order bias.
+        order = list(graphs)
+        if round_index % 2:
+            order.reverse()
+        for name in order:
+            events[0].record()
+            for _ in range(args.replays):
+                graphs[name].replay()
+            events[1].record()
+            events[1].synchronize()
+            samples[name].append(
+                events[0].elapsed_time(events[1])
+                * 1000
+                / (args.inner_repeats * args.replays)
+            )
+    result = {
+        name: {
+            "median_us": statistics.median(values),
+            "min_us": min(values),
+            "max_us": max(values),
+            "round_us": values,
+        }
+        for name, values in samples.items()
+    }
+    result["speedup"] = result["baseline"]["median_us"] / result["fused"]["median_us"]
+    return result
+
+
+def benchmark_case(torch, wrapper, activation, shape, profile, args):
+    expert_num, capacity, hidden = shape
+    counts_host = make_counts(expert_num, capacity, profile)
+    expected_m = max(1, (sum(counts_host) + expert_num - 1) // expert_num)
+    counts = torch.tensor(counts_host, dtype=torch.int32, device="cuda")
+    x = torch.randn(
+        (expert_num, capacity, 2 * hidden), device="cuda", dtype=torch.bfloat16
+    )
+    baseline_out = torch.zeros(
+        (expert_num, capacity, hidden), device="cuda", dtype=torch.float8_e4m3fn
+    )
+    fused_out = torch.zeros_like(baseline_out)
+    fp32_scale = torch.zeros(
+        (expert_num, capacity, hidden // 128), device="cuda", dtype=torch.float32
+    )
+    fused_scale = activation.create_packed_scale_tensor(
+        expert_num, capacity, 2 * hidden, 128, x.device
+    )
+    aligned_capacity = fused_scale.stride(2)
+    fused_scale_storage = fused_scale.as_strided(
+        (expert_num, aligned_capacity, fused_scale.shape[2]), fused_scale.stride()
+    )
+    # Poison physical TMA padding as well as logical rows before validation.
+    fused_scale_storage.fill_(-1)
+    baseline_state = {}
+
+    def baseline():
+        fp32_scale.zero_()
+        if args.round_intermediate:
+            activation.silu_and_mul_masked_post_quant_fwd(
+                x, baseline_out, fp32_scale, 128, counts, scale_ue8m0=True
+            )
+        else:
+            activation.silu_mul_masked_fp8_post_quant_fwd(
+                x,
+                baseline_out,
+                fp32_scale,
+                128,
+                counts,
+                expected_m,
+                input_layout=activation.MaskedSiluInputLayout.PER_EXPERT_CAPACITY,
+                scale_ue8m0=True,
+            )
+        baseline_state["scale"] = wrapper.pack_ue8m0_kernel_launcher(fp32_scale, 1)
+
+    def fused_call():
+        activation.silu_and_mul_masked_post_quant_packed_fwd(
+            x,
+            fused_out,
+            fused_scale,
+            128,
+            counts,
+            round_intermediate=args.round_intermediate,
+        )
+
+    baseline()
+    fused_call()
+    valid = torch.arange(capacity, device="cuda")[None, :] < counts[:, None]
+    old_values = baseline_out.float()[valid]
+    new_values = fused_out.float()[valid]
+    old_bits = baseline_out.view(torch.uint8)[valid]
+    new_bits = fused_out.view(torch.uint8)[valid]
+    baseline_scale = baseline_state["scale"]
+    baseline_scale_storage = baseline_scale.as_strided(
+        (expert_num, aligned_capacity, baseline_scale.shape[2]),
+        baseline_scale.stride(),
+    )
+    # Include invalid rows, unused tail bytes and physical TMA padding. The
+    # public pack launcher zero-initializes the complete baseline allocation.
+    torch.testing.assert_close(
+        fused_scale_storage, baseline_scale_storage, rtol=0, atol=0
+    )
+    torch.testing.assert_close(new_bits, old_bits, rtol=0, atol=0)
+    validation = {
+        "packed_scales_exact": True,
+        "packed_physical_storage_exact": True,
+        "physical_padding_rows_per_expert": aligned_capacity - capacity,
+        "active_fp8_exact": True,
+        "active_fp8_mismatch_count": int((old_bits != new_bits).sum().item()),
+        "active_fp8_max_abs_difference": float(
+            (old_values - new_values).abs().max().item()
+        ),
+        "fp8_comparison": "bitwise_uint8",
+    }
+    result = {
+        "experts": expert_num,
+        "capacity": capacity,
+        "hidden": hidden,
+        "profile": profile,
+        "counts": counts_host,
+        "active_tokens": sum(counts_host),
+        "expected_m": expected_m,
+        "packed_scale_shape": list(fused_scale.shape),
+        "packed_scale_stride": list(fused_scale.stride()),
+        "validation": validation,
+        "activation_pack": time_pair(
+            torch, {"baseline": baseline, "fused": fused_call}, args
+        ),
+    }
+
+    if args.down_hidden:
+        # Finite FP8 values with legal, exact power-of-two unit scales. Pack
+        # weights once, outside timing, so only the activation producer differs.
+        weight = torch.randn(
+            (expert_num, args.down_hidden, hidden), device="cuda", dtype=torch.bfloat16
+        )
+        weight = weight.clamp_(-2, 2).to(torch.float8_e4m3fn)
+        weight_scale = wrapper.pack_ue8m0_kernel_launcher(
+            torch.ones(
+                (expert_num, args.down_hidden // 128, hidden // 128), device="cuda"
+            ),
+            128,
+        )
+        old_down = torch.zeros(
+            (expert_num, capacity, args.down_hidden),
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        new_down = torch.zeros_like(old_down)
+
+        def baseline_down():
+            baseline()
+            wrapper.m_grouped_fp8_gemm_nt_masked(
+                (baseline_out, baseline_state["scale"]),
+                (weight, weight_scale),
+                old_down,
+                counts,
+                expected_m,
+                disable_ue8m0_cast=False,
+            )
+
+        def fused_down():
+            fused_call()
+            wrapper.m_grouped_fp8_gemm_nt_masked(
+                (fused_out, fused_scale),
+                (weight, weight_scale),
+                new_down,
+                counts,
+                expected_m,
+                disable_ue8m0_cast=False,
+            )
+
+        baseline_down()
+        fused_down()
+        old_valid = old_down.float()[valid]
+        new_valid = new_down.float()[valid]
+        if (
+            not torch.isfinite(old_valid).all().item()
+            or not torch.isfinite(new_valid).all().item()
+        ):
+            raise AssertionError("Down GEMM produced non-finite active output")
+        normalized_rmse = (
+            (old_valid - new_valid).square().mean().sqrt()
+            / old_valid.square().mean().sqrt().clamp_min(1e-12)
+        ).item()
+        torch.testing.assert_close(
+            new_down.view(torch.int16)[valid],
+            old_down.view(torch.int16)[valid],
+            rtol=0,
+            atol=0,
+        )
+        result["down_hidden"] = args.down_hidden
+        result["validation"]["down_active_bitwise_exact"] = True
+        result["validation"]["down_normalized_rmse"] = normalized_rmse
+        result["validation"]["down_max_abs_difference"] = float(
+            (old_valid - new_valid).abs().max().item()
+        )
+        result["activation_pack_down"] = time_pair(
+            torch, {"baseline": baseline_down, "fused": fused_down}, args
+        )
+    torch.cuda.synchronize()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--shape",
+        type=parse_shape,
+        action="append",
+        help="repeatable E,M,H; H is output width",
+    )
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        choices=("sparse", "skew", "full"),
+        default=["sparse", "skew", "full"],
+    )
+    parser.add_argument(
+        "--down-hidden",
+        type=int,
+        default=0,
+        help="also benchmark Down GEMM with this output width (multiple of 128)",
+    )
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument(
+        "--inner-repeats",
+        type=int,
+        default=32,
+        help="pipeline calls captured per graph",
+    )
+    parser.add_argument(
+        "--replays", type=int, default=4, help="graph replays per timed round"
+    )
+    parser.add_argument("--rounds", type=int, default=7)
+    parser.add_argument(
+        "--round-intermediate",
+        action="store_true",
+        help="match original packed input-dtype arithmetic (default: ordinary FP32 arithmetic)",
+    )
+    parser.add_argument("--seed", type=int, default=20260907)
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument(
+        "--output", type=Path, help="also write JSON here (stdout always receives JSON)"
+    )
+    args = parser.parse_args()
+    if min(args.warmup, args.inner_repeats, args.replays, args.rounds) < 1:
+        parser.error("warmup, inner-repeats, replays and rounds must be positive")
+    if args.down_hidden < 0 or args.down_hidden % 128:
+        parser.error("down-hidden must be zero or a positive multiple of 128")
+
+    # Lazy imports keep --help usable without an installed CUDA runtime.
+    import torch
+    import triton
+
+    torch.cuda.set_device(args.device)
+    if torch.cuda.get_device_capability()[0] not in (10, 12):
+        raise RuntimeError("This benchmark requires SM100/SM120 hardware")
+    from rtp_llm.models_py.kernels.cuda import deepgemm_wrapper as wrapper
+    from rtp_llm.models_py.triton_kernels.common import activation
+
+    torch.manual_seed(args.seed)
+    shapes = args.shape or [
+        (128, 128, 768),
+        (128, 256, 768),
+        (1, 128, 384),
+        (1, 128, 512),
+        (1, 128, 1024),
+        (1, 128, 2048),
+    ]
+    source_root = Path(__file__).resolve().parents[5]
+
+    def git_output(*command):
+        run = subprocess.run(
+            ["git", "-C", str(source_root), *command], capture_output=True, text=True
+        )
+        return run.stdout.strip() if run.returncode == 0 else None
+
+    metadata = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "gpu": torch.cuda.get_device_name(),
+        "compute_capability": list(torch.cuda.get_device_capability()),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "triton": triton.__version__,
+        "source_head": git_output("rev-parse", "HEAD"),
+        "source_status": git_output("status", "--porcelain"),
+        "activation_module": activation.__file__,
+        "fused_module": activation.__file__,
+        "seed": args.seed,
+        "round_intermediate": args.round_intermediate,
+        "warmup_calls": args.warmup,
+        "calls_per_graph": args.inner_repeats,
+        "replays_per_round": args.replays,
+        "rounds": args.rounds,
+        "timing": "CUDA events around CUDA graph replay; microseconds per pipeline call",
+        "baseline_initialization": "FP32 scale zero each call; public pack launcher includes packed output zero",
+        "allocation": "preallocated buffers plus fixed graph-owned baseline pack outputs; host allocator excluded",
+        "routing": "fixed counts per case; steady-state device timing",
+        "down_weights": "synthetic finite clamped FP8, unit UE8M0 scales packed before timing",
+    }
+    report = {"metadata": metadata, "results": []}
+    for shape in shapes:
+        for profile in args.profiles:
+            print(
+                f"Benchmark E,M,H={shape} profile={profile}",
+                file=sys.stderr,
+                flush=True,
+            )
+            report["results"].append(
+                benchmark_case(torch, wrapper, activation, shape, profile, args)
+            )
+            if args.output:
+                args.output.parent.mkdir(parents=True, exist_ok=True)
+                args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_test.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/silu_mul_masked_packed_test.py
@@ -1,0 +1,289 @@
+"""Shared packed activation contract: tails and padding must not depend on memory."""
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.triton_kernels.common.activation import (
+    create_packed_scale_tensor,
+    silu_and_mul_masked_post_quant_fwd,
+    silu_and_mul_masked_post_quant_packed_fwd,
+    silu_mul_masked_fp8_post_quant_fwd,
+)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class SiluMulMaskedPackedTest(unittest.TestCase):
+    def setUp(self):
+        if torch.cuda.get_device_capability()[0] not in (10, 12):
+            self.skipTest("Blackwell required")
+        torch.manual_seed(123)
+
+    @staticmethod
+    def _run(x, out, scale, group_size, counts):
+        silu_and_mul_masked_post_quant_packed_fwd(
+            x, out, scale, group_size, counts, round_intermediate=False
+        )
+
+    def test_qwen_six_groups(self):
+        scale = create_packed_scale_tensor(3, 129, 1536, 128, torch.device("cuda"))
+        self.assertEqual(scale.shape, (3, 129, 2))
+        self.assertEqual(scale.stride(), (264, 1, 132))
+
+    def test_padding_is_overwritten(self):
+        x = torch.randn(2, 128, 1024, device="cuda", dtype=torch.bfloat16)
+        counts = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+        out = torch.empty((2, 128, 512), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(2, 128, 1024, 128, x.device)
+        scale.fill_(-1)
+        self._run(x, out, scale, 128, counts)
+        self.assertTrue(torch.all(scale[0] == 0).item())
+        self.assertTrue(torch.all(scale[1, 1:] == 0).item())
+
+    @staticmethod
+    def _storage_view(scale, e, m, h):
+        aligned_m = (m + 3) // 4 * 4
+        packed_g = (h // 128 + 3) // 4
+        return scale.as_strided(
+            (e, aligned_m, packed_g), (packed_g * aligned_m, 1, aligned_m)
+        )
+
+    def _assert_reference(
+        self, x, out, scale, counts, counts_cpu, round_intermediate=False
+    ):
+        e, m, twice_h = x.shape
+        h = twice_h // 2
+        ref_out = torch.empty_like(out)
+        ref_scale = torch.zeros((e, m, h // 128), device=x.device)
+        if round_intermediate:
+            silu_and_mul_masked_post_quant_fwd(
+                x, ref_out, ref_scale, 128, counts, scale_ue8m0=True
+            )
+        else:
+            silu_mul_masked_fp8_post_quant_fwd(
+                x,
+                ref_out,
+                ref_scale,
+                128,
+                counts,
+                expected_m=max(1, sum(counts_cpu) // e),
+                scale_ue8m0=True,
+            )
+        # Independent packing in torch, including physical alignment rows.
+        aligned_m = (m + 3) // 4 * 4
+        packed_g = (h // 128 + 3) // 4
+        exp = torch.zeros(
+            (e, aligned_m, packed_g * 4), device=x.device, dtype=torch.int64
+        )
+        exp[:, :m, : h // 128] = (
+            ref_scale.view(torch.int32).to(torch.int64) >> 23
+        ) & 255
+        exp = exp.view(e, aligned_m, packed_g, 4)
+        expected = sum(exp[..., i] << (8 * i) for i in range(4)).to(torch.int32)
+        torch.testing.assert_close(
+            self._storage_view(scale, e, m, h), expected, rtol=0, atol=0
+        )
+        for expert, n in enumerate(counts_cpu):
+            torch.testing.assert_close(
+                out[expert, :n].view(torch.uint8),
+                ref_out[expert, :n].view(torch.uint8),
+                rtol=0,
+                atol=0,
+            )
+
+    def test_tails_and_capacity_boundaries_match_unpacked(self):
+        # Six groups catches the Qwen3 shape; 1/2/3 cover TP-sized tail packs.
+        for h in (128, 256, 384, 512, 768, 1024, 2048):
+            for m in (1, 127, 128, 129, 257):
+                with self.subTest(h=h, m=m):
+                    counts_cpu = [0, 1, m]
+                    counts = torch.tensor(counts_cpu, device="cuda", dtype=torch.int32)
+                    x = torch.randn((3, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+                    x[0].fill_(float("nan"))
+                    x[1, 1:].fill_(float("nan"))
+                    out = torch.empty(
+                        (3, m, h), device="cuda", dtype=torch.float8_e4m3fn
+                    )
+                    scale = create_packed_scale_tensor(3, m, 2 * h, 128, x.device)
+                    self._storage_view(scale, 3, m, h).fill_(-1)
+                    self._run(x, out, scale, 128, counts)
+                    self._assert_reference(x, out, scale, counts, counts_cpu)
+
+    def test_single_expert_zero_and_scale_boundaries(self):
+        h, m = 768, 128
+        x = torch.zeros((1, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+        # Unequal halves detect accidentally swapping gate and up. Sweep scales
+        # across powers of two and include the all-zero epsilon case.
+        x[:, 1:, :h] = torch.logspace(-9, 4, m - 1, base=2, device="cuda")[:, None]
+        x[:, 1:, h:] = 0.75
+        counts = torch.tensor([m], device="cuda", dtype=torch.int32)
+        out = torch.empty((1, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(1, m, 2 * h, 128, x.device)
+        self._storage_view(scale, 1, m, h).fill_(-1)
+        self._run(x, out, scale, 128, counts)
+        self._assert_reference(x, out, scale, counts, [m])
+
+    def test_rounding_modes_and_input_dtypes(self):
+        # Default preserves the original packed API, including input-dtype
+        # intermediate rounding. Explicit False matches the ordinary producer.
+        for dtype in (torch.bfloat16, torch.float16):
+            for round_intermediate in (False, True):
+                for h in (128, 384, 512, 768, 2048):
+                    with self.subTest(dtype=dtype, rounded=round_intermediate, h=h):
+                        e, m = 3, 129
+                        x = torch.randn((e, m, 2 * h), device="cuda", dtype=dtype)
+                        counts_cpu = [0, 1, m]
+                        counts = torch.tensor(
+                            counts_cpu, device="cuda", dtype=torch.int32
+                        )
+                        out = torch.empty(
+                            (e, m, h), device="cuda", dtype=torch.float8_e4m3fn
+                        )
+                        scale = create_packed_scale_tensor(e, m, 2 * h, 128, x.device)
+                        self._storage_view(scale, e, m, h).fill_(-1)
+                        if round_intermediate:
+                            silu_and_mul_masked_post_quant_packed_fwd(
+                                x, out, scale, 128, counts
+                            )
+                        else:
+                            self._run(x, out, scale, 128, counts)
+                        self._assert_reference(
+                            x, out, scale, counts, counts_cpu, round_intermediate
+                        )
+
+    def test_serial_group_schedule_matches_reference(self):
+        from rtp_llm.models_py.triton_kernels.common.activation import (
+            _silu_and_mul_post_quant_packed_kernel,
+        )
+
+        # Exercise the SM100 compile-time tile and pipeline configuration on
+        # either GPU. This checks that specialization, not SM100 performance.
+        for dtype in (torch.bfloat16, torch.float16):
+            for rounded in (False, True):
+                for e in (1, 4):
+                    for h in (512, 768):
+                        with self.subTest(dtype=dtype, rounded=rounded, e=e, h=h):
+                            m, aligned_m = 129, 132
+                            counts_cpu = [m] if e == 1 else [0, 1, 127, m]
+                            counts = torch.tensor(
+                                counts_cpu, device="cuda", dtype=torch.int32
+                            )
+                            x = torch.randn((e, m, 2 * h), device="cuda", dtype=dtype)
+                            x[:, 0].zero_()
+                            out = torch.empty(
+                                (e, m, h), device="cuda", dtype=torch.float8_e4m3fn
+                            )
+                            scale = create_packed_scale_tensor(
+                                e, m, 2 * h, 128, x.device
+                            )
+                            self._storage_view(scale, e, m, h).fill_(-1)
+                            packs = (h // 128 + 3) // 4
+                            workers = 64 if e < 4 else 32
+                            _silu_and_mul_post_quant_packed_kernel[(packs, workers, e)](
+                                x,
+                                out,
+                                scale,
+                                counts,
+                                M=m,
+                                H=h,
+                                ALIGNED_M=aligned_m,
+                                PACKED_G=packs,
+                                BLOCK_T=1,
+                                BLOCK_PAD=128,
+                                GROUP_SIZE=128,
+                                GROUP_TILE=1,
+                                NUM_STAGES=6,
+                                ROUND_INTERMEDIATE=rounded,
+                                num_warps=4,
+                            )
+                            self._assert_reference(
+                                x, out, scale, counts, counts_cpu, rounded
+                            )
+
+    def test_graph_replay_overwrites_previous_routes(self):
+        e, m, h = 3, 129, 768
+        x = torch.randn((e, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+        counts = torch.tensor([m, m, m], device="cuda", dtype=torch.int32)
+        out = torch.empty((e, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(e, m, 2 * h, 128, x.device)
+
+        def run():
+            self._run(x, out, scale, 128, counts)
+
+        run()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run()
+        for counts_cpu in ([m, m, m], [1, 0, 127], [0, 0, 0], [m, 128, 1]):
+            counts.copy_(torch.tensor(counts_cpu, device="cuda", dtype=torch.int32))
+            self._storage_view(scale, e, m, h).fill_(-1)
+            graph.replay()
+            self._assert_reference(x, out, scale, counts, counts_cpu)
+
+    def test_masked_down_gemm_consumes_tail_packs(self):
+        import deep_gemm
+
+        for e in (1, 3):
+            m, h, n = 128, 768, 256
+            x = torch.randn((e, m, h * 2), device="cuda", dtype=torch.bfloat16)
+            counts_cpu = [1] if e == 1 else [0, 1, 127]
+            counts = torch.tensor(counts_cpu, device="cuda", dtype=torch.int32)
+            out = torch.empty((e, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+            scale = create_packed_scale_tensor(e, m, 2 * h, 128, x.device)
+            self._storage_view(scale, e, m, h).fill_(-1)
+            self._run(x, out, scale, 128, counts)
+            w = (torch.randn((e, n, h), device="cuda") * 0.25).to(torch.float8_e4m3fn)
+            # Packed unit scales: no conversion kernel on either operand.
+            ws = torch.full(
+                (e, 2, n), 0x7F7F7F7F, device="cuda", dtype=torch.int32
+            ).transpose(1, 2)
+            d = torch.empty((e, m, n), device="cuda", dtype=torch.bfloat16)
+            deep_gemm.m_grouped_fp8_gemm_nt_masked(
+                (out, scale),
+                (w, ws),
+                d,
+                counts,
+                max(1, sum(counts_cpu) // e),
+                disable_ue8m0_cast=False,
+            )
+            # Reference dequantization is independent of the GEMM consumer.
+            exp = torch.stack(
+                [(scale.to(torch.int64) >> (8 * i)) & 255 for i in range(4)], dim=-1
+            ).flatten(-2)[..., : h // 128]
+            sf = torch.exp2(exp.float() - 127).repeat_interleave(128, dim=-1)
+            for expert, count in enumerate(counts_cpu):
+                if count:
+                    expected = (out[expert, :count].float() * sf[expert, :count]) @ w[
+                        expert
+                    ].float().T
+                    torch.testing.assert_close(
+                        d[expert, :count].float(), expected, rtol=0.01, atol=0.08
+                    )
+
+    def test_nonzero_offset_expert_slices(self):
+        e, m, h = 3, 129, 768
+        x = torch.randn((e, m, 2 * h), device="cuda", dtype=torch.bfloat16)
+        out = torch.empty((e, m, h), device="cuda", dtype=torch.float8_e4m3fn)
+        scale = create_packed_scale_tensor(e, m, 2 * h, 128, x.device)
+        counts = torch.tensor([m, 1, 127], device="cuda", dtype=torch.int32)
+        storage = self._storage_view(scale, e, m, h)
+        storage.fill_(-1)
+        self._run(x[1:], out[1:], scale[1:], 128, counts[1:])
+        self._assert_reference(x[1:], out[1:], scale[1:], counts[1:], [1, 127])
+        self.assertTrue(torch.all(storage[0] == -1).item())
+
+    def test_rejects_storage_missing_physical_padding(self):
+        x = torch.zeros((3, 129, 1536), device="cuda", dtype=torch.bfloat16)
+        out = torch.empty((3, 129, 768), device="cuda", dtype=torch.float8_e4m3fn)
+        counts = torch.tensor([0, 1, 129], device="cuda", dtype=torch.int32)
+        # Correct logical layout but only 789 words; kernel requires 792.
+        scale = torch.empty_strided(
+            (3, 129, 2), (264, 1, 132), device="cuda", dtype=torch.int32
+        )
+        with self.assertRaises(AssertionError):
+            self._run(x, out, scale, 128, counts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

On SM120, masked MoE initializes Down GEMM FP32 scales only for valid token rows. Uninitialized padding can trigger a UE8M0 conversion assertion and surface as CUDA error 719.

The existing fused packed producer requires the scale group count to be divisible by four, excluding shapes such as Qwen3-30B-A3B's H=768 (six groups).

## Changes

- Extend the existing fused SiLU × up, FP8 quantization, and UE8M0 packing kernel for shared use on SM100 and SM120.
- Support partial packs and initialize all scale padding, including masked rows, TMA alignment rows, and unused tail bytes.
- Preserve BF16/FP16 input support and existing numerical behavior through a compile-time intermediate-rounding option.
- Retain architecture-specific launch configurations while sharing the computation.
- Enable the shared producer in both masked executors without changing routing policy.

SM100 shapes that previously used the packed path retain intermediate rounding. SM120 and SM100 shapes previously using the ordinary path retain FP32 intermediate arithmetic.

## Validation

- 25 regression tests passed; 2 expected skips.
- Compute Sanitizer: 10 kernel tests passed with zero errors.
- Eight BF16/FP16, rounding-mode, and shape combinations compiled successfully for SM100.
- On SM120, 18 benchmark cases matched the safe reference pipeline exactly and retained the previous implementation's performance.
- Qwen3-30B-A3B-FP8 completed four 64-token generation requests using the shared kernel.

 Performance results are device microbenchmarks, not end-to-end TPOT measurements.