### PR TITLE
fix(rocm): stabilize deterministic FP8 MoE execution

### DIFF
--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -502,6 +502,7 @@ py_library(
         ":config_ops",
         ":warmup",
         ":jit_cache_manager_lib",
+        "//rtp_llm/models_py/kernel_tuning",
     ],
     data = jit_deps(),
     imports = ["."],

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -59,6 +59,7 @@ py_library(
         ":utils",
         ":tile_kernels_mhc",
         "//rtp_llm:warmup",
+        "//rtp_llm/models_py/kernel_tuning",
         "//rtp_llm/models_py/triton_kernels:triton_kernels",
         "//rtp_llm/models_py/distributed:deepep_wrapper",
         "//rtp_llm/models_py/distributed:moriep_wrapper",

--- a/rtp_llm/models_py/kernel_tuning/BUILD
+++ b/rtp_llm/models_py/kernel_tuning/BUILD
@@ -1,0 +1,32 @@
+py_library(
+    name = "kernel_tuning",
+    srcs = glob([
+        "*.py",
+        "aiter/*.py",
+    ]),
+    data = glob([
+        "aiter/configs/*.csv",
+    ]),
+    deps = [
+        "//rtp_llm:torch",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "aiter_fmoe_test",
+    srcs = ["test/aiter_fmoe_test.py"],
+    main = "test/aiter_fmoe_test.py",
+    data = [
+        "@rtp_deps//:requirements_lock_rocm.txt",
+        "@rtp_deps//:requirements_rocm.txt",
+    ],
+    deps = [":kernel_tuning"],
+)
+
+py_test(
+    name = "registry_test",
+    srcs = ["test/registry_test.py"],
+    main = "test/registry_test.py",
+    deps = [":kernel_tuning"],
+)

--- a/rtp_llm/models_py/kernel_tuning/__init__.py
+++ b/rtp_llm/models_py/kernel_tuning/__init__.py
@@ -1,0 +1,4 @@
+from rtp_llm.models_py.kernel_tuning.registry import configure_kernel_tuning
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+__all__ = ["KernelTuningStatus", "configure_kernel_tuning"]

--- a/rtp_llm/models_py/kernel_tuning/__init__.py
+++ b/rtp_llm/models_py/kernel_tuning/__init__.py
@@ -1,4 +1,13 @@
-from rtp_llm.models_py.kernel_tuning.registry import configure_kernel_tuning
+from rtp_llm.models_py.kernel_tuning.registry import (
+    ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV,
+    configure_kernel_tuning,
+    is_rocm_fp8_moe_deterministic_reduce_enabled,
+)
 from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
 
-__all__ = ["KernelTuningStatus", "configure_kernel_tuning"]
+__all__ = [
+    "KernelTuningStatus",
+    "ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV",
+    "configure_kernel_tuning",
+    "is_rocm_fp8_moe_deterministic_reduce_enabled",
+]

--- a/rtp_llm/models_py/kernel_tuning/aiter/__init__.py
+++ b/rtp_llm/models_py/kernel_tuning/aiter/__init__.py
@@ -1,0 +1,17 @@
+from rtp_llm.models_py.kernel_tuning.aiter.fmoe import (
+    AITER_FMOE_GFX942_OVERLAY,
+    AITER_FMOE_SUPPORTED_VERSION,
+    AiterFmoeWorkloadSignature,
+    configure_aiter_fmoe_overlays,
+    is_affected_aiter_fmoe_signature,
+    require_aiter_fmoe_tuning,
+)
+
+__all__ = [
+    "AITER_FMOE_GFX942_OVERLAY",
+    "AITER_FMOE_SUPPORTED_VERSION",
+    "AiterFmoeWorkloadSignature",
+    "configure_aiter_fmoe_overlays",
+    "is_affected_aiter_fmoe_signature",
+    "require_aiter_fmoe_tuning",
+]

--- a/rtp_llm/models_py/kernel_tuning/aiter/configs/gfx942_cu80_fmoe_m1_16_h2048_i128_e256_topk8_bf16_fp8pt.csv
+++ b/rtp_llm/models_py/kernel_tuning/aiter/configs/gfx942_cu80_fmoe_m1_16_h2048_i128_e256_topk8_bf16_fp8pt.csv
@@ -1,0 +1,6 @@
+cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,block_m,ksplit,us1,kernelName1,err1,us2,kernelName2,err2,us,run_1stage,tflops,bw,_tag
+80,1,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,2,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,4,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,8,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,16,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,

--- a/rtp_llm/models_py/kernel_tuning/aiter/fmoe.py
+++ b/rtp_llm/models_py/kernel_tuning/aiter/fmoe.py
@@ -1,0 +1,331 @@
+import csv
+import hashlib
+import importlib.metadata
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+_LOGGER = logging.getLogger(__name__)
+
+AITER_FMOE_GFX942_OVERLAY = (
+    "aiter_fmoe_gfx942_cu80_m1_16_h2048_i128_e256_topk8_bf16_fp8pt"
+)
+AITER_FMOE_SUPPORTED_VERSION = "0.1.21.dev80+g987203ba5.d20260825"
+_SUPPORTED_DEFAULT_CONFIG_SHA256 = (
+    "00a7d76ae7c49760b2bb389d9cd38887713878f139dc49ff3b0af5dc65a6039f"
+)
+_OVERLAY_CONFIG = (
+    Path(__file__).resolve().parent
+    / "configs"
+    / "gfx942_cu80_fmoe_m1_16_h2048_i128_e256_topk8_bf16_fp8pt.csv"
+)
+_DISPATCH_KEY_FIELDS = (
+    "cu_num",
+    "token",
+    "model_dim",
+    "inter_dim",
+    "expert",
+    "topk",
+    "act_type",
+    "dtype",
+    "q_dtype_a",
+    "q_dtype_w",
+    "q_type",
+    "use_g1u1",
+    "doweight_stage1",
+)
+_AFFECTED_TOKEN_BUCKETS = (1, 2, 4, 8, 16)
+
+
+@dataclass(frozen=True)
+class AiterFmoeWorkloadSignature:
+    """Static portion of the AITER FMoE dispatch key.
+
+    Tensor-parallel, expert-parallel, and model identity are intentionally
+    absent. They matter only through the local workload passed to AITER.
+    """
+
+    gfx: str
+    cu_num: int
+    model_dim: int
+    inter_dim: int
+    expert: int
+    topk: int
+    act_type: str
+    dtype: str
+    q_dtype_a: str
+    q_dtype_w: str
+    q_type: str
+    use_g1u1: int
+    doweight_stage1: int
+
+
+_AFFECTED_WORKLOAD_SIGNATURES = frozenset(
+    {
+        AiterFmoeWorkloadSignature(
+            gfx="gfx942",
+            cu_num=80,
+            model_dim=2048,
+            inter_dim=128,
+            expert=256,
+            topk=8,
+            act_type="ActivationType.Silu",
+            dtype="torch.bfloat16",
+            q_dtype_a="torch.float8_e4m3fnuz",
+            q_dtype_w="torch.float8_e4m3fnuz",
+            q_type="QuantType.per_Token",
+            use_g1u1=1,
+            doweight_stage1=0,
+        )
+    }
+)
+
+_CONFIG_STATUS: Optional[KernelTuningStatus] = None
+
+
+def is_affected_aiter_fmoe_signature(
+    signature: AiterFmoeWorkloadSignature,
+) -> bool:
+    return signature in _AFFECTED_WORKLOAD_SIGNATURES
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _stock_fmoe_configs(default_config: Path) -> list[Path]:
+    model_config_dir = default_config.parent / "model_configs"
+    model_configs = sorted(
+        path
+        for path in model_config_dir.glob("*tuned_fmoe*.csv")
+        if path.is_file() and "untuned" not in path.name
+    )
+    return [default_config, *model_configs]
+
+
+def _dispatch_keys(config: Path) -> set[tuple[str, ...]]:
+    with config.open(newline="") as source:
+        reader = csv.DictReader(source)
+        fieldnames = set(reader.fieldnames or ())
+        missing = set(_DISPATCH_KEY_FIELDS) - fieldnames
+        if missing:
+            raise ValueError(
+                f"{config} is missing AITER FMoE dispatch columns: {sorted(missing)}"
+            )
+        return {
+            tuple((row.get(field) or "").strip() for field in _DISPATCH_KEY_FIELDS)
+            for row in reader
+        }
+
+
+def _validated_overlay_dispatch_keys(config: Path) -> set[tuple[str, ...]]:
+    with config.open(newline="") as source:
+        reader = csv.DictReader(source)
+        fieldnames = set(reader.fieldnames or ())
+        missing = set(_DISPATCH_KEY_FIELDS) - fieldnames
+        if missing:
+            raise ValueError(
+                f"{config} is missing AITER FMoE dispatch columns: {sorted(missing)}"
+            )
+        rows = list(reader)
+
+    tagged_rows = [row for row in rows if (row.get("_tag") or "").strip()]
+    if tagged_rows:
+        raise ValueError(
+            f"{config} has non-empty _tag values; AITER excludes tagged rows from "
+            "normal FMoE dispatch"
+        )
+
+    actual_keys = {
+        tuple((row.get(field) or "").strip() for field in _DISPATCH_KEY_FIELDS)
+        for row in rows
+    }
+    expected_keys = {
+        tuple(
+            str(token if field == "token" else getattr(signature, field))
+            for field in _DISPATCH_KEY_FIELDS
+        )
+        for signature in _AFFECTED_WORKLOAD_SIGNATURES
+        for token in _AFFECTED_TOKEN_BUCKETS
+    }
+    if actual_keys != expected_keys or len(rows) != len(expected_keys):
+        raise ValueError(
+            f"{config} dispatch rows do not match the declared affected workload "
+            f"signatures and token buckets {_AFFECTED_TOKEN_BUCKETS}"
+        )
+    return actual_keys
+
+
+def _validate_no_overlay_dispatch_collisions(
+    overlay_config: Path,
+    overlay_keys: set[tuple[str, ...]],
+    config_paths: list[Path],
+) -> None:
+    for config_path in config_paths:
+        if config_path == overlay_config:
+            continue
+        duplicate_keys = overlay_keys & _dispatch_keys(config_path)
+        if duplicate_keys:
+            raise ValueError(
+                f"{config_path} overlaps the RTP AITER FMoE overlay "
+                f"{overlay_config}"
+            )
+
+
+def _validated_explicit_config_paths(
+    value: str,
+    overlay_config: Path,
+    overlay_keys: set[tuple[str, ...]],
+) -> list[Path]:
+    raw_paths = value.split(os.pathsep)
+    if any(not raw_path.strip() for raw_path in raw_paths):
+        raise ValueError("AITER_CONFIG_FMOE contains an empty config path")
+
+    config_paths = [Path(raw_path).expanduser().resolve() for raw_path in raw_paths]
+    duplicate_paths = sorted(
+        {str(path) for path in config_paths if config_paths.count(path) > 1}
+    )
+    if duplicate_paths:
+        raise ValueError(
+            "AITER_CONFIG_FMOE contains duplicate config paths: " f"{duplicate_paths}"
+        )
+
+    overlay_count = config_paths.count(overlay_config)
+    if overlay_count != 1:
+        raise ValueError(
+            "AITER_CONFIG_FMOE must contain the RTP overlay exactly once; "
+            f"found {overlay_count} occurrences of {overlay_config}"
+        )
+
+    missing_paths = [str(path) for path in config_paths if not path.is_file()]
+    if missing_paths:
+        raise OSError(
+            "AITER_CONFIG_FMOE contains missing or non-file config paths: "
+            f"{missing_paths}"
+        )
+
+    _validate_no_overlay_dispatch_collisions(overlay_config, overlay_keys, config_paths)
+    return config_paths
+
+
+def _status(
+    applied: bool, reason: str, version: Optional[str] = None
+) -> KernelTuningStatus:
+    return KernelTuningStatus(
+        overlay=AITER_FMOE_GFX942_OVERLAY,
+        applied=applied,
+        reason=reason,
+        dependency_version=version,
+    )
+
+
+def configure_aiter_fmoe_overlays() -> KernelTuningStatus:
+    """Append reviewed RTP dispatch rows before AITER's first FMoE lookup."""
+
+    global _CONFIG_STATUS
+    if _CONFIG_STATUS is not None:
+        return _CONFIG_STATUS
+
+    try:
+        distribution = importlib.metadata.distribution("aiter")
+    except importlib.metadata.PackageNotFoundError:
+        _CONFIG_STATUS = _status(False, "aiter is not installed")
+        return _CONFIG_STATUS
+
+    version = distribution.version
+    if version != AITER_FMOE_SUPPORTED_VERSION:
+        _CONFIG_STATUS = _status(
+            False,
+            "unsupported AITER version; review whether the overlay is still needed",
+            version,
+        )
+        return _CONFIG_STATUS
+
+    default_config = Path(
+        distribution.locate_file("aiter/configs/tuned_fmoe.csv")
+    ).resolve()
+    if not default_config.is_file():
+        _CONFIG_STATUS = _status(
+            False, f"AITER default FMoE config is missing: {default_config}", version
+        )
+        return _CONFIG_STATUS
+
+    actual_sha256 = _sha256(default_config)
+    if actual_sha256 != _SUPPORTED_DEFAULT_CONFIG_SHA256:
+        _CONFIG_STATUS = _status(
+            False,
+            "AITER default FMoE config changed; review the RTP overlay before use "
+            f"(expected {_SUPPORTED_DEFAULT_CONFIG_SHA256}, got {actual_sha256})",
+            version,
+        )
+        return _CONFIG_STATUS
+
+    overlay_config = _OVERLAY_CONFIG.resolve()
+    if not overlay_config.is_file():
+        _CONFIG_STATUS = _status(
+            False, f"RTP AITER FMoE overlay is missing: {overlay_config}", version
+        )
+        return _CONFIG_STATUS
+
+    stock_configs = _stock_fmoe_configs(default_config)
+    try:
+        overlay_keys = _validated_overlay_dispatch_keys(overlay_config)
+        _validate_no_overlay_dispatch_collisions(
+            overlay_config, overlay_keys, stock_configs
+        )
+    except (OSError, ValueError) as error:
+        _CONFIG_STATUS = _status(
+            False, f"failed to validate AITER FMoE config keys: {error}", version
+        )
+        return _CONFIG_STATUS
+
+    existing = os.environ.get("AITER_CONFIG_FMOE")
+    if existing:
+        try:
+            _validated_explicit_config_paths(existing, overlay_config, overlay_keys)
+        except (OSError, ValueError) as error:
+            _CONFIG_STATUS = _status(
+                False,
+                f"failed to validate explicit AITER_CONFIG_FMOE: {error}",
+                version,
+            )
+            return _CONFIG_STATUS
+    else:
+        config_paths = [*stock_configs, overlay_config]
+        os.environ["AITER_CONFIG_FMOE"] = os.pathsep.join(map(str, config_paths))
+
+    _CONFIG_STATUS = _status(True, "RTP AITER FMoE overlay configured", version)
+    _LOGGER.info(
+        "Configured kernel tuning overlay %s from %s",
+        AITER_FMOE_GFX942_OVERLAY,
+        overlay_config,
+    )
+    return _CONFIG_STATUS
+
+
+def require_aiter_fmoe_tuning(signature: AiterFmoeWorkloadSignature) -> None:
+    """Fail closed only for a workload with known-bad stock dispatch rows."""
+
+    if not is_affected_aiter_fmoe_signature(signature):
+        _LOGGER.debug(
+            "AITER FMoE tuning overlay is not required for workload signature: %s",
+            signature,
+        )
+        return
+    status = configure_aiter_fmoe_overlays()
+    if status.applied:
+        return
+    raise RuntimeError(
+        "The AITER FMoE workload signature "
+        f"{signature} for token buckets {_AFFECTED_TOKEN_BUCKETS} requires the "
+        f"reviewed one-stage tuning overlay, but it is inactive: {status.reason}. "
+        "Revalidate the small-token FMoE kernels and update or remove the overlay."
+    )

--- a/rtp_llm/models_py/kernel_tuning/registry.py
+++ b/rtp_llm/models_py/kernel_tuning/registry.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Optional
+
+import torch
+
+from rtp_llm.models_py.kernel_tuning.aiter.fmoe import configure_aiter_fmoe_overlays
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+_LOGGER = logging.getLogger(__name__)
+
+_PROVIDERS_BY_ARCH = {
+    "gfx942": (configure_aiter_fmoe_overlays,),
+}
+
+
+def _current_rocm_arch() -> Optional[str]:
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        return None
+    try:
+        properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+        return str(getattr(properties, "gcnArchName", "")).split(":", 1)[0] or None
+    except Exception as error:
+        _LOGGER.warning("Failed to resolve the current ROCm architecture: %s", error)
+        return None
+
+
+def configure_kernel_tuning(
+    arch: Optional[str] = None,
+) -> tuple[KernelTuningStatus, ...]:
+    """Configure registered kernel-tuning providers for the current device."""
+
+    resolved_arch = arch if arch is not None else _current_rocm_arch()
+    statuses = tuple(
+        provider() for provider in _PROVIDERS_BY_ARCH.get(resolved_arch, ())
+    )
+    for status in statuses:
+        if not status.applied:
+            _LOGGER.warning(
+                "Kernel tuning overlay %s is inactive: %s",
+                status.overlay,
+                status.reason,
+            )
+    return statuses

--- a/rtp_llm/models_py/kernel_tuning/registry.py
+++ b/rtp_llm/models_py/kernel_tuning/registry.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Optional
 
 import torch
@@ -8,9 +9,15 @@ from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
 
 _LOGGER = logging.getLogger(__name__)
 
+ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV = "RTP_LLM_ROCM_FP8_MOE_DETERMINISTIC_REDUCE"
+
 _PROVIDERS_BY_ARCH = {
     "gfx942": (configure_aiter_fmoe_overlays,),
 }
+
+
+def is_rocm_fp8_moe_deterministic_reduce_enabled() -> bool:
+    return os.environ.get(ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV, "0") == "1"
 
 
 def _current_rocm_arch() -> Optional[str]:
@@ -28,6 +35,9 @@ def configure_kernel_tuning(
     arch: Optional[str] = None,
 ) -> tuple[KernelTuningStatus, ...]:
     """Configure registered kernel-tuning providers for the current device."""
+
+    if not is_rocm_fp8_moe_deterministic_reduce_enabled():
+        return ()
 
     resolved_arch = arch if arch is not None else _current_rocm_arch()
     statuses = tuple(

--- a/rtp_llm/models_py/kernel_tuning/test/aiter_fmoe_test.py
+++ b/rtp_llm/models_py/kernel_tuning/test/aiter_fmoe_test.py
@@ -1,0 +1,340 @@
+import csv
+import hashlib
+import os
+import re
+import tempfile
+import unittest
+from dataclasses import fields, replace
+from pathlib import Path
+from unittest import mock
+from urllib.parse import unquote
+
+from rtp_llm.models_py.kernel_tuning.aiter import fmoe
+
+_AITER_WHEEL_VERSION_PATTERN = re.compile(
+    r"/aiter/aiter-([^/\s]+)-cp\d+-cp\d+-linux_x86_64\.whl"
+)
+
+
+def _runfile(path: str) -> Path:
+    test_srcdir = os.environ.get("TEST_SRCDIR")
+    if test_srcdir:
+        return Path(test_srcdir) / path
+    return Path(path.replace("rtp_deps/", "deps/", 1))
+
+
+class _FakeDistribution:
+    def __init__(self, root: Path, version: str):
+        self._root = root
+        self.version = version
+
+    def locate_file(self, path: str) -> Path:
+        return self._root / path
+
+
+class AiterFmoeTuningTest(unittest.TestCase):
+    def setUp(self):
+        self._old_env = os.environ.pop("AITER_CONFIG_FMOE", None)
+        fmoe._CONFIG_STATUS = None
+
+    def tearDown(self):
+        if self._old_env is not None:
+            os.environ["AITER_CONFIG_FMOE"] = self._old_env
+        else:
+            os.environ.pop("AITER_CONFIG_FMOE", None)
+        fmoe._CONFIG_STATUS = None
+
+    def _write_config(
+        self, path: Path, tokens: tuple[int, ...] = (64,), tag: str = ""
+    ) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        row = {
+            "cu_num": "80",
+            "model_dim": "2048",
+            "inter_dim": "128",
+            "expert": "256",
+            "topk": "8",
+            "act_type": "ActivationType.Silu",
+            "dtype": "torch.bfloat16",
+            "q_dtype_a": "torch.float8_e4m3fnuz",
+            "q_dtype_w": "torch.float8_e4m3fnuz",
+            "q_type": "QuantType.per_Token",
+            "use_g1u1": "1",
+            "doweight_stage1": "0",
+            "_tag": tag,
+        }
+        with path.open("w", newline="") as destination:
+            writer = csv.DictWriter(
+                destination, fieldnames=(*fmoe._DISPATCH_KEY_FIELDS, "_tag")
+            )
+            writer.writeheader()
+            for token in tokens:
+                writer.writerow({**row, "token": str(token)})
+
+    def _fixture(self, root: Path, stock_token: int = 64):
+        config_dir = root / "aiter" / "configs"
+        default_config = config_dir / "tuned_fmoe.csv"
+        model_config = config_dir / "model_configs" / "model_tuned_fmoe.csv"
+        overlay_config = root / "rtp_overlay.csv"
+        self._write_config(default_config, (stock_token,))
+        self._write_config(model_config, (stock_token + 1,))
+        self._write_config(overlay_config, fmoe._AFFECTED_TOKEN_BUCKETS)
+        return default_config, model_config, overlay_config
+
+    def _configure(self, root: Path, default_config: Path, overlay_config: Path):
+        default_hash = hashlib.sha256(default_config.read_bytes()).hexdigest()
+        distribution = _FakeDistribution(root, fmoe.AITER_FMOE_SUPPORTED_VERSION)
+        return mock.patch.multiple(
+            fmoe,
+            _SUPPORTED_DEFAULT_CONFIG_SHA256=default_hash,
+            _OVERLAY_CONFIG=overlay_config,
+        ), mock.patch.object(
+            fmoe.importlib.metadata, "distribution", return_value=distribution
+        )
+
+    def test_configures_additive_overlay_and_keeps_model_configs(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, model_config, overlay_config = self._fixture(root)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertTrue(status.applied)
+            self.assertEqual(
+                os.environ["AITER_CONFIG_FMOE"].split(os.pathsep),
+                [str(default_config), str(model_config), str(overlay_config)],
+            )
+
+    def test_stock_dispatch_collision_requires_review(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root, stock_token=1)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("overlap", status.reason)
+
+    def test_nonempty_overlay_tag_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            self._write_config(
+                overlay_config,
+                fmoe._AFFECTED_TOKEN_BUCKETS,
+                tag="not-used-for-normal-dispatch",
+            )
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("excludes tagged rows", status.reason)
+
+    def test_version_change_requires_review_for_affected_signature(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._fixture(root)
+            distribution = _FakeDistribution(root, "new-aiter-version")
+            with mock.patch.object(
+                fmoe.importlib.metadata,
+                "distribution",
+                return_value=distribution,
+            ):
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("review", status.reason)
+            with self.assertRaisesRegex(RuntimeError, "Revalidate"):
+                fmoe.require_aiter_fmoe_tuning(self._affected_signature())
+
+    def test_supported_version_matches_pinned_rocm_wheel(self):
+        for requirements_path in (
+            "rtp_deps/requirements_rocm.txt",
+            "rtp_deps/requirements_lock_rocm.txt",
+        ):
+            with self.subTest(requirements_path=requirements_path):
+                requirements = _runfile(requirements_path).read_text()
+                versions = {
+                    unquote(match.group(1))
+                    for match in _AITER_WHEEL_VERSION_PATTERN.finditer(requirements)
+                }
+                self.assertEqual(versions, {fmoe.AITER_FMOE_SUPPORTED_VERSION})
+
+    def test_installed_aiter_matches_supported_artifacts_when_available(self):
+        try:
+            distribution = fmoe.importlib.metadata.distribution("aiter")
+        except fmoe.importlib.metadata.PackageNotFoundError:
+            self.skipTest("aiter is not installed in this test environment")
+
+        self.assertEqual(distribution.version, fmoe.AITER_FMOE_SUPPORTED_VERSION)
+        default_config = Path(
+            distribution.locate_file("aiter/configs/tuned_fmoe.csv")
+        ).resolve()
+        self.assertTrue(default_config.is_file())
+        self.assertEqual(
+            fmoe._sha256(default_config), fmoe._SUPPORTED_DEFAULT_CONFIG_SHA256
+        )
+
+    def test_explicit_config_must_include_overlay(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            os.environ["AITER_CONFIG_FMOE"] = str(default_config)
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("exactly once", status.reason)
+
+    def test_valid_explicit_config_set_is_accepted_without_rewriting(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, model_config, overlay_config = self._fixture(root)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            explicit = os.pathsep.join(
+                map(str, (default_config, model_config, overlay_config))
+            )
+            os.environ["AITER_CONFIG_FMOE"] = explicit
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertTrue(status.applied)
+            self.assertEqual(os.environ["AITER_CONFIG_FMOE"], explicit)
+
+    def test_explicit_config_rejects_missing_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            missing_config = root / "missing.csv"
+            os.environ["AITER_CONFIG_FMOE"] = os.pathsep.join(
+                map(str, (missing_config, overlay_config))
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("missing or non-file", status.reason)
+
+    def test_explicit_config_rejects_unreadable_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            unreadable_config = root / "unreadable.csv"
+            self._write_config(unreadable_config)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            os.environ["AITER_CONFIG_FMOE"] = os.pathsep.join(
+                map(str, (unreadable_config, overlay_config))
+            )
+            original_dispatch_keys = fmoe._dispatch_keys
+
+            def dispatch_keys(path):
+                if path == unreadable_config:
+                    raise PermissionError(f"cannot read {path}")
+                return original_dispatch_keys(path)
+
+            with (
+                config_patch,
+                distribution_patch,
+                mock.patch.object(fmoe, "_dispatch_keys", side_effect=dispatch_keys),
+            ):
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("failed to validate explicit", status.reason)
+
+    def test_explicit_config_rejects_duplicate_overlay(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            os.environ["AITER_CONFIG_FMOE"] = os.pathsep.join(
+                map(str, (default_config, overlay_config, overlay_config))
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("duplicate config paths", status.reason)
+
+    def test_explicit_config_rejects_overlay_dispatch_collision(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            colliding_config = root / "colliding.csv"
+            self._write_config(colliding_config, (1,))
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            os.environ["AITER_CONFIG_FMOE"] = os.pathsep.join(
+                map(str, (colliding_config, overlay_config))
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("overlaps", status.reason)
+
+    def test_signature_is_shape_based_not_model_or_parallelism_based(self):
+        signature = self._affected_signature()
+        self.assertTrue(fmoe.is_affected_aiter_fmoe_signature(signature))
+        self.assertNotIn("model", {field.name for field in fields(signature)})
+        self.assertNotIn("tp_size", {field.name for field in fields(signature)})
+        self.assertNotIn("ep_size", {field.name for field in fields(signature)})
+
+        for name, value in (
+            ("gfx", "gfx950"),
+            ("cu_num", 79),
+            ("model_dim", 4096),
+            ("inter_dim", 256),
+            ("expert", 128),
+            ("topk", 4),
+            ("dtype", "torch.float16"),
+            ("use_g1u1", 0),
+        ):
+            with self.subTest(field=name):
+                self.assertFalse(
+                    fmoe.is_affected_aiter_fmoe_signature(
+                        replace(signature, **{name: value})
+                    )
+                )
+
+    def test_unaffected_signature_does_not_require_an_active_overlay(self):
+        fmoe._CONFIG_STATUS = fmoe._status(False, "inactive")
+        fmoe.require_aiter_fmoe_tuning(
+            replace(self._affected_signature(), inter_dim=256)
+        )
+
+    def test_bundled_overlay_matches_declared_dispatch_rows(self):
+        self.assertEqual(
+            len(fmoe._validated_overlay_dispatch_keys(fmoe._OVERLAY_CONFIG)),
+            len(fmoe._AFFECTED_TOKEN_BUCKETS),
+        )
+
+    @staticmethod
+    def _affected_signature():
+        return next(iter(fmoe._AFFECTED_WORKLOAD_SIGNATURES))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/kernel_tuning/test/registry_test.py
+++ b/rtp_llm/models_py/kernel_tuning/test/registry_test.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest import mock
+
+from rtp_llm.models_py.kernel_tuning import registry
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+
+class KernelTuningRegistryTest(unittest.TestCase):
+    def test_provider_is_selected_by_compute_architecture(self):
+        status = KernelTuningStatus("test", True, "configured")
+        provider = mock.Mock(return_value=status)
+        with mock.patch.dict(
+            registry._PROVIDERS_BY_ARCH, {"gfx942": (provider,)}, clear=True
+        ):
+            self.assertEqual(registry.configure_kernel_tuning("gfx942"), (status,))
+            self.assertEqual(registry.configure_kernel_tuning("gfx950"), ())
+        provider.assert_called_once_with()
+
+    def test_current_arch_uses_rocm_device_properties(self):
+        properties = mock.Mock(gcnArchName="gfx942:sramecc+:xnack-")
+        with mock.patch.object(
+            registry.torch.cuda, "is_available", return_value=True
+        ), mock.patch.object(registry.torch.version, "hip", "7.0"), mock.patch.object(
+            registry.torch.cuda, "current_device", return_value=2
+        ), mock.patch.object(
+            registry.torch.cuda,
+            "get_device_properties",
+            return_value=properties,
+        ):
+            self.assertEqual(registry._current_rocm_arch(), "gfx942")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/kernel_tuning/test/registry_test.py
+++ b/rtp_llm/models_py/kernel_tuning/test/registry_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest import mock
 
@@ -11,10 +12,21 @@ class KernelTuningRegistryTest(unittest.TestCase):
         provider = mock.Mock(return_value=status)
         with mock.patch.dict(
             registry._PROVIDERS_BY_ARCH, {"gfx942": (provider,)}, clear=True
+        ), mock.patch.dict(
+            os.environ,
+            {registry.ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV: "1"},
         ):
             self.assertEqual(registry.configure_kernel_tuning("gfx942"), (status,))
             self.assertEqual(registry.configure_kernel_tuning("gfx950"), ())
         provider.assert_called_once_with()
+
+    def test_providers_are_not_called_when_feature_is_disabled(self):
+        provider = mock.Mock()
+        with mock.patch.dict(
+            registry._PROVIDERS_BY_ARCH, {"gfx942": (provider,)}, clear=True
+        ), mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(registry.configure_kernel_tuning("gfx942"), ())
+        provider.assert_not_called()
 
     def test_current_arch_uses_rocm_device_properties(self):
         properties = mock.Mock(gcnArchName="gfx942:sramecc+:xnack-")

--- a/rtp_llm/models_py/kernel_tuning/types.py
+++ b/rtp_llm/models_py/kernel_tuning/types.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class KernelTuningStatus:
+    overlay: str
+    applied: bool
+    reason: str
+    dependency_version: Optional[str] = None

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import aiter
 import torch
 
+from rtp_llm.models_py.kernel_tuning import is_rocm_fp8_moe_deterministic_reduce_enabled
 from rtp_llm.models_py.modules.factory.attention import common
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.models_py.modules.factory.attention.rocm_impl._attn_utils import (
@@ -828,21 +829,30 @@ class AiterPrefillAttnOpPaged:
             device=self.graph_device, dtype=torch.int32
         )
         batch_size = fmha_params.cu_seqlens_q.shape[0] - 1
-        bt = fmha_params.kv_cache_block_id_device
-        extra_pages = (128 + self.tokens_per_block - 1) // self.tokens_per_block
-        required_shape = (batch_size, bt.shape[1] + extra_pages)
-        buffer = self.sanitized_bt_buf
-        if buffer is not None and (
-            buffer.shape != required_shape or buffer.device != self.graph_device
+        stability_enabled = is_rocm_fp8_moe_deterministic_reduce_enabled()
+        if self.seqlen_k_buf is None or (
+            not stability_enabled and self.seqlen_k_buf.shape[0] < batch_size
         ):
-            raise ValueError("Aiter graph buffer changed; recapture required")
-        if self.seqlen_k_buf is None or self.seqlen_k_buf.shape[0] < batch_size:
             self.seqlen_k_buf = torch.empty(
                 max(1, batch_size), dtype=torch.int32, device=self.graph_device
             )
-        if self.kv_indptr_buf is None or self.kv_indptr_buf.shape[0] < batch_size + 1:
+        elif self.seqlen_k_buf.shape[0] < batch_size:
+            raise ValueError(
+                "Aiter paged-prefill CUDA graph replay exceeds the captured "
+                f"seqlen_k capacity: capture={self.seqlen_k_buf.shape[0]}, "
+                f"replay={batch_size}"
+            )
+        if self.kv_indptr_buf is None or (
+            not stability_enabled and self.kv_indptr_buf.shape[0] < batch_size + 1
+        ):
             self.kv_indptr_buf = torch.zeros(
                 max(1, batch_size + 1), dtype=torch.int32, device=self.graph_device
+            )
+        elif self.kv_indptr_buf.shape[0] < batch_size + 1:
+            raise ValueError(
+                "Aiter paged-prefill CUDA graph replay exceeds the captured "
+                f"kv_indptr capacity: capture={self.kv_indptr_buf.shape[0]}, "
+                f"replay={batch_size + 1}"
             )
         if self.kv_page_indices_buf is None:
             self.kv_page_indices_buf = torch.zeros(
@@ -852,9 +862,40 @@ class AiterPrefillAttnOpPaged:
             self.descale_buf = torch.ones(
                 1, dtype=torch.float32, device=self.graph_device
             )
-        if self.sanitized_bt_buf is None:
+        # Pre-allocate a fixed-address buffer for the sanitized+padded block_table.
+        # CUDA graph replay requires stable tensor addresses; sanitize produces a
+        # new tensor each call, so we copy_ into this fixed buffer.
+        bt = fmha_params.kv_cache_block_id_device
+        extra_pages = (128 + self.tokens_per_block - 1) // self.tokens_per_block
+        max_cols = bt.shape[1] + extra_pages
+        if not stability_enabled:
+            required_shape = (batch_size, max_cols)
+            buffer = self.sanitized_bt_buf
+            if buffer is not None and (
+                buffer.shape != required_shape or buffer.device != self.graph_device
+            ):
+                raise ValueError("Aiter graph buffer changed; recapture required")
+            if buffer is None:
+                self.sanitized_bt_buf = torch.zeros(
+                    required_shape, dtype=torch.int32, device=self.graph_device
+                )
+        elif self.sanitized_bt_buf is None:
             self.sanitized_bt_buf = torch.zeros(
-                required_shape, dtype=torch.int32, device=self.graph_device
+                batch_size, max_cols, dtype=torch.int32, device=self.graph_device
+            )
+        elif (
+            self.sanitized_bt_buf.device != self.graph_device
+            or self.sanitized_bt_buf.dtype != torch.int32
+            or self.sanitized_bt_buf.shape[0] < batch_size
+            or self.sanitized_bt_buf.shape[1] < max_cols
+        ):
+            raise ValueError(
+                "Aiter paged-prefill CUDA graph replay exceeds or changes the "
+                "captured sanitized block-table buffer: "
+                f"capture_shape={tuple(self.sanitized_bt_buf.shape)}, "
+                f"replay_shape={(batch_size, max_cols)}, "
+                f"capture_device={self.sanitized_bt_buf.device}, "
+                f"replay_device={self.graph_device}"
             )
         self.cuda_graph_prepared = True
 

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -38,6 +38,7 @@ except ImportError:
     _AITER_AVAILABLE = False
 
 try:
+    from rtp_llm.models_py.kernel_tuning import ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV
     from rtp_llm.models_py.modules.factory.attention import attn_factory
     from rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter import (
         AiterDecodeImplTriton,
@@ -1303,6 +1304,57 @@ class TestAiterPrefillAttnOpTritonCudaGraphWorkspace(unittest.TestCase):
         self.assertIsNone(kernel.call_args.args[11])
         self.assertIsNone(kernel.call_args.args[12])
         self.assertIsNone(kernel.call_args.args[13])
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillAttnOp module")
+class TestAiterPrefillAttnOpPagedCudaGraphWorkspace(unittest.TestCase):
+    """Regression tests for fixed-address batch-prefill graph workspace."""
+
+    @patch.dict("os.environ", {ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV: "1"})
+    def test_repeated_prepare_keeps_captured_workspace_addresses(self):
+        from types import SimpleNamespace
+
+        cfg = _make_attn_configs(head_num=4, head_num_kv=2, head_dim=8)
+        cfg.kernel_tokens_per_block = 16
+        op = AiterPrefillAttnOpPaged(cfg)
+        device = torch.device("cuda")
+        block_table = torch.zeros(3, 4, dtype=torch.int32, device=device)
+        fmha_params = SimpleNamespace(
+            cu_seqlens_q=torch.tensor([0, 8, 16, 24], dtype=torch.int32, device=device),
+            cu_seqlens_k=torch.tensor(
+                [0, 40, 80, 120], dtype=torch.int32, device=device
+            ),
+            kv_cache_block_id_device=block_table,
+        )
+        attn_inputs = SimpleNamespace(
+            input_lengths_device=torch.full((3,), 8, dtype=torch.int32, device=device),
+            prefix_lengths_device=torch.full(
+                (3,), 32, dtype=torch.int32, device=device
+            ),
+            kv_cache_kernel_block_id_device=block_table,
+            kv_cache_block_id_device=block_table,
+        )
+
+        op.prepare_cuda_graph(fmha_params, attn_inputs)
+        captured_ptrs = {
+            "seqlen_k": op.seqlen_k_buf.data_ptr(),
+            "kv_indptr": op.kv_indptr_buf.data_ptr(),
+            "kv_page_indices": op.kv_page_indices_buf.data_ptr(),
+            "descale": op.descale_buf.data_ptr(),
+            "sanitized_block_table": op.sanitized_bt_buf.data_ptr(),
+        }
+
+        op.prepare_cuda_graph(fmha_params, attn_inputs)
+
+        replay_ptrs = {
+            "seqlen_k": op.seqlen_k_buf.data_ptr(),
+            "kv_indptr": op.kv_indptr_buf.data_ptr(),
+            "kv_page_indices": op.kv_page_indices_buf.data_ptr(),
+            "descale": op.descale_buf.data_ptr(),
+            "sanitized_block_table": op.sanitized_bt_buf.data_ptr(),
+        }
+        self.assertEqual(replay_ptrs, captured_ptrs)
 
 
 @unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deterministic_fp8_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deterministic_fp8_moe.py
@@ -18,6 +18,10 @@ from typing import Optional
 import aiter
 import torch
 
+from rtp_llm.models_py.kernel_tuning import (
+    ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV,
+    is_rocm_fp8_moe_deterministic_reduce_enabled,
+)
 from rtp_llm.models_py.kernel_tuning.aiter import AITER_FMOE_SUPPORTED_VERSION
 from rtp_llm.models_py.triton_kernels.moe.fixed_order_route_reduce import (
     fixed_order_fp32_route_reduce,
@@ -27,9 +31,7 @@ from rtp_llm.models_py.triton_kernels.moe.fixed_order_route_reduce import (
 _LOGGER = logging.getLogger(__name__)
 _LOGGED_MESSAGES: set[str] = set()
 
-_ENABLE_ENV = "RTP_LLM_ROCM_FP8_MOE_DETERMINISTIC_REDUCE"
 _MAX_TOKENS_ENV = "RTP_LLM_ROCM_FP8_MOE_DETERMINISTIC_MAX_TOKENS"
-_GRAPH_ENVS = ("ENABLE_CUDA_GRAPH", "ENABLE_NATIVE_CUDA_GRAPH")
 
 _SUPPORTED_EXPERTS = 256
 _SUPPORTED_HIDDEN_SIZE = 2048
@@ -55,19 +57,6 @@ def _log_once(level: int, key: str, message: str) -> None:
         return
     _LOGGED_MESSAGES.add(key)
     _LOGGER.log(level, message)
-
-
-def _enabled() -> bool:
-    return os.environ.get(_ENABLE_ENV, "0") == "1"
-
-
-def _validate_runtime_mode() -> None:
-    enabled_graph_envs = [name for name in _GRAPH_ENVS if os.environ.get(name) == "1"]
-    if enabled_graph_envs:
-        raise RuntimeError(
-            f"{_ENABLE_ENV}=1 requires CUDA/HIP graph mode to be disabled; "
-            f"set {', '.join(enabled_graph_envs)}=0"
-        )
 
 
 def _max_tokens() -> int:
@@ -282,9 +271,8 @@ def try_deterministic_fp8_moe(
 ) -> Optional[torch.Tensor]:
     """Return deterministic output when enabled/supported, otherwise ``None``."""
 
-    if not _enabled():
+    if not is_rocm_fp8_moe_deterministic_reduce_enabled():
         return None
-    _validate_runtime_mode()
 
     reason = _unsupported_reason(
         hidden_states,
@@ -301,7 +289,8 @@ def try_deterministic_fp8_moe(
         _log_once(
             logging.WARNING,
             f"fallback:{reason}",
-            f"{_ENABLE_ENV}=1 but deterministic ROCm FP8 MoE is falling back: {reason}",
+            f"{ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV}=1 but deterministic ROCm "
+            f"FP8 MoE is falling back: {reason}",
         )
         return None
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deterministic_fp8_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deterministic_fp8_moe.py
@@ -1,0 +1,329 @@
+"""Opt-in deterministic ROCm FP8-per-channel MoE path for Qwen3.5 TP2.
+
+The current AITER CK stage-2 kernel atomically scatters every TopK route into
+the token output.  On TP2 this makes the final BF16 value depend on CTA arrival
+order.  This module reuses the same per-token-FP8 CK GEMMs, but gives every
+route a private output row and performs one fixed-order FP32 reduction after
+stage2.
+"""
+
+import dataclasses
+import functools
+import importlib
+import importlib.metadata
+import logging
+import os
+from typing import Optional
+
+import aiter
+import torch
+
+from rtp_llm.models_py.kernel_tuning.aiter import AITER_FMOE_SUPPORTED_VERSION
+from rtp_llm.models_py.triton_kernels.moe.fixed_order_route_reduce import (
+    fixed_order_fp32_route_reduce,
+    make_route_local_ids,
+)
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGED_MESSAGES: set[str] = set()
+
+_ENABLE_ENV = "RTP_LLM_ROCM_FP8_MOE_DETERMINISTIC_REDUCE"
+_MAX_TOKENS_ENV = "RTP_LLM_ROCM_FP8_MOE_DETERMINISTIC_MAX_TOKENS"
+_GRAPH_ENVS = ("ENABLE_CUDA_GRAPH", "ENABLE_NATIVE_CUDA_GRAPH")
+
+_SUPPORTED_EXPERTS = 256
+_SUPPORTED_HIDDEN_SIZE = 2048
+_SUPPORTED_INTER_SIZE = 256
+_SUPPORTED_TOPK = 8
+_DEFAULT_MAX_TOKENS = 128
+_BLOCK_M = 32
+_SUPPORTED_GFX = "gfx942"
+_SUPPORTED_CU_COUNT = 80
+
+_STAGE1_KERNEL = (
+    "moe_ck2stages_gemm1_256x32x64x256_1x4_MulABScale_v1_"
+    "Nswizzle0_Quant2_MulRoutedWeight0_silu_F8_F8_B16"
+)
+_STAGE2_KERNEL = (
+    "moe_ck2stages_gemm2_256x32x64x256_1x4_MulABScaleExpertWeight_v1_"
+    "Nswizzle0_Quant2_MulRoutedWeight1_F8_F8_B16"
+)
+
+
+def _log_once(level: int, key: str, message: str) -> None:
+    if key in _LOGGED_MESSAGES:
+        return
+    _LOGGED_MESSAGES.add(key)
+    _LOGGER.log(level, message)
+
+
+def _enabled() -> bool:
+    return os.environ.get(_ENABLE_ENV, "0") == "1"
+
+
+def _validate_runtime_mode() -> None:
+    enabled_graph_envs = [name for name in _GRAPH_ENVS if os.environ.get(name) == "1"]
+    if enabled_graph_envs:
+        raise RuntimeError(
+            f"{_ENABLE_ENV}=1 requires CUDA/HIP graph mode to be disabled; "
+            f"set {', '.join(enabled_graph_envs)}=0"
+        )
+
+
+def _max_tokens() -> int:
+    value = int(os.environ.get(_MAX_TOKENS_ENV, str(_DEFAULT_MAX_TOKENS)))
+    return max(1, value)
+
+
+@functools.lru_cache(maxsize=8)
+def _runtime_unsupported_reason(device_name: str) -> Optional[str]:
+    device = torch.device(device_name)
+    properties = torch.cuda.get_device_properties(device)
+    gfx = str(getattr(properties, "gcnArchName", "")).split(":", 1)[0]
+    if gfx != _SUPPORTED_GFX:
+        return f"GPU architecture {gfx or '<unknown>'} is unsupported"
+    cu_count = int(getattr(properties, "multi_processor_count", 0))
+    if cu_count != _SUPPORTED_CU_COUNT:
+        return f"GPU CU count {cu_count} is unsupported"
+
+    try:
+        aiter_version = importlib.metadata.version("aiter")
+    except importlib.metadata.PackageNotFoundError:
+        return "AITER distribution metadata is unavailable"
+    if aiter_version != AITER_FMOE_SUPPORTED_VERSION:
+        return (
+            f"AITER version {aiter_version} is unsupported; expected "
+            f"{AITER_FMOE_SUPPORTED_VERSION}"
+        )
+
+    try:
+        fused_moe_module = importlib.import_module("aiter.fused_moe")
+    except ImportError as error:
+        return f"AITER fused_moe module is unavailable: {error}"
+    required_symbols = {
+        "aiter.ck_moe_stage2_fwd": getattr(aiter, "ck_moe_stage2_fwd", None),
+        "aiter.fused_moe.ck_moe_stage1": getattr(
+            fused_moe_module, "ck_moe_stage1", None
+        ),
+        "aiter.fused_moe._fused_moe_impl": getattr(
+            fused_moe_module, "_fused_moe_impl", None
+        ),
+    }
+    missing_symbols = [
+        name for name, symbol in required_symbols.items() if not callable(symbol)
+    ]
+    if missing_symbols:
+        return f"required AITER symbols are unavailable: {missing_symbols}"
+    return None
+
+
+def _unsupported_reason(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    activation: aiter.ActivationType,
+    expert_mask: Optional[torch.Tensor],
+) -> Optional[str]:
+    if torch.version.hip is None:
+        return "ROCm is unavailable"
+    tensors = (w1, w2, topk_weights, topk_ids, w1_scale, w2_scale)
+    if any(tensor.device != hidden_states.device for tensor in tensors):
+        return "input, routing, weight, and scale tensors must share one device"
+    runtime_reason = _runtime_unsupported_reason(str(hidden_states.device))
+    if runtime_reason is not None:
+        return runtime_reason
+    if expert_mask is not None:
+        return "expert-parallel masking is unsupported"
+    if activation != aiter.ActivationType.Silu:
+        return f"activation {activation} is unsupported"
+    if hidden_states.dtype != torch.bfloat16:
+        return f"hidden dtype {hidden_states.dtype} is unsupported"
+    if hidden_states.dim() != 2 or hidden_states.shape[1] != _SUPPORTED_HIDDEN_SIZE:
+        return f"hidden shape {tuple(hidden_states.shape)} is unsupported"
+    if not 0 < hidden_states.shape[0] <= _max_tokens():
+        return f"token count {hidden_states.shape[0]} exceeds {_max_tokens()}"
+    if topk_ids.shape != (hidden_states.shape[0], _SUPPORTED_TOPK):
+        return f"topk id shape {tuple(topk_ids.shape)} is unsupported"
+    if topk_weights.shape != topk_ids.shape:
+        return "topk weight shape does not match topk ids"
+    if topk_ids.dtype != torch.int32 or topk_weights.dtype != torch.float32:
+        return "topk ids/weights must be int32/float32"
+    if w1.shape != (
+        _SUPPORTED_EXPERTS,
+        _SUPPORTED_INTER_SIZE * 2,
+        _SUPPORTED_HIDDEN_SIZE,
+    ):
+        return f"w1 shape {tuple(w1.shape)} is unsupported"
+    if w2.shape != (
+        _SUPPORTED_EXPERTS,
+        _SUPPORTED_HIDDEN_SIZE,
+        _SUPPORTED_INTER_SIZE,
+    ):
+        return f"w2 shape {tuple(w2.shape)} is unsupported"
+    if w1.dtype != torch.float8_e4m3fnuz or w2.dtype != torch.float8_e4m3fnuz:
+        return f"weight dtypes {w1.dtype}/{w2.dtype} are unsupported"
+    if w1_scale.dtype != torch.float32 or w2_scale.dtype != torch.float32:
+        return "weight scales must use FP32 per-output-channel layout"
+    if w1_scale.shape != (_SUPPORTED_EXPERTS, _SUPPORTED_INTER_SIZE * 2, 1):
+        return f"w1 scale shape {tuple(w1_scale.shape)} is unsupported"
+    if w2_scale.shape != (_SUPPORTED_EXPERTS, _SUPPORTED_HIDDEN_SIZE, 1):
+        return f"w2 scale shape {tuple(w2_scale.shape)} is unsupported"
+    if not getattr(w1, "is_shuffled", False) or not getattr(w2, "is_shuffled", False):
+        return "weights are not marked as AITER-preshuffled"
+    return None
+
+
+def _route_local_stage2(
+    ck_stage2,
+    expected_topk: int,
+    inter_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    sorted_expert_ids: torch.Tensor,
+    num_valid_ids: torch.Tensor,
+    output: torch.Tensor,
+    topk: int,
+    **kwargs,
+) -> torch.Tensor:
+    if topk != expected_topk:
+        raise RuntimeError(f"unexpected TopK in deterministic stage2: {topk}")
+
+    token_num = inter_states.shape[0]
+    route_num = token_num * topk
+    route_inter_states = inter_states.reshape(route_num, inter_states.shape[-1])
+    route_token_ids = make_route_local_ids(sorted_token_ids, token_num, topk)
+
+    # CK stage2 still uses AtomicAdd, so its private route rows must start at
+    # zero.  With one route per row there are no conflicting atomic writers.
+    route_output = torch.zeros(
+        (route_num, output.shape[-1]), dtype=output.dtype, device=output.device
+    )
+    ck_stage2(
+        route_inter_states,
+        w1,
+        w2,
+        route_token_ids,
+        sorted_expert_ids,
+        num_valid_ids,
+        route_output,
+        1,
+        **kwargs,
+    )
+    fixed_order_fp32_route_reduce(route_output, output, topk)
+    return output
+
+
+@functools.lru_cache(maxsize=4)
+def _make_metadata_transform(output_dtype: torch.dtype, topk: int):
+    fused_moe_module = importlib.import_module("aiter.fused_moe")
+
+    def transform(metadata):
+        use_non_temporal_load = metadata.use_non_temporal_load
+        ck_stage2 = functools.partial(
+            aiter.ck_moe_stage2_fwd,
+            kernelName=_STAGE2_KERNEL,
+            activation=aiter.ActivationType.Silu,
+            quant_type=aiter.QuantType.per_Token,
+            use_non_temporal_load=use_non_temporal_load,
+        )
+        route_local_stage2 = functools.partial(
+            _route_local_stage2,
+            ck_stage2,
+            topk,
+        )
+        stage1 = functools.partial(
+            fused_moe_module.ck_moe_stage1,
+            kernelName=_STAGE1_KERNEL,
+            activation=aiter.ActivationType.Silu,
+            quant_type=aiter.QuantType.per_Token,
+            dtype=output_dtype,
+            splitk=0,
+            use_non_temporal_load=use_non_temporal_load,
+        )
+        # get_2stage_cfgs is cached; never mutate its metadata object in place.
+        return dataclasses.replace(
+            metadata,
+            stage1=stage1,
+            stage2=route_local_stage2,
+            block_m=_BLOCK_M,
+            ksplit=0,
+            run_1stage=False,
+            has_bias=False,
+            stage2_has_bias=False,
+            flat=False,
+            output_aux=False,
+            prequant=True,
+            skip_inter_quant=False,
+            fuse_quant="",
+            route_bucket="",
+            expected_sorted_blocks=None,
+            min_sorted_blocks=None,
+            max_sorted_blocks=None,
+        )
+
+    return transform
+
+
+def try_deterministic_fp8_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    activation: aiter.ActivationType,
+    expert_mask: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Return deterministic output when enabled/supported, otherwise ``None``."""
+
+    if not _enabled():
+        return None
+    _validate_runtime_mode()
+
+    reason = _unsupported_reason(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        w1_scale,
+        w2_scale,
+        activation,
+        expert_mask,
+    )
+    if reason is not None:
+        _log_once(
+            logging.WARNING,
+            f"fallback:{reason}",
+            f"{_ENABLE_ENV}=1 but deterministic ROCm FP8 MoE is falling back: {reason}",
+        )
+        return None
+
+    _log_once(
+        logging.INFO,
+        "enabled",
+        "Using route-local CK stage2 plus fixed-order FP32 reduction for ROCm "
+        "FP8-per-channel MoE",
+    )
+    fused_moe_module = importlib.import_module("aiter.fused_moe")
+    return fused_moe_module._fused_moe_impl(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weight=topk_weights,
+        topk_ids=topk_ids,
+        activation=activation.value,
+        quant_type=aiter.QuantType.per_Token.value,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        block_size_M=-1,
+        _metadata_transform=_make_metadata_transform(
+            hidden_states.dtype, _SUPPORTED_TOPK
+        ),
+    )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
@@ -6,6 +6,10 @@ import torch
 from aiter.fused_moe import fused_moe
 
 from rtp_llm.device.device_impl import is_gfx950
+from rtp_llm.models_py.kernel_tuning.aiter import (
+    AiterFmoeWorkloadSignature,
+    require_aiter_fmoe_tuning,
+)
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
@@ -27,10 +31,55 @@ from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
 from rtp_llm.utils.model_weight import W
 
 
-def _moe_activation_type(activation: str) -> aiter.ActivationType:
-    if activation in ("silu", "SiGLU"):
-        return aiter.ActivationType.Silu
-    return aiter.ActivationType.Gelu
+_MOE_ACTIVATION_TYPES = {
+    "gelu": aiter.ActivationType.Gelu,
+    "gated-silu": aiter.ActivationType.Silu,
+    "siglu": aiter.ActivationType.Silu,
+    "silu": aiter.ActivationType.Silu,
+    "swiglu": aiter.ActivationType.Silu,
+}
+
+
+def _moe_activation_type(activation: Any) -> aiter.ActivationType:
+    # ModelConfig canonicalizes activation strings to an RTP ActivationType
+    # enum. Normalize both that representation and the raw strings accepted by
+    # fused_moe so the tuning signature describes the activation actually sent
+    # to AITER.
+    activation_name = str(getattr(activation, "name", activation))
+    activation_name = activation_name.rsplit(".", 1)[-1].lower()
+    try:
+        return _MOE_ACTIVATION_TYPES[activation_name]
+    except KeyError as error:
+        raise ValueError(
+            f"Unsupported AITER FMoE activation: {activation!r} "
+            f"(normalized as {activation_name!r})"
+        ) from error
+
+
+def _aiter_fmoe_workload_signature(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk: int,
+    activation: Any,
+    output_dtype: torch.dtype,
+) -> AiterFmoeWorkloadSignature:
+    properties = torch.cuda.get_device_properties(w1.device)
+    gfx = str(getattr(properties, "gcnArchName", "")).split(":", 1)[0]
+    return AiterFmoeWorkloadSignature(
+        gfx=gfx,
+        cu_num=properties.multi_processor_count,
+        model_dim=w1.shape[2],
+        inter_dim=w2.shape[2],
+        expert=w1.shape[0],
+        topk=topk,
+        act_type=str(_moe_activation_type(activation)),
+        dtype=str(output_dtype),
+        q_dtype_a=str(w1.dtype),
+        q_dtype_w=str(w2.dtype),
+        q_type=str(aiter.QuantType.per_Token),
+        use_g1u1=int(w1.shape[1] == 2 * w2.shape[2]),
+        doweight_stage1=0,
+    )
 
 
 def build_ep_expert_mask(
@@ -197,6 +246,19 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         self.w2 = weights[W.moe_w2]
         self.w1_scale = weights[W.moe_s1]
         self.w2_scale = weights[W.moe_s2]
+        self._configured_activation_type = _moe_activation_type(
+            config.activation_type
+        )
+
+        require_aiter_fmoe_tuning(
+            _aiter_fmoe_workload_signature(
+                self.w1,
+                self.w2,
+                config.moe_k,
+                self._configured_activation_type,
+                config.model_config.compute_dtype,
+            )
+        )
 
         self.expert_mask = build_ep_expert_mask(
             self.num_experts, self.ep_rank, self.ep_size, self.w1
@@ -224,6 +286,14 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         assert self.w1.stride(-1) == 1, "Stride of last dimension must be 1"
         assert self.w2.stride(-1) == 1, "Stride of last dimension must be 1"
         assert payload.expert_tokens_meta is not None
+
+        activation_type = _moe_activation_type(activation)
+        if activation_type != self._configured_activation_type:
+            raise ValueError(
+                "MoE activation mismatch: ModelConfig resolved to "
+                f"{self._configured_activation_type}, but execute() received "
+                f"{activation!r}, which resolved to {activation_type}"
+            )
 
         E = self.local_num_experts
         assert payload.expert_topk_ids is not None
@@ -265,7 +335,7 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
             quant_type=aiter.QuantType.per_Token,
             w1_scale=self.w1_scale,
             w2_scale=self.w2_scale,
-            activation=_moe_activation_type(activation),
+            activation=activation_type,
             expert_mask=effective_expert_mask,
         )
 
@@ -320,6 +390,7 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
         self.expert_mask = build_ep_expert_mask(
             self.num_experts, self.ep_rank, self.ep_size, self.w1
         )
+
     @property
     def local_num_experts(self) -> int:
         return self.w1.size(0)
@@ -574,7 +645,9 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
         self.w2_scale = weights[W.moe_s2]
 
         self.hidden_size_raw = config.hidden_size
-        self.intermediate_size_raw = config.model_config.moe_inter_size // config.tp_size
+        self.intermediate_size_raw = (
+            config.model_config.moe_inter_size // config.tp_size
+        )
         packed_factor = 2 if self.w1.dtype == torch.uint8 else 1
         self.hidden_size_padded = self.w1.size(2) * packed_factor
         self.intermediate_size_padded = self.w2.size(1)
@@ -625,7 +698,7 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
             ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
-        
+
         # view w1 and w2 to float4_e2m1fn_x2 if they are uint8
         w1 = self.w1
         w2 = self.w2

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
@@ -6,6 +6,7 @@ import torch
 from aiter.fused_moe import fused_moe
 
 from rtp_llm.device.device_impl import is_gfx950
+from rtp_llm.models_py.kernel_tuning import is_rocm_fp8_moe_deterministic_reduce_enabled
 from rtp_llm.models_py.kernel_tuning.aiter import (
     AiterFmoeWorkloadSignature,
     require_aiter_fmoe_tuning,
@@ -25,14 +26,10 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.type import ExecutorType
 from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils import (
     get_rocm_fp8_dtype,
 )
-from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deterministic_fp8_moe import (
-    try_deterministic_fp8_moe,
-)
 from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
     MoeConfigResolver,
 )
 from rtp_llm.utils.model_weight import W
-
 
 _MOE_ACTIVATION_TYPES = {
     "gelu": aiter.ActivationType.Gelu,
@@ -43,7 +40,7 @@ _MOE_ACTIVATION_TYPES = {
 }
 
 
-def _moe_activation_type(activation: Any) -> aiter.ActivationType:
+def _normalized_moe_activation_type(activation: Any) -> aiter.ActivationType:
     # ModelConfig canonicalizes activation strings to an RTP ActivationType
     # enum. Normalize both that representation and the raw strings accepted by
     # fused_moe so the tuning signature describes the activation actually sent
@@ -57,6 +54,14 @@ def _moe_activation_type(activation: Any) -> aiter.ActivationType:
             f"Unsupported AITER FMoE activation: {activation!r} "
             f"(normalized as {activation_name!r})"
         ) from error
+
+
+def _moe_activation_type(activation: Any) -> aiter.ActivationType:
+    if not is_rocm_fp8_moe_deterministic_reduce_enabled():
+        if activation in ("silu", "SiGLU"):
+            return aiter.ActivationType.Silu
+        return aiter.ActivationType.Gelu
+    return _normalized_moe_activation_type(activation)
 
 
 def _aiter_fmoe_workload_signature(
@@ -249,26 +254,27 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         self.w2 = weights[W.moe_w2]
         self.w1_scale = weights[W.moe_s1]
         self.w2_scale = weights[W.moe_s2]
-        self._configured_activation_type = _moe_activation_type(
-            config.activation_type
-        )
-
-        require_aiter_fmoe_tuning(
-            _aiter_fmoe_workload_signature(
-                self.w1,
-                self.w2,
-                config.moe_k,
-                self._configured_activation_type,
-                config.model_config.compute_dtype,
+        self._stability_enabled = is_rocm_fp8_moe_deterministic_reduce_enabled()
+        if self._stability_enabled:
+            self._configured_activation_type = _normalized_moe_activation_type(
+                config.activation_type
             )
-        )
+            require_aiter_fmoe_tuning(
+                _aiter_fmoe_workload_signature(
+                    self.w1,
+                    self.w2,
+                    config.moe_k,
+                    self._configured_activation_type,
+                    config.model_config.compute_dtype,
+                )
+            )
 
-        # ROCmDevice.shuffle_moe_weight always converts MoE weights to the
-        # layout consumed by AITER's preshuffle_on kernels.  Tensor attributes
-        # can be dropped while the loaded tensors are registered on the model,
-        # so restore the layout marker at the executor boundary.
-        self.w1.is_shuffled = True
-        self.w2.is_shuffled = True
+            # ROCmDevice.shuffle_moe_weight always converts MoE weights to the
+            # layout consumed by AITER's preshuffle_on kernels. Tensor attributes
+            # can be dropped while the loaded tensors are registered on the model,
+            # so restore the layout marker only for the opt-in deterministic path.
+            self.w1.is_shuffled = True
+            self.w2.is_shuffled = True
 
         self.expert_mask = build_ep_expert_mask(
             self.num_experts, self.ep_rank, self.ep_size, self.w1
@@ -298,7 +304,10 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         assert payload.expert_tokens_meta is not None
 
         activation_type = _moe_activation_type(activation)
-        if activation_type != self._configured_activation_type:
+        if (
+            self._stability_enabled
+            and activation_type != self._configured_activation_type
+        ):
             raise ValueError(
                 "MoE activation mismatch: ModelConfig resolved to "
                 f"{self._configured_activation_type}, but execute() received "
@@ -336,18 +345,23 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
-        activation_type = _moe_activation_type(activation)
-        output = try_deterministic_fp8_moe(
-            hidden_states=hidden_states,
-            w1=self.w1,
-            w2=self.w2,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            w1_scale=self.w1_scale,
-            w2_scale=self.w2_scale,
-            activation=activation_type,
-            expert_mask=effective_expert_mask,
-        )
+        output = None
+        if self._stability_enabled:
+            from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deterministic_fp8_moe import (
+                try_deterministic_fp8_moe,
+            )
+
+            output = try_deterministic_fp8_moe(
+                hidden_states=hidden_states,
+                w1=self.w1,
+                w2=self.w2,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                w1_scale=self.w1_scale,
+                w2_scale=self.w2_scale,
+                activation=activation_type,
+                expert_mask=effective_expert_mask,
+            )
         if output is None:
             output = fused_moe(
                 hidden_states,

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
@@ -25,6 +25,9 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.type import ExecutorType
 from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils import (
     get_rocm_fp8_dtype,
 )
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deterministic_fp8_moe import (
+    try_deterministic_fp8_moe,
+)
 from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
     MoeConfigResolver,
 )
@@ -260,6 +263,13 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
             )
         )
 
+        # ROCmDevice.shuffle_moe_weight always converts MoE weights to the
+        # layout consumed by AITER's preshuffle_on kernels.  Tensor attributes
+        # can be dropped while the loaded tensors are registered on the model,
+        # so restore the layout marker at the executor boundary.
+        self.w1.is_shuffled = True
+        self.w2.is_shuffled = True
+
         self.expert_mask = build_ep_expert_mask(
             self.num_experts, self.ep_rank, self.ep_size, self.w1
         )
@@ -326,18 +336,31 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
-        output = fused_moe(
-            hidden_states,
-            self.w1,
-            self.w2,
-            topk_weights,
-            topk_ids,
-            quant_type=aiter.QuantType.per_Token,
+        activation_type = _moe_activation_type(activation)
+        output = try_deterministic_fp8_moe(
+            hidden_states=hidden_states,
+            w1=self.w1,
+            w2=self.w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
             w1_scale=self.w1_scale,
             w2_scale=self.w2_scale,
             activation=activation_type,
             expert_mask=effective_expert_mask,
         )
+        if output is None:
+            output = fused_moe(
+                hidden_states,
+                self.w1,
+                self.w2,
+                topk_weights,
+                topk_ids,
+                quant_type=aiter.QuantType.per_Token,
+                w1_scale=self.w1_scale,
+                w2_scale=self.w2_scale,
+                activation=activation_type,
+                expert_mask=effective_expert_mask,
+            )
 
         return CombineForwardPayload(fused_expert_output=output)
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
@@ -63,6 +63,21 @@ py_test (
     exec_properties = {'gpu':'MI308X-ROCM7'},
 )
 
+py_test (
+    name = "rocm_fp8_deterministic_tp2_test",
+    srcs = ["rocm_fp8_deterministic_tp2_test.py"],
+    main = "rocm_fp8_deterministic_tp2_test.py",
+    deps = py_test_deps + [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+        "//rtp_llm:testlib",
+    ],
+    timeout = "eternal",
+    env = {"GPU_COUNT": "2"},
+    tags = ["rocm", "multi_device"],
+    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'2'},
+)
+
 # Quark MXFP4 fused_moe numerical test (MI355 / gfx950 only).
 # Not part of bulk MI308 ROCm CI: tag "rocm" is omitted; "manual" skips default
 # bazel test //...; "rocm_gfx950" only matches jobs that opt into that filter.

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_deterministic_tp2_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_deterministic_tp2_test.py
@@ -1,0 +1,304 @@
+"""Real two-GPU coverage for deterministic ROCm FP8-per-channel MoE."""
+
+import multiprocessing as mp
+import os
+import socket
+import unittest
+from datetime import timedelta
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.device.device_impl import RocmImpl
+from rtp_llm.models_py.kernel_tuning import ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    ExpertForwardPayload,
+    ExpertTokensMetadata,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors import (
+    deterministic_fp8_moe,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors import (
+    rocm_moe as rocm_moe_module,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
+    RocmExpertsFp8PerChannel,
+)
+from rtp_llm.ops import MoeConfig, ParallelismConfig
+from rtp_llm.utils.model_weight import W
+
+_WORLD_SIZE = 2
+_HIDDEN_SIZE = 2048
+_LOCAL_INTER_SIZE = 256
+_EXPERTS = 256
+_TOPK = 8
+_TOKENS = 4
+_REPEATS = 10
+_FP8_MAX = 240.0
+
+
+def _configured_gpu_count() -> int:
+    if (gpu_count := os.environ.get("GPU_COUNT")) is not None:
+        return int(gpu_count)
+    visible_devices = os.environ.get("HIP_VISIBLE_DEVICES")
+    if visible_devices is None:
+        return 0
+    return len([device for device in visible_devices.split(",") if device.strip()])
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _quantize_per_channel(
+    shape: tuple[int, ...], seed: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(seed)
+    source = torch.randn(shape, dtype=torch.bfloat16, device=device).mul_(0.02)
+    scale = source.abs().amax(dim=-1, keepdim=True).clamp_(min=1e-8)
+    scale = scale.div_(_FP8_MAX).to(torch.float32)
+    quantized = (source / scale).to(torch.float8_e4m3fnuz)
+    quantized_bits = quantized.view(torch.int8)
+    quantized_bits[quantized_bits == -128] = 0
+    return quantized_bits.view(torch.float8_e4m3fnuz), scale.mul_(2.0)
+
+
+def _parallelism_config(rank: int) -> ParallelismConfig:
+    config = ParallelismConfig()
+    config.tp_size = _WORLD_SIZE
+    config.tp_rank = rank
+    config.ffn_tp_size = _WORLD_SIZE
+    config.ffn_tp_rank = rank
+    config.ep_size = 1
+    config.ep_rank = 0
+    config.dp_size = 1
+    config.dp_rank = 0
+    config.world_size = _WORLD_SIZE
+    config.world_rank = rank
+    config.local_rank = rank
+    config.local_world_size = _WORLD_SIZE
+    return config
+
+
+def _build_executor(rank: int, device: torch.device) -> RocmExpertsFp8PerChannel:
+    runtime_device = RocmImpl.__new__(RocmImpl)
+    w1_quantized, w1_scale = _quantize_per_channel(
+        (_EXPERTS, 2 * _LOCAL_INTER_SIZE, _HIDDEN_SIZE), 1000 + rank, device
+    )
+    w2_quantized, w2_scale = _quantize_per_channel(
+        (_EXPERTS, _HIDDEN_SIZE, _LOCAL_INTER_SIZE), 2000 + rank, device
+    )
+    w1_quantized = runtime_device.cat_0(
+        [
+            w1_quantized[:, _LOCAL_INTER_SIZE:, :],
+            w1_quantized[:, :_LOCAL_INTER_SIZE, :],
+        ],
+        dim=1,
+    )
+    w1_scale = torch.cat(
+        [
+            w1_scale[:, _LOCAL_INTER_SIZE:, :],
+            w1_scale[:, :_LOCAL_INTER_SIZE, :],
+        ],
+        dim=1,
+    )
+    weights = {
+        W.moe_w1: runtime_device.shuffle_moe_weight(
+            w1_quantized, w1_quantized.dtype, W.moe_w1
+        ),
+        W.moe_w2: runtime_device.shuffle_moe_weight(
+            w2_quantized, w2_quantized.dtype, W.moe_w2
+        ),
+        W.moe_s1: runtime_device.shuffle_moe_weight(w1_scale, w1_scale.dtype, W.moe_s1),
+        W.moe_s2: w2_scale,
+    }
+
+    model_config = ModelConfig()
+    model_config.attn_config.head_num = 4
+    model_config.attn_config.size_per_head = 64
+    model_config.num_layers = 2
+    model_config.max_seq_len = 2048
+    model_config.vocab_size = 32000
+    model_config.expert_num = _EXPERTS
+    model_config.moe_k = _TOPK
+    model_config.inter_size = _LOCAL_INTER_SIZE * _WORLD_SIZE
+    model_config.activation_type = "SiGLU"
+    model_config.data_type = "bf16"
+    config = MoEConfigAdapter(
+        model_config=model_config,
+        parallelism_config=_parallelism_config(rank),
+        moe_config=MoeConfig(),
+    )
+    return RocmExpertsFp8PerChannel(config, FusedMoEQuantConfig(), weights)
+
+
+def _payload(device: torch.device) -> ExpertForwardPayload:
+    torch.manual_seed(2026)
+    hidden_states = torch.randn(
+        _TOKENS, _HIDDEN_SIZE, dtype=torch.bfloat16, device=device
+    )
+    topk_ids = torch.arange(_TOPK, dtype=torch.int32, device=device).repeat(_TOKENS, 1)
+    topk_weights = torch.softmax(
+        torch.randn(_TOKENS, _TOPK, dtype=torch.float32, device=device), dim=-1
+    )
+    dist.broadcast(hidden_states, src=0)
+    dist.broadcast(topk_ids, src=0)
+    dist.broadcast(topk_weights, src=0)
+    return ExpertForwardPayload(
+        expert_x=hidden_states,
+        expert_x_origin_dtype=hidden_states.dtype,
+        expert_x_scale=None,
+        expert_tokens_meta=ExpertTokensMetadata(None, None, None),
+        expert_topk_ids=topk_ids,
+        expert_topk_weights=topk_weights,
+    )
+
+
+def _execute(executor, payload) -> torch.Tensor:
+    return executor.execute(
+        payload=payload,
+        activation="SiGLU",
+        expert_map=None,
+        a2_scale=None,
+        apply_router_weight_on_input=False,
+        extra_expert_args=None,
+    ).fused_expert_output
+
+
+def _tp2_worker(rank: int, port: int) -> None:
+    initialized = False
+    try:
+        os.environ[ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV] = "1"
+        torch.cuda.set_device(rank)
+        device = torch.device(f"cuda:{rank}")
+        dist.init_process_group(
+            "nccl",
+            init_method=f"tcp://127.0.0.1:{port}",
+            rank=rank,
+            world_size=_WORLD_SIZE,
+            timeout=timedelta(seconds=300),
+            device_id=device,
+        )
+        initialized = True
+        executor = _build_executor(rank, device)
+        payload = _payload(device)
+
+        route_local_calls = 0
+        route_local_stage2 = deterministic_fp8_moe._route_local_stage2
+
+        def observed_route_local_stage2(*args, **kwargs):
+            nonlocal route_local_calls
+            route_local_calls += 1
+            return route_local_stage2(*args, **kwargs)
+
+        def reject_legacy_fallback(*args, **kwargs):
+            raise AssertionError("deterministic TP2 test unexpectedly used fused_moe")
+
+        deterministic_fp8_moe._make_metadata_transform.cache_clear()
+        deterministic_fp8_moe._runtime_unsupported_reason.cache_clear()
+        with (
+            patch.object(
+                deterministic_fp8_moe,
+                "_route_local_stage2",
+                side_effect=observed_route_local_stage2,
+            ),
+            patch.object(
+                rocm_moe_module, "fused_moe", side_effect=reject_legacy_fallback
+            ),
+        ):
+            baseline = _execute(executor, payload)
+            if route_local_calls == 0:
+                raise AssertionError(
+                    "route-local deterministic stage2 was not selected"
+                )
+            dist.all_reduce(baseline)
+            torch.cuda.synchronize(device)
+            baseline = baseline.clone()
+
+            for _ in range(_REPEATS):
+                eager_output = _execute(executor, payload)
+                dist.all_reduce(eager_output)
+                torch.cuda.synchronize(device)
+                if not torch.equal(eager_output, baseline):
+                    raise AssertionError(
+                        "TP2 eager output changed across identical runs"
+                    )
+
+            capture_stream = torch.cuda.Stream(device=device)
+            capture_stream.wait_stream(torch.cuda.current_stream(device))
+            with torch.cuda.stream(capture_stream):
+                _execute(executor, payload)
+            capture_stream.synchronize()
+            dist.barrier()
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=capture_stream):
+                graph_local_output = _execute(executor, payload)
+            capture_stream.synchronize()
+            dist.barrier()
+
+            for _ in range(_REPEATS):
+                graph.replay()
+                torch.cuda.synchronize(device)
+                graph_output = graph_local_output.clone()
+                dist.all_reduce(graph_output)
+                torch.cuda.synchronize(device)
+                if not torch.equal(graph_output, baseline):
+                    raise AssertionError(
+                        "TP2 HIP graph output changed across identical replays"
+                    )
+    finally:
+        if initialized:
+            dist.destroy_process_group()
+
+
+def _launch_tp2() -> None:
+    context = mp.get_context("spawn")
+    port = _free_port()
+    processes = [
+        context.Process(target=_tp2_worker, args=(rank, port), name=f"tp2-rank-{rank}")
+        for rank in range(_WORLD_SIZE)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=600)
+        failed = [process for process in processes if process.exitcode != 0]
+        if failed:
+            raise RuntimeError(
+                "deterministic ROCm FP8 MoE TP2 worker failed: "
+                + ", ".join(
+                    f"{process.name} exitcode={process.exitcode}" for process in failed
+                )
+            )
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+
+@unittest.skipUnless(torch.version.hip is not None, "requires ROCm PyTorch")
+class DeterministicFp8MoeTp2Test(unittest.TestCase):
+    def test_real_tp2_eager_and_hip_graph_are_bitwise_stable(self):
+        self.assertGreaterEqual(
+            _configured_gpu_count(),
+            _WORLD_SIZE,
+            "test target must allocate two MI308X GPUs",
+        )
+        _launch_tp2()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
@@ -12,9 +12,12 @@ from unittest import SkipTest
 import torch
 
 try:
+    import aiter
     from aiter.ops.shuffle import shuffle_weight  # noqa: F401
 
     from rtp_llm.config.model_config import ModelConfig
+    from rtp_llm.device.device_impl import RocmImpl
+    from rtp_llm.models_py.kernel_tuning.aiter import is_affected_aiter_fmoe_signature
     from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
         MoEConfigAdapter,
     )
@@ -34,6 +37,8 @@ try:
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
         RocmExpertsFp8PerBlock,
         RocmExpertsFp8PerChannel,
+        _aiter_fmoe_workload_signature,
+        _moe_activation_type,
     )
     from rtp_llm.ops import MoeConfig, ParallelismConfig
     from rtp_llm.utils.model_weight import W
@@ -51,6 +56,17 @@ def _per_channel_quant_fp8(w: torch.Tensor, fp8_dtype: torch.dtype):
     scale = (amax / FP8_E4M3FNUZ_MAX).to(torch.float32)
     wq = (w / scale).to(fp8_dtype)
     return wq, scale.squeeze(-1)
+
+
+def _online_loader_quant_fp8(w: torch.Tensor):
+    from rtp_llm.model_loader.per_channel_fp8_quant_weight import (
+        per_channel_cast_to_fp8,
+    )
+
+    wq, scale = per_channel_cast_to_fp8(w)
+    bits = wq.view(torch.int8)
+    bits[bits == -128] = 0
+    return bits.view(torch.float8_e4m3fnuz), scale * 2.0
 
 
 def _per_block_quant_fp8(w: torch.Tensor, fp8_dtype: torch.dtype, block: int = 128):
@@ -78,22 +94,29 @@ def _dequant_per_block(
     return deq.reshape(E, OUT, IN).to(torch.bfloat16)
 
 
-def _make_parallelism_config():
+def _make_parallelism_config(tp_size: int = 1):
     p = ParallelismConfig()
     p.ep_size = 1
     p.ep_rank = 0
-    p.tp_size = 1
+    p.tp_size = tp_size
     p.tp_rank = 0
     p.dp_size = 1
     p.dp_rank = 0
-    p.world_size = 1
+    p.world_size = tp_size
     p.world_rank = 0
     p.local_rank = 0
-    p.local_world_size = 1
+    p.local_world_size = tp_size
     return p
 
 
-def _make_config_adapter(expert_num: int, top_k: int, inter_dim: int):
+def _make_config_adapter(
+    expert_num: int,
+    top_k: int,
+    inter_dim: int,
+    tp_size: int = 1,
+    data_type: str | None = None,
+    activation_type: str = "silu",
+):
     model_config = ModelConfig()
     model_config.attn_config.head_num = 4
     model_config.attn_config.size_per_head = 64
@@ -103,11 +126,13 @@ def _make_config_adapter(expert_num: int, top_k: int, inter_dim: int):
     model_config.expert_num = expert_num
     model_config.moe_k = top_k
     model_config.inter_size = inter_dim
-    model_config.activation_type = "silu"
+    model_config.activation_type = activation_type
+    if data_type is not None:
+        model_config.data_type = data_type
 
     return MoEConfigAdapter(
         model_config=model_config,
-        parallelism_config=_make_parallelism_config(),
+        parallelism_config=_make_parallelism_config(tp_size),
         moe_config=MoeConfig(),
     )
 
@@ -151,6 +176,32 @@ class RocmExpertsFp8PerChannelTest(_Fp8MoeBaseTest):
     """Cover the refactored single-aiter-fused_moe path (review item #7)."""
 
     M, K, N, E, TOP_K = 16, 256, 256, 4, 2
+
+    def test_activation_type_normalization(self):
+        swiglu_config = ModelConfig()
+        swiglu_config.activation_type = "SiGLU"
+        silu_config = ModelConfig()
+        silu_config.activation_type = "silu"
+
+        silu_aliases = (
+            "silu",
+            "SiGLU",
+            "swiglu",
+            "gated-silu",
+            silu_config.activation_type,
+            swiglu_config.activation_type,
+        )
+        for activation in silu_aliases:
+            with self.subTest(activation=activation):
+                self.assertEqual(
+                    _moe_activation_type(activation), aiter.ActivationType.Silu
+                )
+
+        self.assertEqual(
+            _moe_activation_type("gelu"), aiter.ActivationType.Gelu
+        )
+        with self.assertRaisesRegex(ValueError, "Unsupported AITER FMoE activation"):
+            _moe_activation_type("unknown")
 
     def _run(self, apply_router_weight_on_input: bool):
         payload = self._build_payload(self.M, self.K, self.E, self.TOP_K)
@@ -224,6 +275,116 @@ class RocmExpertsFp8PerChannelTest(_Fp8MoeBaseTest):
     def test_apply_router_weight_on_input(self):
         # PR #882 review #7 specifically called out this newly-enabled path.
         self._run(apply_router_weight_on_input=True)
+
+    def test_small_token_tuned_shape_with_loader_postprocess(self):
+        hidden, local_inter, experts, top_k = 2048, 128, 256, 8
+        runtime_device = RocmImpl.__new__(RocmImpl)
+
+        # Reproduce the FP8 loader conversion, [gate, up] reorder, and the
+        # physical ROCm weight shuffle used by a real checkpoint load.
+        w1_checkpoint = (
+            torch.randn(
+                experts,
+                2 * local_inter,
+                hidden,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            * 0.02
+        )
+        w2_checkpoint = (
+            torch.randn(
+                experts,
+                hidden,
+                local_inter,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            * 0.02
+        )
+        w1q_checkpoint, s1_checkpoint = _online_loader_quant_fp8(w1_checkpoint)
+        w2q, s2 = _online_loader_quant_fp8(w2_checkpoint)
+        w1q_loader = runtime_device.cat_0(
+            [
+                w1q_checkpoint[:, local_inter:, :],
+                w1q_checkpoint[:, :local_inter, :],
+            ],
+            dim=1,
+        )
+        s1_loader = torch.cat(
+            [
+                s1_checkpoint[:, local_inter:, :],
+                s1_checkpoint[:, :local_inter, :],
+            ],
+            dim=1,
+        )
+        weights = {
+            W.moe_w1: runtime_device.shuffle_moe_weight(
+                w1q_loader, w1q_loader.dtype, W.moe_w1
+            ),
+            W.moe_w2: runtime_device.shuffle_moe_weight(w2q, w2q.dtype, W.moe_w2),
+            W.moe_s1: runtime_device.shuffle_moe_weight(
+                s1_loader, s1_loader.dtype, W.moe_s1
+            ),
+            W.moe_s2: s2,
+        }
+        w1_dequant = (w1q_checkpoint.float() * s1_checkpoint).to(torch.bfloat16)
+        w2_dequant = (w2q.float() * s2).to(torch.bfloat16)
+
+        # TP is deliberately varied while the local AITER dispatch shape stays
+        # fixed. The tuning decision must therefore be identical for both.
+        for tp_size in (2, 4):
+            config = _make_config_adapter(
+                experts,
+                top_k,
+                local_inter * tp_size,
+                tp_size=tp_size,
+                data_type="bf16",
+                activation_type="SiGLU",
+            )
+            signature = _aiter_fmoe_workload_signature(
+                weights[W.moe_w1],
+                weights[W.moe_w2],
+                config.moe_k,
+                config.activation_type,
+                config.model_config.compute_dtype,
+            )
+            self.assertTrue(is_affected_aiter_fmoe_signature(signature))
+
+            executor = RocmExpertsFp8PerChannel(
+                config,
+                FusedMoEQuantConfig(),
+                weights,
+            )
+            for token_count in (1, 2, 4, 8, 16):
+                with self.subTest(tp_size=tp_size, token_count=token_count):
+                    payload = self._build_payload(token_count, hidden, experts, top_k)
+                    reference = torch_moe_ref(
+                        payload=payload,
+                        activation="silu",
+                        global_num_experts=experts,
+                        expert_map=None,
+                        a2_scale=None,
+                        apply_router_weight_on_input=False,
+                        extra_expert_args=None,
+                        w1=w1_dequant,
+                        w2=w2_dequant,
+                    )
+                    output = executor.execute(
+                        payload=payload,
+                        activation="SiGLU",
+                        expert_map=None,
+                        a2_scale=None,
+                        apply_router_weight_on_input=False,
+                        extra_expert_args=None,
+                    ).fused_expert_output
+                    cosine = torch.nn.functional.cosine_similarity(
+                        output.float(), reference.float(), dim=-1
+                    ).mean()
+
+                    self.assertEqual(output.shape, (token_count, hidden))
+                    self.assertTrue(torch.isfinite(output).all().item())
+                    self.assertGreater(cosine.item(), 0.99)
 
 
 class RocmExpertsFp8PerBlockTest(_Fp8MoeBaseTest):

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
@@ -6,8 +6,11 @@ runs each executor against a BF16 reference (computed from the dequantized
 weights) and asserts shape, finiteness and approximate numerical agreement.
 """
 
+import os
 import unittest
+from types import SimpleNamespace
 from unittest import SkipTest
+from unittest.mock import patch
 
 import torch
 
@@ -34,6 +37,9 @@ try:
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deepep_normal_fused_moe_executor import (
         torch_moe_ref,
     )
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deterministic_fp8_moe import (
+        _validate_runtime_mode,
+    )
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
         RocmExpertsFp8PerBlock,
         RocmExpertsFp8PerChannel,
@@ -48,6 +54,99 @@ except ImportError as exc:  # stale librtp_compute_ops.so / missing aiter / etc.
     _IMPORT_ERROR = exc
 
 FP8_E4M3FNUZ_MAX = 240.0  # max representable in float8_e4m3fnuz
+
+
+class DeterministicFp8MoeConfigTest(unittest.TestCase):
+    def tearDown(self):
+        if _IMPORT_ERROR is None:
+            deterministic_fp8_moe._runtime_unsupported_reason.cache_clear()
+
+    def _runtime_reason(
+        self,
+        *,
+        gfx: str = "gfx942",
+        cu_count: int = 80,
+        version: str | None = None,
+        stage1=None,
+        stage2=None,
+        implementation=None,
+    ):
+        if version is None:
+            version = deterministic_fp8_moe.AITER_FMOE_SUPPORTED_VERSION
+        if stage1 is None:
+            stage1 = lambda: None
+        if stage2 is None:
+            stage2 = lambda: None
+        if implementation is None:
+            implementation = lambda: None
+        fused_moe_module = SimpleNamespace(
+            ck_moe_stage1=stage1,
+            _fused_moe_impl=implementation,
+        )
+        deterministic_fp8_moe._runtime_unsupported_reason.cache_clear()
+        with (
+            patch.object(
+                deterministic_fp8_moe.torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(
+                    gcnArchName=f"{gfx}:sramecc+:xnack-",
+                    multi_processor_count=cu_count,
+                ),
+            ),
+            patch.object(
+                deterministic_fp8_moe.importlib.metadata,
+                "version",
+                return_value=version,
+            ),
+            patch.object(
+                deterministic_fp8_moe.importlib,
+                "import_module",
+                return_value=fused_moe_module,
+            ),
+            patch.object(
+                deterministic_fp8_moe.aiter,
+                "ck_moe_stage2_fwd",
+                stage2,
+                create=True,
+            ),
+        ):
+            return deterministic_fp8_moe._runtime_unsupported_reason("cuda:0")
+
+    @unittest.skipIf(
+        _IMPORT_ERROR is not None, f"ROCm imports unavailable: {_IMPORT_ERROR}"
+    )
+    def test_runtime_support_matrix_requires_target_device_version_and_symbols(self):
+        self.assertIsNone(self._runtime_reason())
+        cases = (
+            ({"gfx": "gfx950"}, "GPU architecture"),
+            ({"cu_count": 79}, "GPU CU count"),
+            ({"version": "future-aiter"}, "AITER version"),
+            ({"implementation": False}, "required AITER symbols"),
+        )
+        for overrides, expected_reason in cases:
+            with self.subTest(overrides=overrides):
+                self.assertIn(expected_reason, self._runtime_reason(**overrides))
+
+    @unittest.skipIf(
+        _IMPORT_ERROR is not None, f"ROCm imports unavailable: {_IMPORT_ERROR}"
+    )
+    def test_cuda_graph_conflict_fails_fast(self):
+        with patch.dict(
+            os.environ,
+            {"ENABLE_CUDA_GRAPH": "1", "ENABLE_NATIVE_CUDA_GRAPH": "0"},
+        ):
+            with self.assertRaisesRegex(RuntimeError, "requires CUDA/HIP graph"):
+                _validate_runtime_mode()
+
+    @unittest.skipIf(
+        _IMPORT_ERROR is not None, f"ROCm imports unavailable: {_IMPORT_ERROR}"
+    )
+    def test_graph_disabled_is_supported(self):
+        with patch.dict(
+            os.environ,
+            {"ENABLE_CUDA_GRAPH": "0", "ENABLE_NATIVE_CUDA_GRAPH": "0"},
+        ):
+            _validate_runtime_mode()
 
 
 def _per_channel_quant_fp8(w: torch.Tensor, fp8_dtype: torch.dtype):
@@ -245,15 +344,19 @@ class RocmExpertsFp8PerChannelTest(_Fp8MoeBaseTest):
 
         # Build the executor.
         config_adapter = _make_config_adapter(self.E, self.TOP_K, 2 * self.N)
+        w1q_runtime = shuffle_weight(w1q, layout=(16, 16))
+        w2q_runtime = shuffle_weight(w2q, layout=(16, 16))
         weights = {
-            W.moe_w1: w1q,
-            W.moe_w2: w2q,
+            W.moe_w1: w1q_runtime,
+            W.moe_w2: w2q_runtime,
             W.moe_s1: s1,
             W.moe_s2: s2,
         }
         executor = RocmExpertsFp8PerChannel(
             config_adapter, FusedMoEQuantConfig(), weights
         )
+        self.assertTrue(executor.w1.is_shuffled)
+        self.assertTrue(executor.w2.is_shuffled)
 
         out = executor.execute(
             payload=payload,

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
@@ -14,12 +14,17 @@ from unittest.mock import patch
 
 import torch
 
+from rtp_llm.models_py.kernel_tuning.aiter import configure_aiter_fmoe_overlays
+
+_AITER_TUNING_STATUS = configure_aiter_fmoe_overlays()
+
 try:
     import aiter
     from aiter.ops.shuffle import shuffle_weight  # noqa: F401
 
     from rtp_llm.config.model_config import ModelConfig
     from rtp_llm.device.device_impl import RocmImpl
+    from rtp_llm.models_py.kernel_tuning import ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV
     from rtp_llm.models_py.kernel_tuning.aiter import is_affected_aiter_fmoe_signature
     from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
         MoEConfigAdapter,
@@ -34,11 +39,11 @@ try:
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils import (
         get_rocm_fp8_dtype,
     )
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors import (
+        deterministic_fp8_moe,
+    )
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deepep_normal_fused_moe_executor import (
         torch_moe_ref,
-    )
-    from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deterministic_fp8_moe import (
-        _validate_runtime_mode,
     )
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
         RocmExpertsFp8PerBlock,
@@ -130,23 +135,25 @@ class DeterministicFp8MoeConfigTest(unittest.TestCase):
     @unittest.skipIf(
         _IMPORT_ERROR is not None, f"ROCm imports unavailable: {_IMPORT_ERROR}"
     )
-    def test_cuda_graph_conflict_fails_fast(self):
+    def test_cuda_graph_does_not_block_opt_in_path(self):
         with patch.dict(
             os.environ,
-            {"ENABLE_CUDA_GRAPH": "1", "ENABLE_NATIVE_CUDA_GRAPH": "0"},
+            {
+                ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV: "1",
+                "ENABLE_CUDA_GRAPH": "1",
+                "ENABLE_NATIVE_CUDA_GRAPH": "1",
+            },
+            clear=True,
+        ), patch.object(
+            deterministic_fp8_moe,
+            "_unsupported_reason",
+            return_value="test fallback",
         ):
-            with self.assertRaisesRegex(RuntimeError, "requires CUDA/HIP graph"):
-                _validate_runtime_mode()
-
-    @unittest.skipIf(
-        _IMPORT_ERROR is not None, f"ROCm imports unavailable: {_IMPORT_ERROR}"
-    )
-    def test_graph_disabled_is_supported(self):
-        with patch.dict(
-            os.environ,
-            {"ENABLE_CUDA_GRAPH": "0", "ENABLE_NATIVE_CUDA_GRAPH": "0"},
-        ):
-            _validate_runtime_mode()
+            self.assertIsNone(
+                deterministic_fp8_moe.try_deterministic_fp8_moe(
+                    None, None, None, None, None, None, None, None, None
+                )
+            )
 
 
 def _per_channel_quant_fp8(w: torch.Tensor, fp8_dtype: torch.dtype):
@@ -250,6 +257,12 @@ class _Fp8MoeBaseTest(unittest.TestCase):
         torch.set_default_device(self.device)
         torch.manual_seed(42)
         self.fp8_dtype = get_rocm_fp8_dtype()
+        self._feature_env = patch.dict(
+            os.environ,
+            {ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV: "0"},
+        )
+        self._feature_env.start()
+        self.addCleanup(self._feature_env.stop)
 
     def _build_payload(self, M, K, E, top_k):
         hidden_states = (
@@ -290,17 +303,24 @@ class RocmExpertsFp8PerChannelTest(_Fp8MoeBaseTest):
             silu_config.activation_type,
             swiglu_config.activation_type,
         )
-        for activation in silu_aliases:
-            with self.subTest(activation=activation):
-                self.assertEqual(
-                    _moe_activation_type(activation), aiter.ActivationType.Silu
-                )
+        with patch.dict(
+            os.environ,
+            {ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV: "1"},
+        ):
+            for activation in silu_aliases:
+                with self.subTest(activation=activation):
+                    self.assertEqual(
+                        _moe_activation_type(activation), aiter.ActivationType.Silu
+                    )
 
-        self.assertEqual(
-            _moe_activation_type("gelu"), aiter.ActivationType.Gelu
-        )
-        with self.assertRaisesRegex(ValueError, "Unsupported AITER FMoE activation"):
-            _moe_activation_type("unknown")
+            self.assertEqual(_moe_activation_type("gelu"), aiter.ActivationType.Gelu)
+            with self.assertRaisesRegex(
+                ValueError, "Unsupported AITER FMoE activation"
+            ):
+                _moe_activation_type("unknown")
+
+    def test_feature_disabled_keeps_legacy_activation_mapping(self):
+        self.assertEqual(_moe_activation_type("swiglu"), aiter.ActivationType.Gelu)
 
     def _run(self, apply_router_weight_on_input: bool):
         payload = self._build_payload(self.M, self.K, self.E, self.TOP_K)
@@ -379,7 +399,12 @@ class RocmExpertsFp8PerChannelTest(_Fp8MoeBaseTest):
         # PR #882 review #7 specifically called out this newly-enabled path.
         self._run(apply_router_weight_on_input=True)
 
+    @patch.dict(
+        os.environ,
+        {ROCM_FP8_MOE_DETERMINISTIC_REDUCE_ENV: "1"},
+    )
     def test_small_token_tuned_shape_with_loader_postprocess(self):
+        self.assertTrue(_AITER_TUNING_STATUS.applied, _AITER_TUNING_STATUS)
         hidden, local_inter, experts, top_k = 2048, 128, 256, 8
         runtime_device = RocmImpl.__new__(RocmImpl)
 

--- a/rtp_llm/models_py/triton_kernels/moe/fixed_order_route_reduce.py
+++ b/rtp_llm/models_py/triton_kernels/moe/fixed_order_route_reduce.py
@@ -1,0 +1,107 @@
+"""Deterministic helpers for route-local MoE stage-2 output on ROCm."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _make_route_local_ids_kernel(
+    sorted_ids_ptr,
+    route_ids_ptr,
+    count,
+    token_num,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < count
+    fused_ids = tl.load(sorted_ids_ptr + offsets, mask=mask, other=0)
+
+    # AITER encodes the source token in the low 24 bits and the TopK slot in
+    # the high 8 bits.  Flatten the pair into a unique stage-2 output row.
+    token_ids = fused_ids & 0xFFFFFF
+    slot_ids = fused_ids >> 24
+    route_num = token_num * TOPK
+    route_ids = tl.where(token_ids < token_num, token_ids * TOPK + slot_ids, route_num)
+    tl.store(route_ids_ptr + offsets, route_ids, mask=mask)
+
+
+@triton.jit
+def _fixed_order_fp32_route_reduce_kernel(
+    route_output_ptr,
+    output_ptr,
+    hidden_size,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    hidden_offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    hidden_mask = hidden_offsets < hidden_size
+    base_offset = token_id * TOPK * hidden_size + hidden_offsets
+
+    # A single program owns each output element.  The static loop gives every
+    # run the same slot order and keeps all intermediate sums in FP32.
+    accumulator = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    for slot in tl.static_range(0, TOPK):
+        route_value = tl.load(
+            route_output_ptr + base_offset + slot * hidden_size,
+            mask=hidden_mask,
+            other=0.0,
+        )
+        accumulator += route_value.to(tl.float32)
+
+    tl.store(
+        output_ptr + token_id * hidden_size + hidden_offsets,
+        accumulator,
+        mask=hidden_mask,
+    )
+
+
+def make_route_local_ids(
+    sorted_token_ids: torch.Tensor, token_num: int, topk: int
+) -> torch.Tensor:
+    """Map AITER's packed ``(token, slot)`` IDs to unique flat-route rows."""
+
+    assert sorted_token_ids.dtype == torch.int32
+    assert sorted_token_ids.is_contiguous()
+    assert token_num > 0
+    assert 0 < topk <= 255
+
+    route_ids = torch.empty_like(sorted_token_ids)
+    block_size = 256
+    _make_route_local_ids_kernel[(triton.cdiv(sorted_token_ids.numel(), block_size),)](
+        sorted_token_ids,
+        route_ids,
+        sorted_token_ids.numel(),
+        token_num,
+        TOPK=topk,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return route_ids
+
+
+def fixed_order_fp32_route_reduce(
+    route_output: torch.Tensor, output: torch.Tensor, topk: int
+) -> None:
+    """Reduce ``[token, slot, hidden]`` BF16 routes into BF16 token output."""
+
+    assert route_output.dtype == output.dtype
+    assert route_output.is_contiguous()
+    assert output.is_contiguous()
+    assert output.dim() == 2
+    assert route_output.shape == (output.shape[0] * topk, output.shape[1])
+
+    token_num, hidden_size = output.shape
+    block_size = 256
+    _fixed_order_fp32_route_reduce_kernel[
+        (token_num, triton.cdiv(hidden_size, block_size))
+    ](
+        route_output,
+        output,
+        hidden_size,
+        TOPK=topk,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )

--- a/rtp_llm/models_py/triton_kernels/moe/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/moe/test/BUILD
@@ -14,6 +14,17 @@ py_test(
 )
 
 py_test(
+    name = "test_fixed_order_route_reduce",
+    srcs = ["test_fixed_order_route_reduce.py"],
+    deps = [
+        "//rtp_llm/models_py/triton_kernels:moe",
+    ] + [":triton", ":torch"],
+    env = {"GPU_COUNT": "1"},
+    tags = ["rocm"],
+    exec_properties = {'gpu': 'MI308X-ROCM7', 'gpu_count': '1'},
+)
+
+py_test(
     name = "test_ep_kernels",
     srcs = ["test_ep_kernels.py"],
     deps = [

--- a/rtp_llm/models_py/triton_kernels/moe/test/test_fixed_order_route_reduce.py
+++ b/rtp_llm/models_py/triton_kernels/moe/test/test_fixed_order_route_reduce.py
@@ -1,0 +1,57 @@
+import unittest
+
+import torch
+
+from rtp_llm.models_py.triton_kernels.moe.fixed_order_route_reduce import (
+    fixed_order_fp32_route_reduce,
+    make_route_local_ids,
+)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA/HIP is required")
+class FixedOrderRouteReduceTest(unittest.TestCase):
+    def test_make_route_local_ids(self):
+        token_num = 3
+        topk = 2
+        packed_ids = torch.tensor(
+            [0, (1 << 24) | 2, 3, (7 << 24) | 0xFFFFFF],
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        actual = make_route_local_ids(packed_ids, token_num, topk)
+
+        torch.testing.assert_close(
+            actual.cpu(), torch.tensor([0, 5, 6, 6], dtype=torch.int32)
+        )
+
+    def test_reduce_matches_fixed_fp32_order_and_repeats_exactly(self):
+        torch.manual_seed(7)
+        token_num, topk, hidden_size = 5, 8, 513
+        route_output = torch.randn(
+            token_num * topk,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        route_view = route_output.view(token_num, topk, hidden_size)
+        expected_fp32 = torch.zeros(
+            token_num, hidden_size, dtype=torch.float32, device="cuda"
+        )
+        for slot in range(topk):
+            expected_fp32.add_(route_view[:, slot].float())
+        expected = expected_fp32.bfloat16()
+
+        first = None
+        for _ in range(20):
+            actual = torch.empty_like(expected)
+            fixed_order_fp32_route_reduce(route_output, actual, topk)
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+            if first is None:
+                first = actual.clone()
+            else:
+                torch.testing.assert_close(actual, first, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/start_backend_server.py
+++ b/rtp_llm/start_backend_server.py
@@ -22,6 +22,7 @@ from rtp_llm.config.server_config_setup import (
     set_parallelism_config,
     setup_cuda_device_and_accl_env,
 )
+from rtp_llm.models_py.kernel_tuning import configure_kernel_tuning
 from rtp_llm.utils.concurrency_controller import (
     ConcurrencyController,
     set_global_controller,
@@ -88,6 +89,7 @@ def local_rank_start(
         py_env_configs.server_config.set_local_rank(local_rank)
         py_env_configs.distribute_config.set_local_rank(local_rank)
         setup_cuda_device_and_accl_env(local_rank)
+        configure_kernel_tuning()
         if py_env_configs.parallelism_config.world_size > 1:
             setproctitle(f"rtp_llm_rank-{local_rank}")
         set_global_controller(global_controller)

--- a/rtp_llm/utils/test/jit_cache_manager_test.py
+++ b/rtp_llm/utils/test/jit_cache_manager_test.py
@@ -1028,11 +1028,13 @@ class BackendTest(JitCacheTestBase):
 
     def test_runtime_handler_installed_after_start_requests_shutdown(self):
         handlers = {}
+        events = []
 
         class FakeBackendManager:
             instance = None
 
             def __init__(self, _configs):
+                events.append("backend")
                 self.request_shutdown = mock.Mock()
                 self.serve_forever = mock.Mock()
                 FakeBackendManager.instance = self
@@ -1052,11 +1054,24 @@ class BackendTest(JitCacheTestBase):
             for name in (
                 "copy_gemm_config",
                 "set_parallelism_config",
-                "setup_cuda_device_and_accl_env",
                 "set_global_controller",
                 "setproctitle",
             ):
                 stack.enter_context(mock.patch.object(backend, name))
+            stack.enter_context(
+                mock.patch.object(
+                    backend,
+                    "setup_cuda_device_and_accl_env",
+                    side_effect=lambda *_: events.append("device"),
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    backend,
+                    "configure_kernel_tuning",
+                    side_effect=lambda: events.append("tuning"),
+                )
+            )
             stack.enter_context(
                 mock.patch.object(
                     backend.signal,
@@ -1067,6 +1082,7 @@ class BackendTest(JitCacheTestBase):
             stack.enter_context(mock.patch.object(backend, "_send_pipe_status", status))
             backend.local_rank_start(None, configs, pipe_writer=object())
         self.assertEqual(status.call_args[0][1], "success")
+        self.assertEqual(events, ["device", "tuning", "backend"])
         handlers[backend.signal.SIGTERM](backend.signal.SIGTERM, None)
         FakeBackendManager.instance.request_shutdown.assert_called_once_with()
         FakeBackendManager.instance.serve_forever.assert_called_once_with()


### PR DESCRIPTION
## Summary

- add centralized ROCm FP8 FMoE kernel tuning
- add route-local CK stage-2 output plus fixed-order FP32 reduction for the affected Qwen3.5 TP2 FP8-per-channel MoE workload
- use `RTP_LLM_ROCM_FP8_MOE_DETERMINISTIC_REDUCE` as the single opt-in switch for tuning, deterministic reduction, and graph workspace stabilization
- preserve existing behavior when the switch is disabled; do not disable or restrict CUDA/HIP graph

This branch is intended only for merging the isolated change into `main`. Packaging and Whale template cloning are performed from the release-target branch.

## Validation

- ROCm Bazel focused suite: 5/5 targets passed on the release-target branch
- captured TP2 rank outputs: 200 replays per rank, one unique hash per rank
- `ENABLE_CUDA_GRAPH=1`, cache reuse on: 100/100 responses produced the expected business JSON
- `ENABLE_CUDA_GRAPH=1`, cache reuse off: 100/100 responses produced the same parsed business JSON (two whitespace-only serializations)

A separate AITER-version A/B was intentionally not run.
