### PR TITLE
feat(flexlb): support logical multi-engine workers

### DIFF
--- a/rtp_llm/cpp/model_rpc/proto/flexlb_schedule_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/flexlb_schedule_service.proto
@@ -72,6 +72,8 @@ message FlexlbServerStatusPB {
     int32 http_port = 3;
     int32 grpc_port = 4;
     reserved 5;
+    // Present only for a multi-engine frontend; zero is a valid selected index.
+    optional int32 engine_index = 6;
 }
 
 // Why an incoming request was rejected by the admission decision.  This is

--- a/rtp_llm/flexlb/README.md
+++ b/rtp_llm/flexlb/README.md
@@ -370,9 +370,21 @@ Each endpoint must contain exactly one `discovery` object. Supported types are:
 - `dashscope`: Uses `address` as the virtual service ID (internal builds). `base_url` defaults to
   `http://127.0.0.1:8880` when omitted.
 
-`worker_status_port` is optional and controls the gRPC port used only for `GetWorkerStatus`.
+`worker_status_port` is optional and controls the per-engine gRPC port used for `GetWorkerStatus`
+and `GetCacheStatus`.
+When configured, it must be in the TCP port range `[1, 65535]`, including single-engine endpoints.
 When omitted, FlexLB uses the endpoint gRPC port (`http` discovery port + 1, or the discovered
-port itself when `protocol` is `grpc`).
+port itself when `protocol` is `grpc`). `multi_engine_num` defaults to `1`. When it is greater
+than `1`, `worker_status_port` is required and logical engine index `i` is polled at
+`worker_status_port + i`; the endpoint protocol does not change this status-port range.
+
+Each discovered frontend expands to `multi_engine_num` logical workers identified as
+`ip:http_port@index` (including `@0` when the value is `1`). The frontend HTTP/gRPC address stays
+physical and shared. If any index in a physical frontend is unhealthy, FlexLB removes all of its
+logical siblings from routing; resource capacity, queue state, and cache ownership remain
+independent per index. The schedule response omits `engine_index` when `multi_engine_num` is `1`
+and returns the selected index when it is greater than `1`; internal cache and rollback identities
+remain index-qualified in both cases.
 
 Discovery runtime policy belongs to `FLEXLB_CONFIG`, not to each topology endpoint:
 

--- a/rtp_llm/flexlb/docs/architecture/00-overview.md
+++ b/rtp_llm/flexlb/docs/architecture/00-overview.md
@@ -89,8 +89,12 @@ LoadBalancer 策略选 worker（读 EngineWorkerStatus 共享状态 + CacheAware
 ## 核心不变量
 
 - **路由读、同步写**：`EngineWorkerStatus.MODEL_ROLE_WORKER_STATUS`（静态单例，四个角色各一个
-  `ConcurrentHashMap<ip:port, WorkerStatus>`）由后台同步线程写、路由线程读；`WorkerStatus`
-  内所有计数为 Atomic 字段，原子性是**字段级**而非快照级。
+  `ConcurrentHashMap<ip:httpPort@index, WorkerStatus>`）由后台同步线程写、路由线程读；
+  `WorkerStatus` 内所有计数为 Atomic 字段，原子性是**字段级**而非快照级。
+- **内部逻辑地址、外部物理地址**：worker 身份内部一律用逻辑 `ip:httpPort@index`
+  （map key、cache 匹配、回滚、feedback，N=1 也是 `@0`）；对外（schedule 响应、gRPC 拨号）
+  一律用物理地址，线上协议不出现 `@index`，仅 N>1 时 schedule 响应附加 wire
+  `engine_index`。
 - **选中即记账，失败必回滚**：策略 `select()` 成功即 `putLocalTask()` 预扣队列时间与 KV
   token；多阶段路由部分失败必须经 `rollBackRoutingFailure()` → `removeLocalTask()` 撤销。
 - **本地预测 + 引擎对账**：`localTaskMap` 记录 IN_TRANSIT 任务；引擎状态返回后

--- a/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
+++ b/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
@@ -32,7 +32,9 @@ worker 选择契约，两者组合完成多角色多阶段路由。
    worker group 约束后续所有角色的候选集**（group 亲和链，如 DECODE 选中的 group 决定
    PREFILL 只能在同 group 中选）。任一角色失败立即返回
    `RoutingResult.failure(已成功列表, 失败角色, 错误信息)`。
-4. **响应**：全部成功 → success 响应（携带 `List<ServerStatus>`）；失败 → 先
+4. **响应**：全部成功 → success 响应（携带 `List<ServerStatus>`；物理
+   `server_ip/http_port/grpc_port` 保持不变，N>1 时每个成功项带逻辑 `engine_index`，
+   N=1 时省略该字段）；失败 → 先
    `rollBackRoutingFailure()` 再构造错误响应，错误码取
    `failedRoleType.getErrorType().getErrorCode()`。
 
@@ -49,10 +51,20 @@ worker 选择契约，两者组合完成多角色多阶段路由。
 | DECODE | `decodeLoadBalanceStrategy` | `WEIGHTED_CACHE` | `REMAINING_KV_CACHE` |
 | VIT | `vitLoadBalanceStrategy` | `RANDOM` | `WAIT_TIME` |
 
+### gRPC Schedule 响应
+
+`FlexlbService.Schedule` 的 `FlexlbServerStatusPB` 使用 `optional int32 engine_index = 6`。
+字段号 5 保持 reserved。N=1 不设置字段；N>1 设置所选 index，包含显式 0，调用方应通过
+字段 presence 区分这两种情况。`FlexlbServiceImpl` 从内部 `ServerStatus` 转换时保留该语义；
+master forwarding 透传 protobuf 响应。物理地址字段与既有 service path 不变，旧客户端可忽略
+新增字段。此字段不改变 `EnqueueBatch` 的派发协议。
+
 ## 回滚机制
 
 `DefaultRouter.rollBackRoutingFailure()`：对 `RoutingResult` 中已成功的每个 `ServerStatus`，
-以 `serverIp:httpPort` 调用对应策略的 `rollBack(ipPort, requestId)`。
+以内部 `serverIp:httpPort@routingEngineIndex` 调用对应策略的 `rollBack(ipPort, requestId)`。
+`routingEngineIndex` 不序列化且始终存在，因此 N=1 对外省略 `engine_index` 时仍精确回滚
+`@0`；N>1 的 wire `engine_index` 只负责把选择结果传给共享 frontend。
 
 回滚的实体是**选中时的本地记账**——`WorkerStatus.removeLocalTask(requestId)` 逆转
 `putLocalTask()`：从 `runningQueueTime` 扣回估算 prefill 时间（下限 0）、把
@@ -68,16 +80,22 @@ worker 选择契约，两者组合完成多角色多阶段路由。
 均实现 `LoadBalancer.select(ctx, roleType, group)`，注册名见 `LoadBalanceStrategyEnum`
 （RANDOM / SHORTEST_TTFT / CACHE_AFFINITY_FIRST / WEIGHTED_CACHE）。
 
+所有策略先通过 `EngineWorkerStatus.selectRoutableModelWorkerStatus()` 的公共健康门控：同一
+endpoint/group/物理 frontend 展开的 `multiEngineNum` 个逻辑 worker 必须齐全、index 唯一且
+全部 `alive`，否则整组从候选集中移除。该 AND 只约束健康；门控后的资源、队列、cache 命中、
+outstanding tokens 和 score 仍读取当前 `ip:httpPort@index` 自己的状态。
+
 ### RandomStrategy
 
-随机起点环形扫描，取第一个 `isAlive()` 的 worker。不看资源水位、不做 cache 匹配、
+公共物理健康门控后随机起点环形扫描，取第一个 `isAlive()` 的逻辑 worker。不看资源水位、不做 cache 匹配、
 **不 `putLocalTask()`**（因此 rollBack 为空实现）。
 
 ### ShortestTTFTStrategy（PREFILL/PDFUSION 默认）
 
 1. **候选过滤**：`isAlive()` 且 `ResourceMeasure.isResourceAvailable()`（PREFILL 用等待队列
    长度 + 滞回，见 [03-resource-management](03-resource-management.md)）。
-2. **cache 匹配**：`CacheAwareService.findMatchingEngines()`（见
+2. **cache 匹配**：`CacheAwareService.findMatchingEngines()`，用逻辑
+   `ip:httpPort@index` exact-match cache ownership（见
    [04-worker-sync-and-cache](04-worker-sync-and-cache.md)）。
 3. **打分**：每个 worker 计算
    `hitCacheTokens = blockSize × 匹配块数`，

--- a/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
+++ b/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
@@ -84,6 +84,8 @@ master forwarding 透传 protobuf 响应。物理地址字段与既有 service p
 endpoint/group/物理 frontend 展开的 `multiEngineNum` 个逻辑 worker 必须齐全、index 唯一且
 全部 `alive`，否则整组从候选集中移除。该 AND 只约束健康；门控后的资源、队列、cache 命中、
 outstanding tokens 和 score 仍读取当前 `ip:httpPort@index` 自己的状态。
+候选筛选按物理组一次计算健康状态；最终路由选择及 admission 提交（含 prefill queue
+抢占）重新检查当前组健康，失效时释放 incoming 的预留并拒绝提交，保留已有 victim。
 
 ### RandomStrategy
 

--- a/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
+++ b/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
@@ -22,6 +22,25 @@ KVCM（外部 KV Cache Manager）、LOCAL_STANDBY（KVCM 的本地兜底）。
     一个在途状态检查**；
   - **仅当 `!kvcmEnabled`** 时提交 `GrpcCacheStatusCheckRunner`（`cacheCheckInProgress` CAS）。
 
+一个服务发现 frontend 会按 Endpoint `multi_engine_num` 展开为 N 个逻辑 worker，map key
+统一为 `ip:httpPort@index`（N=1 也是 `@0`）。frontend HTTP/gRPC 地址保持共享；第 i 个
+`GrpcWorkerStatusRunner` 独立连接 `worker_status_port + i`。N>1 必须显式配置 status base，
+配置加载时同时校验 count、base 和 `base + N - 1 <= 65535`。
+
+worker 地址表示由不可变 `WorkerIdentity` 一次性预计算并保存，调用方不再解析或临时拼接：
+
+| 表示 | 格式 | 用途 |
+|---|---|---|
+| raw IP | `ip` | 网络连接与服务发现 |
+| raw port | `port` | 共享 frontend 端口 |
+| raw engine index | `engineIndex` | 逻辑引擎序号 |
+| physical IP-port | `ip:port` | 共享 frontend 身份、物理健康分组 |
+| logical IP-port | `ip:port@index` | 路由、rollback、KVCM 与 cache key |
+| metrics IP-index | `ip@index` | 所有可归属具体引擎的 `engineIp` 指标标签 |
+
+`WorkerHost` 在服务发现展开时持有该 identity；`WorkerStatus` 更新任一 raw 字段时原子替换
+整份 identity，保证三种派生表示来自同一个快照。N=1 也保留 `@0`。
+
 ### GrpcWorkerStatusRunner
 
 gRPC `getWorkerStatus`（VIT 走 multimodal 变体）携带 `latest_finished_version` 做增量拉取。
@@ -34,6 +53,10 @@ dp/tp size、内嵌 `cache_status`、`block_hash_lookahead_tokens`、`cache_matc
 处理逻辑：版本号新才全量更新（并发/任务表/队列时间）；版本号旧也更新 alive、时间戳并做任务
 对账；`cache_status` 总量恒更新（used = total − available）。带 `CacheHitFeedback` 的完成
 任务会异步送 `CacheAwareService.buildCacheHitComparison`（预测 vs 实际命中对比，出指标 + pv 日志）。
+连续 3 次 RPC 失败会把该逻辑 worker 标为不健康并移除其 endpoint；公共 physical AND
+gate 同时将所有 siblings 排除出路由候选，成功状态恢复且整组健康后才重新可路由。
+新发现的 worker 在首次接受有效状态前不可路由。空响应标为不健康；未初始化状态
+（`status_version=0`）与响应处理异常跳过本轮更新。
 
 ### WorkerStatus 的本地预测与对账
 
@@ -77,6 +100,10 @@ cache 版本做增量；响应恒更新 KV token 总量，版本更新时把 `ca
   `calculateDiff` 在专用 ForkJoinPool 上并行算 added/removed，diff 大小回馈动态间隔服务。
 - `KvCacheManager`：门面——`findMatchingEngines`（候选来自 `WorkerStatusProvider`）、
   `updateEngineCache`（diff 后双表应用）、`removeStaleEngineCaches`、`clear`。
+
+上述 LOCAL_SYNC key、KVCM `host_ip_port`、LOCAL_STANDBY 映射与 cache-hit comparison 均使用
+逻辑 `ip:httpPort@index`。KVCM 对 N=1 worker 兼容旧 physical `ip:httpPort` key：logical key
+未命中时才回退查询 physical key；N>1 或非 KVCM source 仍要求 exact match，无法匹配时按零命中忽略。
 
 ### KVCM（外部 KV Cache Manager）
 

--- a/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
+++ b/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
@@ -24,8 +24,9 @@ KVCM（外部 KV Cache Manager）、LOCAL_STANDBY（KVCM 的本地兜底）。
 
 一个服务发现 frontend 会按 Endpoint `multi_engine_num` 展开为 N 个逻辑 worker，map key
 统一为 `ip:httpPort@index`（N=1 也是 `@0`）。frontend HTTP/gRPC 地址保持共享；第 i 个
-`GrpcWorkerStatusRunner` 独立连接 `worker_status_port + i`。N>1 必须显式配置 status base，
-配置加载时同时校验 count、base 和 `base + N - 1 <= 65535`。
+`GrpcWorkerStatusRunner` 在 N>1 时独立连接 `worker_status_port + i`；N=1 使用发现到的
+legacy gRPC port。N>1 必须显式配置 status base，配置加载时同时校验 count、base 和
+`base + N - 1 <= 65535`。
 
 worker 地址表示由不可变 `WorkerIdentity` 一次性预计算并保存，调用方不再解析或临时拼接：
 
@@ -36,7 +37,7 @@ worker 地址表示由不可变 `WorkerIdentity` 一次性预计算并保存，�
 | raw engine index | `engineIndex` | 逻辑引擎序号 |
 | physical IP-port | `ip:port` | 共享 frontend 身份、物理健康分组 |
 | logical IP-port | `ip:port@index` | 路由、rollback、KVCM 与 cache key |
-| metrics IP-index | `ip@index` | 所有可归属具体引擎的 `engineIp` 指标标签 |
+| metrics logical IP-port | `ip:port@index` | 所有可归属具体引擎的 `engineIp` 指标标签 |
 
 `WorkerHost` 在服务发现展开时持有该 identity；`WorkerStatus` 更新任一 raw 字段时原子替换
 整份 identity，保证三种派生表示来自同一个快照。N=1 也保留 `@0`。

--- a/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
+++ b/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
@@ -217,3 +217,14 @@ logger group `flexlb` 包含 `org.flexlb`、`flexlbLogger`、`syncLogger`、
 
 Spring profile 与日志、监控 provider 的具体默认值见
 `flexlb-api/src/main/resources/application.yml`。
+
+## Multi-engine endpoint 与观测
+
+`MODEL_SERVICE_CONFIG` 的 endpoint 支持 `multi_engine_num`（默认 1）。显式
+`worker_status_port` 必须处于 `[1, 65535]`；N>1 必须指定该端口，并保证
+`worker_status_port + N - 1 <= 65535`。每个 index 使用独立的 status gRPC 端口，
+frontend HTTP/gRPC 仍为共享物理地址。protocol 只解释 frontend discovery port。
+
+逻辑 worker identity 为 `ip:http_port@engineIndex`，包括 N=1 的 `@0`。
+引擎与 cache 指标的 `engineIp` 使用不含端口的 `ip@engineIndex`；网络连接仍使用
+物理地址。schedule 在 N=1 时省略 `engine_index`，内部 identity 和观测仍保留 index 0。

--- a/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
+++ b/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
@@ -224,7 +224,9 @@ Spring profile 与日志、监控 provider 的具体默认值见
 `worker_status_port` 必须处于 `[1, 65535]`；N>1 必须指定该端口，并保证
 `worker_status_port + N - 1 <= 65535`。每个 index 使用独立的 status gRPC 端口，
 frontend HTTP/gRPC 仍为共享物理地址。protocol 只解释 frontend discovery port。
+N=1 沿用 discovery 的 legacy gRPC port，因而兼容未配置 `worker_status_port` 的 RTP-LLM。
 
 逻辑 worker identity 为 `ip:http_port@engineIndex`，包括 N=1 的 `@0`。
-引擎与 cache 指标的 `engineIp` 使用不含端口的 `ip@engineIndex`；网络连接仍使用
-物理地址。schedule 在 N=1 时省略 `engine_index`，内部 identity 和观测仍保留 index 0。
+引擎与 cache 指标的 `engineIp` 使用完整 logical identity `ip:http_port@engineIndex`；
+网络连接仍使用物理地址。schedule 在 N=1 时省略 `engine_index`，内部 identity 和观测仍保留
+index 0。

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
@@ -970,12 +970,16 @@ public class FlexlbServiceImpl extends FlexlbServiceGrpc.FlexlbServiceImplBase {
 
         if (response.getServerStatus() != null) {
             for (ServerStatus ss : response.getServerStatus()) {
-                builder.addServerStatus(FlexlbScheduleProtocol.FlexlbServerStatusPB.newBuilder()
-                        .setRole(ss.getRole().getCode())
-                        .setServerIp(ss.getServerIp() != null ? ss.getServerIp() : "")
-                        .setHttpPort(ss.getHttpPort())
-                        .setGrpcPort(ss.getGrpcPort())
-                        .build());
+                FlexlbScheduleProtocol.FlexlbServerStatusPB.Builder status =
+                        FlexlbScheduleProtocol.FlexlbServerStatusPB.newBuilder()
+                                .setRole(ss.getRole().getCode())
+                                .setServerIp(ss.getServerIp() != null ? ss.getServerIp() : "")
+                                .setHttpPort(ss.getHttpPort())
+                                .setGrpcPort(ss.getGrpcPort());
+                if (ss.getEngineIndex() != null) {
+                    status.setEngineIndex(ss.getEngineIndex());
+                }
+                builder.addServerStatus(status);
             }
         }
         return builder.build();

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
@@ -667,7 +667,7 @@ public class FlexlbServiceImpl extends FlexlbServiceGrpc.FlexlbServiceImplBase {
             if (ctx.getResponse() != null && ctx.getResponse().getServerStatus() != null) {
                 for (ServerStatus ss : ctx.getResponse().getServerStatus()) {
                     if (ss.getRole() == RoleType.PREFILL) {
-                        prefillIp = ss.getServerIp() != null ? ss.getServerIp() : "";
+                        prefillIp = ss.getLogicalIpPort() != null ? ss.getLogicalIpPort() : "";
                         break;
                     }
                 }

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/RequestSchedulerTestRuntime.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/RequestSchedulerTestRuntime.java
@@ -213,7 +213,7 @@ public final class RequestSchedulerTestRuntime implements AutoCloseable {
                 if (status == null) {
                     continue;
                 }
-                String address = status.getServerIp() + ":" + status.getHttpPort();
+                String address = status.getLogicalIpPort();
                 WorkerEndpoint.GenerationPin pin = registry.capture(
                         status.getRole(), address);
                 if (pin == null) {

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/RequestSchedulerTestRuntime.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/RequestSchedulerTestRuntime.java
@@ -162,11 +162,11 @@ public final class RequestSchedulerTestRuntime implements AutoCloseable {
         Objects.requireNonNull(observation, "observation");
         RoleType role = observation.role();
         WorkerEndpoint endpoint = registry.get(
-                role, status.getIpPort(), status);
+                role, status.getLogicalIpPort(), status);
         if (endpoint == null) {
             throw new IllegalStateException(
                     "status generation has no published endpoint: "
-                            + status.getIpPort() + "#" + status.getGenerationId());
+                            + status.getLogicalIpPort() + "#" + status.getGenerationId());
         }
 
         Runnable projection;

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/TransientCapacityQueueContractTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/TransientCapacityQueueContractTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -580,44 +581,53 @@ class TransientCapacityQueueContractTest {
 
         try (Fixture fixture = new Fixture(null, config)) {
             fixture.submission.blockPreparation();
-            CompletableFuture<Response> waiting =
-                    fixture.runtime.scheduler().submit(
-                            fixture.context(501L, 50, 128_000L));
-            assertTrue(fixture.submission.awaitPreparation(
-                    2, TimeUnit.SECONDS));
+            try {
+                CompletableFuture<Response> waiting =
+                        fixture.runtime.scheduler().submit(
+                                fixture.context(501L, 50, 128_000L));
+                assertTrue(fixture.submission.awaitPreparation(
+                        2, TimeUnit.SECONDS));
+                assertSame(fixture.decodeStatus,
+                        fixture.runtime.endpointRegistry().get(
+                                RoleType.DECODE,
+                                fixture.decodeStatus.getLogicalIpPort())
+                                .getStatus());
 
-            fixture.runtime.applyStatus(
-                    fixture.decodeStatus,
-                    statusResponse(RoleType.DECODE, 2L, true));
-            WorkerStatus spareStatus = initializedStatus(
-                    RoleType.DECODE, "127.0.0.2", 18_082);
-            DecodeEndpoint spareEndpoint = (DecodeEndpoint)
-                    publishEndpoint(
-                            fixture.runtime.endpointRegistry(),
-                            RoleType.DECODE,
-                            "127.0.0.2:18082",
-                            spareStatus);
+                fixture.runtime.applyStatus(
+                        fixture.decodeStatus,
+                        statusResponse(RoleType.DECODE, 2L, true));
+                WorkerStatus spareStatus = initializedStatus(
+                        RoleType.DECODE, "127.0.0.2", 18_082);
+                DecodeEndpoint spareEndpoint = (DecodeEndpoint)
+                        publishEndpoint(
+                                fixture.runtime.endpointRegistry(),
+                                RoleType.DECODE,
+                                "127.0.0.2:18082",
+                                spareStatus);
 
-            fixture.submission.unblockPreparation();
+                fixture.submission.unblockPreparation();
 
-            assertFalse(fixture.submission.awaitCommands(
-                    1, 200, TimeUnit.MILLISECONDS));
-            assertFalse(waiting.isDone(),
-                    "the committed route waits for its exact Decode capacity");
-            assertEquals(0, spareEndpoint.routingView().engineLoad(),
-                    "a committed route must not switch to a newly idle Decode");
+                assertFalse(fixture.submission.awaitCommands(
+                        1, 200, TimeUnit.MILLISECONDS));
+                assertFalse(waiting.isDone(),
+                        "the committed route waits for its exact Decode capacity");
+                assertEquals(0, spareEndpoint.routingView().engineLoad(),
+                        "a committed route must not switch to a newly idle Decode");
 
-            fixture.runtime.applyStatus(
-                    fixture.decodeStatus,
-                    statusResponse(RoleType.DECODE, 3L, false));
+                fixture.runtime.applyStatus(
+                        fixture.decodeStatus,
+                        statusResponse(RoleType.DECODE, 3L, false));
 
-            Response response = waiting.get(2, TimeUnit.SECONDS);
-            assertTrue(response.isSuccess());
-            assertEquals("127.0.0.1:18081", decodeAddress(response));
-            assertEquals(List.of("127.0.0.1:18081"),
-                    fixture.submission.decodeAddresses());
-            assertEquals(0, spareEndpoint.routingView().engineLoad(),
-                    "a committed route must not switch to a newly idle Decode");
+                Response response = waiting.get(2, TimeUnit.SECONDS);
+                assertTrue(response.isSuccess());
+                assertEquals("127.0.0.1:18081", decodeAddress(response));
+                assertEquals(List.of("127.0.0.1:18081"),
+                        fixture.submission.decodeAddresses());
+                assertEquals(0, spareEndpoint.routingView().engineLoad(),
+                        "a committed route must not switch to a newly idle Decode");
+            } finally {
+                fixture.submission.unblockPreparation();
+            }
         }
     }
 
@@ -1316,15 +1326,17 @@ class TransientCapacityQueueContractTest {
     private static WorkerEndpoint publishEndpoint(
             EndpointRegistry registry,
             RoleType role,
-            String address,
+            String physicalAddress,
             WorkerStatus status) {
+        assertEquals(physicalAddress, status.getPhysicalIpPort());
         WorkerStatusResponse response = statusResponse(role, 1L, false);
         status.lock.lock();
         try {
             WorkerStatus.PreparedStatus prepared = status.prepareNewStatus(
                     status.freezeStatusResponse(response));
             WorkerEndpoint endpoint = registry
-                    .publishPreparedEndpoint(address, status, prepared)
+                    .publishPreparedEndpoint(
+                            status.getLogicalIpPort(), status, prepared)
                     .endpoint();
             status.recordSuccessfulPoll(true);
             return endpoint;
@@ -1431,7 +1443,8 @@ class TransientCapacityQueueContractTest {
                 new CopyOnWriteArrayList<>();
         private final Semaphore commandSignals = new Semaphore(0);
         private final Semaphore preparationSignals = new Semaphore(0);
-        private final Semaphore preparationReleases = new Semaphore(0);
+        private final CountDownLatch preparationReleases =
+                new CountDownLatch(1);
         private final AtomicBoolean holdCompletions = new AtomicBoolean();
         private final AtomicBoolean blockPreparation = new AtomicBoolean();
 
@@ -1440,7 +1453,18 @@ class TransientCapacityQueueContractTest {
                 tryPrepareSubmission() {
             if (blockPreparation.get()) {
                 preparationSignals.release();
-                preparationReleases.acquireUninterruptibly();
+                boolean interrupted = false;
+                while (true) {
+                    try {
+                        preparationReleases.await();
+                        break;
+                    } catch (InterruptedException interruption) {
+                        interrupted = true;
+                    }
+                }
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
             }
             return CapacityBoundary.Attempt.accepted(
                     new BatchDeliveryStrategy.PreparedSubmission() {
@@ -1504,7 +1528,7 @@ class TransientCapacityQueueContractTest {
 
         private void unblockPreparation() {
             blockPreparation.set(false);
-            preparationReleases.release();
+            preparationReleases.countDown();
         }
 
         private void holdCompletions() {

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/httpserver/FlexlbScheduleEngineIndexTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/httpserver/FlexlbScheduleEngineIndexTest.java
@@ -1,0 +1,137 @@
+package org.flexlb.httpserver;
+
+import io.grpc.stub.StreamObserver;
+import org.flexlb.cache.match.CacheAwareService;
+import org.flexlb.config.ConfigService;
+import org.flexlb.config.FlexlbConfig;
+import org.flexlb.consistency.LBStatusConsistencyService;
+import org.flexlb.dao.BalanceContext;
+import org.flexlb.dao.loadbalance.Response;
+import org.flexlb.dao.loadbalance.ServerStatus;
+import org.flexlb.dao.route.RoleType;
+import org.flexlb.schedule.grpc.FlexlbScheduleProtocol;
+import org.flexlb.service.RouteService;
+import org.flexlb.service.grace.ActiveRequestCounter;
+import org.flexlb.service.monitor.BatchSchedulerReporter;
+import org.flexlb.service.monitor.EngineHealthReporter;
+import org.flexlb.service.monitor.RequestSchedulerReporter;
+import org.flexlb.service.optimizer.OptimizerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FlexlbScheduleEngineIndexTest {
+
+    private RouteService routeService;
+    private FlexlbServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        routeService = mock(RouteService.class);
+        LBStatusConsistencyService consistencyService =
+                mock(LBStatusConsistencyService.class);
+        when(consistencyService.isNeedConsistency()).thenReturn(false);
+
+        ConfigService configService = mock(ConfigService.class);
+        when(configService.loadBalanceConfig()).thenReturn(new FlexlbConfig());
+
+        ActiveRequestCounter activeRequestCounter = mock(ActiveRequestCounter.class);
+        when(activeRequestCounter.acquire()).thenReturn(
+                mock(ActiveRequestCounter.RequestToken.class));
+
+        CacheAwareService cacheAwareService = mock(CacheAwareService.class);
+        when(cacheAwareService.prepareBlockCacheKeys(any(BalanceContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        service = new FlexlbServiceImpl(
+                routeService,
+                consistencyService,
+                mock(EngineHealthReporter.class),
+                activeRequestCounter,
+                null,
+                configService,
+                mock(BatchSchedulerReporter.class),
+                mock(ServerScheduleLatencyRecorder.class),
+                mock(RequestSchedulerReporter.class),
+                cacheAwareService,
+                mock(OptimizerClient.class));
+    }
+
+    @Test
+    void scheduleIncludesEngineIndexForMultiEngineWorker() {
+        when(routeService.route(any(BalanceContext.class))).thenReturn(
+                CompletableFuture.completedFuture(response(serverStatus(1, 2))));
+
+        FlexlbScheduleProtocol.FlexlbScheduleResponsePB response = schedule();
+
+        assertTrue(response.getSuccess());
+        assertEquals(1, response.getServerStatusCount());
+        FlexlbScheduleProtocol.FlexlbServerStatusPB selected =
+                response.getServerStatus(0);
+        assertEquals("127.0.0.1", selected.getServerIp());
+        assertEquals(8080, selected.getHttpPort());
+        assertEquals(8081, selected.getGrpcPort());
+        assertTrue(selected.hasEngineIndex());
+        assertEquals(1, selected.getEngineIndex());
+    }
+
+    @Test
+    void scheduleOmitsEngineIndexForSingleEngineWorker() {
+        when(routeService.route(any(BalanceContext.class))).thenReturn(
+                CompletableFuture.completedFuture(response(serverStatus(0, 1))));
+
+        FlexlbScheduleProtocol.FlexlbScheduleResponsePB response = schedule();
+
+        assertTrue(response.getSuccess());
+        assertEquals(1, response.getServerStatusCount());
+        assertFalse(response.getServerStatus(0).hasEngineIndex());
+    }
+
+    private FlexlbScheduleProtocol.FlexlbScheduleResponsePB schedule() {
+        StreamObserver<FlexlbScheduleProtocol.FlexlbScheduleResponsePB> observer =
+                mock(StreamObserver.class);
+        service.schedule(FlexlbScheduleProtocol.FlexlbScheduleRequestPB.newBuilder()
+                .setRequestId("5001")
+                .setSeqLen(16)
+                .build(), observer);
+
+        ArgumentCaptor<FlexlbScheduleProtocol.FlexlbScheduleResponsePB> captor =
+                ArgumentCaptor.forClass(
+                        FlexlbScheduleProtocol.FlexlbScheduleResponsePB.class);
+        org.mockito.Mockito.verify(observer).onNext(captor.capture());
+        org.mockito.Mockito.verify(observer).onCompleted();
+        return captor.getValue();
+    }
+
+    private static Response response(ServerStatus status) {
+        Response response = new Response();
+        response.setSuccess(true);
+        response.setCode(200);
+        response.setServerStatus(List.of(status));
+        return response;
+    }
+
+    private static ServerStatus serverStatus(int engineIndex, int multiEngineNum) {
+        ServerStatus status = new ServerStatus();
+        status.setSuccess(true);
+        status.setRole(RoleType.DECODE);
+        status.setServerIp("127.0.0.1");
+        status.setHttpPort(8080);
+        status.setGrpcPort(8081);
+        status.setDpRank(0);
+        status.setGroup("test-group");
+        status.setRequestId("5001");
+        status.setSelectedEngineIndex(engineIndex, multiEngineNum);
+        return status;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/FlexLBMockTestBase.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/FlexLBMockTestBase.java
@@ -350,12 +350,12 @@ public abstract class FlexLBMockTestBase {
 
     protected PrefillEndpoint getPrefillEndpoint() {
         return (PrefillEndpoint) endpointRegistry.get(
-                RoleType.PREFILL, prefillIpPort);
+                RoleType.PREFILL, logicalWorkerIpPort(prefillIpPort));
     }
 
     protected DecodeEndpoint getDecodeEndpoint() {
         return (DecodeEndpoint) endpointRegistry.get(
-                RoleType.DECODE, decodeIpPort);
+                RoleType.DECODE, logicalWorkerIpPort(decodeIpPort));
     }
 
     // ==================== Helper: multi-worker support ====================
@@ -405,10 +405,31 @@ public abstract class FlexLBMockTestBase {
     }
 
     /**
-     * Get the {@code ip:httpPort} string for a mock worker (for routing/endpoint lookup).
+     * Get the {@code ip:httpPort} string for a mock worker.
      */
     protected static String workerIpPort(MockWorker worker) {
         return "127.0.0.1:" + worker.getHttpPort();
+    }
+
+    protected static String logicalWorkerIpPort(String ipPort) {
+        return ipPort.contains("@") ? ipPort : ipPort + "@0";
+    }
+
+    /**
+     * Get the physical {@code ip:httpPort} address exposed by the RTP-LLM mock frontend.
+     */
+    protected static String physicalWorkerIpPort(MockWorker worker) {
+        return "127.0.0.1:" + worker.getHttpPort();
+    }
+
+    /** Get a physical frontend address from its independent host and port fields. */
+    protected static String physicalIpPort(String ip, int httpPort) {
+        return ip + ":" + httpPort;
+    }
+
+    protected static String physicalIpPort(String ipPort) {
+        int separator = ipPort.indexOf('@');
+        return separator >= 0 ? ipPort.substring(0, separator) : ipPort;
     }
 
     /**
@@ -523,7 +544,7 @@ public abstract class FlexLBMockTestBase {
 
     private void discover(WorkerStatus status) {
         engineWorkerStatus.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
     }
 
     /** Apply one already immutable gRPC status observation. */
@@ -561,8 +582,10 @@ public abstract class FlexLBMockTestBase {
         try {
             WorkerStatus.PreparedStatus prepared = status.prepareNewStatus(
                     status.freezeStatusResponse(initial));
-            return endpointRegistry.publishPreparedEndpoint(
-                    status.getIpPort(), status, prepared).endpoint();
+            WorkerEndpoint endpoint = endpointRegistry.publishPreparedEndpoint(
+                    status.getLogicalIpPort(), status, prepared).endpoint();
+            status.recordSuccessfulPoll(initial.isAlive());
+            return endpoint;
         } finally {
             status.lock.unlock();
         }

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/grpc/FileDiscoveryDynamicScaleEndToEndTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/grpc/FileDiscoveryDynamicScaleEndToEndTest.java
@@ -126,7 +126,9 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
 
         // Initial discovery file: A + B on the prefill domain, base decode worker.
         discoveryFile = tempDir.resolve("discovery-" + System.nanoTime() + ".json");
-        writeDiscoveryFileAtomic(List.of(prefillIpPort, workerIpPort(workerB)));
+        writeDiscoveryFileAtomic(List.of(
+                physicalIpPort(prefillIp, prefillHttpPort),
+                physicalWorkerIpPort(workerB)));
 
         // Real file-backed ServiceDiscovery — re-reads the file on every poll.
         fileServiceDiscovery = new RoutingServiceDiscovery(
@@ -255,7 +257,10 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
         workerC = new MockPrefillWorker(MockWorkerBehavior.builder().build());
         workerC.start(0);
         String cIpPort = workerIpPort(workerC);
-        writeDiscoveryFileAtomic(List.of(prefillIpPort, workerIpPort(workerB), cIpPort));
+        writeDiscoveryFileAtomic(List.of(
+                physicalIpPort(prefillIp, prefillHttpPort),
+                physicalWorkerIpPort(workerB),
+                physicalWorkerIpPort(workerC)));
 
         long addStartMs = System.nanoTime();
         AtomicBoolean cReceived = new AtomicBoolean(false);
@@ -272,15 +277,18 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
         assertTrue(cReceived.get(),
                 "worker C should start receiving requests within " + CONVERGENCE_CAP_MS + " ms "
                         + "of appearing in the discovery file");
-        assertNotNull(endpointRegistry.get(RoleType.PREFILL, cIpPort),
+        assertNotNull(endpointRegistry.get(RoleType.PREFILL, logicalWorkerIpPort(cIpPort)),
                 "worker C must be registered in the EndpointRegistry after discovery");
 
         // ─── Phase 3: remove A from the file → A must stop receiving new requests ───
-        writeDiscoveryFileAtomic(List.of(workerIpPort(workerB), cIpPort));
+        writeDiscoveryFileAtomic(List.of(
+                physicalWorkerIpPort(workerB),
+                physicalWorkerIpPort(workerC)));
 
         long removeStartMs = System.nanoTime();
         awaitUntil(CONVERGENCE_CAP_MS, () ->
-                        endpointRegistry.get(RoleType.PREFILL, prefillIpPort) == null,
+                        endpointRegistry.get(RoleType.PREFILL,
+                                logicalWorkerIpPort(prefillIpPort)) == null,
                 "worker A should be evicted from the EndpointRegistry after removal from the file");
         long removeConvergenceMs = elapsedMs(removeStartMs);
 
@@ -308,7 +316,7 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
     private void writeDiscoveryFileAtomic(List<String> prefillHosts) throws IOException {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put(PREFILL_DOMAIN, prefillHosts);
-        payload.put(DECODE_DOMAIN, List.of(decodeIpPort));
+        payload.put(DECODE_DOMAIN, List.of(physicalIpPort(decodeIp, decodeHttpPort)));
         Path tmp = discoveryFile.resolveSibling(discoveryFile.getFileName() + ".tmp");
         MAPPER.writerWithDefaultPrettyPrinter().writeValue(tmp.toFile(), payload);
         try {
@@ -342,7 +350,12 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
             }
             Collections.sort(candidates);
             String chosen = candidates.get(routerCounter.getAndIncrement() % candidates.size());
-            String[] parts = chosen.split(":");
+            int engineSeparator = chosen.lastIndexOf('@');
+            String physicalAddress = engineSeparator < 0
+                    ? chosen : chosen.substring(0, engineSeparator);
+            int engineIndex = engineSeparator < 0
+                    ? 0 : Integer.parseInt(chosen.substring(engineSeparator + 1));
+            String[] parts = physicalAddress.split(":");
             String ip = parts[0];
             int httpPort = Integer.parseInt(parts[1]);
             // admittedRoute() converts this response into the exact pinned
@@ -351,29 +364,36 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
             // later marks queued; without it admission would hit NOT_QUEUED ->
             // OwnershipLost and the request would never complete.
             return admittedRoute(ctx,
-                    routeResponse(ctx.getRequestId(), ip, httpPort, httpPort + 1));
+                    routeResponse(ctx.getRequestId(), ip, httpPort, httpPort + 1, engineIndex));
         });
         return roundRobin;
     }
 
     private Response routeResponse(String requestId, String prefillIpAddr, int prefillHttpPort,
-                                    int prefillGrpcPort) {
+                                    int prefillGrpcPort, int prefillEngineIndex) {
         Response response = new Response();
         response.setSuccess(true);
         response.setServerStatus(List.of(
-                serverStatus(RoleType.PREFILL, prefillIpAddr, prefillHttpPort, prefillGrpcPort, requestId),
+                serverStatus(RoleType.PREFILL, prefillIpAddr, prefillHttpPort, prefillGrpcPort,
+                        prefillEngineIndex, requestId),
                 serverStatus(RoleType.DECODE, decodeIp, decodeHttpPort, decodeGrpcPort, requestId)));
         return response;
     }
 
     private static ServerStatus serverStatus(RoleType role, String ip, int httpPort, int grpcPort,
                                               String requestId) {
+        return serverStatus(role, ip, httpPort, grpcPort, 0, requestId);
+    }
+
+    private static ServerStatus serverStatus(RoleType role, String ip, int httpPort, int grpcPort,
+                                              int engineIndex, String requestId) {
         ServerStatus status = new ServerStatus();
         status.setSuccess(true);
         status.setRole(role);
         status.setServerIp(ip);
         status.setHttpPort(httpPort);
         status.setGrpcPort(grpcPort);
+        status.setSelectedEngineIndex(engineIndex, 1);
         status.setDpRank(0);
         status.setGroup("test-group");
         status.setRequestId(requestId);
@@ -416,7 +436,7 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
         List<String> routable =
                 endpointRegistry.endpointAddressSnapshot(RoleType.PREFILL);
         for (String ipPort : ipPorts) {
-            if (!routable.contains(ipPort)) {
+            if (!routable.contains(logicalWorkerIpPort(ipPort))) {
                 return false;
             }
         }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheHitComparisonResult.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheHitComparisonResult.java
@@ -3,9 +3,14 @@ package org.flexlb.cache.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.flexlb.dao.master.WorkerIdentity;
 
 /**
  * Cache-hit comparison result and PV log payload.
+ *
+ * @param workerIdentity worker identity providing the routing/PV identity
+ *                       {@code ip:port@engineIndex} and the metrics identity
+ *                       {@code ip@engineIndex}; omitted from PV JSON itself
  */
 @JsonPropertyOrder({
         "event", "requestId", "source", "role", "group", "worker", "state", "inputTokens",
@@ -17,13 +22,24 @@ public record CacheHitComparisonResult(
         String source,
         String role,
         String group,
-        String worker,
+        @JsonIgnore WorkerIdentity workerIdentity,
         String state,
         long inputTokens,
         Actual actual,
         @JsonIgnore HitComparison routing,
         HitComparison localStandby,
         @JsonIgnore KvcmDetails kvcmDetails) {
+
+    /** Routing/PV identity in {@code ip:port@engineIndex} format. */
+    @JsonProperty("worker")
+    public String worker() {
+        return workerIdentity == null ? null : workerIdentity.getLogicalIpPort();
+    }
+
+    /** Metrics identity in {@code ip@engineIndex} format; omitted from PV JSON. */
+    public String ipIndex() {
+        return workerIdentity == null ? null : workerIdentity.getIpIndex();
+    }
 
     @JsonProperty("kvcm")
     public KvcmComparison kvcm() {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheHitComparisonResult.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheHitComparisonResult.java
@@ -9,7 +9,7 @@ import org.flexlb.dao.master.WorkerIdentity;
  * Cache-hit comparison result and PV log payload.
  *
  * @param workerIdentity worker identity providing the routing/PV identity
- *                       {@code ip:port@engineIndex} and the metrics identity
+ *                       {@code ip:port@engineIndex} and legacy short identity
  *                       {@code ip@engineIndex}; omitted from PV JSON itself
  */
 @JsonPropertyOrder({
@@ -36,7 +36,7 @@ public record CacheHitComparisonResult(
         return workerIdentity == null ? null : workerIdentity.getLogicalIpPort();
     }
 
-    /** Metrics identity in {@code ip@engineIndex} format; omitted from PV JSON. */
+    /** Legacy short identity in {@code ip@engineIndex} format; omitted from PV JSON. */
     public String ipIndex() {
         return workerIdentity == null ? null : workerIdentity.getIpIndex();
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheMatchResult.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheMatchResult.java
@@ -1,6 +1,7 @@
 package org.flexlb.cache.domain;
 
 import org.flexlb.dao.cache.HostCacheMatch;
+import org.flexlb.dao.master.WorkerStatus;
 
 import java.util.Collections;
 import java.util.Map;
@@ -8,7 +9,9 @@ import java.util.Map;
 /**
  * Cache matches and the block size used to produce them.
  *
- * <p>Each worker has one {@link HostCacheMatch} containing the raw local/P2P block counts.
+ * <p>Each map key normally is a logical worker identity in {@code ip:port@engineIndex} format
+ * and has one {@link HostCacheMatch} containing the raw local/P2P block counts. KVCM responses
+ * from legacy single-engine deployments can use the physical {@code ip:port} identity.
  */
 public record CacheMatchResult(
         Map<String, HostCacheMatch> hostMatches,
@@ -32,8 +35,34 @@ public record CacheMatchResult(
         return inputTokens > 0 ? Math.min(inputTokens, matchedTokens) : matchedTokens;
     }
 
-    public HostCacheMatch hostMatch(String workerIpPort) {
+    /**
+     * Returns the match stored under the given key, without any KVCM legacy fallback. Routing
+     * paths should use {@link #hostMatch(WorkerStatus)} instead.
+     *
+     * @param workerIpPort worker identity key, typically logical {@code ip:port@engineIndex}
+     */
+    public HostCacheMatch exactHostMatch(String workerIpPort) {
         return hostMatches.get(workerIpPort);
+    }
+
+    /**
+     * Returns the match for a worker, preserving legacy KVCM host identities for one engine.
+     *
+     * <p>KVCM formerly returned a physical {@code ip:port} host identity. A single-engine
+     * worker has an unambiguous logical {@code @0} identity, so it can use that legacy entry
+     * when no exact logical match exists. Multi-engine workers require an exact logical match.
+     */
+    public HostCacheMatch hostMatch(WorkerStatus workerStatus) {
+        if (workerStatus == null) {
+            return null;
+        }
+        HostCacheMatch exactMatch = exactHostMatch(workerStatus.getLogicalIpPort());
+        if (exactMatch != null
+                || source != CacheMatchSource.KVCM
+                || workerStatus.getMultiEngineNum() != 1) {
+            return exactMatch;
+        }
+        return exactHostMatch(workerStatus.getPhysicalIpPort());
     }
 
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/WorkerCacheUpdateResult.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/WorkerCacheUpdateResult.java
@@ -15,8 +15,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class WorkerCacheUpdateResult {
+
     private boolean success;
-    private String engineIpPort;
+    /**
+     * Logical worker identity in {@code ip:port@engineIndex} format.
+     *
+     * @see org.flexlb.dao.master.WorkerIdentity#getEngineIndex()
+     */
+    private String logicalIpPort;
     private long cacheBlockCount;
     private long availableKvCache;
     private long totalKvCache;

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMatchProvider.java
@@ -14,6 +14,11 @@ public interface CacheMatchProvider {
 
     CacheMatchSource source();
 
+    /**
+     * Finds cache matches keyed by logical worker identity in
+     * {@code ip:port@engineIndex} format. The index identifies one independently routable
+     * engine behind the physical frontend.
+     */
     Map<String, HostCacheMatch> findMatchingEngines(
             String requestId,
             List<Long> blockCacheKeys,

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMetadataUpdateOrchestrator.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMetadataUpdateOrchestrator.java
@@ -39,10 +39,10 @@ public class CacheMetadataUpdateOrchestrator {
             return localSyncProvider.updateFromWorkerStatus(workerStatus);
         }
 
-        String engineIpPort = workerStatus == null ? null : workerStatus.getIpPort();
+        String logicalIpPort = workerStatus == null ? null : workerStatus.getLogicalIpPort();
         return WorkerCacheUpdateResult.builder()
                 .success(false)
-                .engineIpPort(engineIpPort)
+                .logicalIpPort(logicalIpPort)
                 .errorMessage("Local Sync cache metadata updates are disabled when KVCM is enabled")
                 .build();
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProvider.java
@@ -27,6 +27,10 @@ public class KvcmCacheMatchProvider implements CacheMatchProvider {
         return CacheMatchSource.KVCM;
     }
 
+    /**
+     * Returns KVCM matches without rewriting their keys. KVCM {@code host_ip_port} values follow
+     * the logical {@code ip:port@engineIndex} identity reported by the Subscriber.
+     */
     @Override
     public Map<String, HostCacheMatch> findMatchingEngines(String requestId, List<Long> blockCacheKeys, long blockSize,
                                                            RoleType roleType, String group) {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheIndex.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheIndex.java
@@ -67,6 +67,13 @@ class LocalStandbyCacheIndex {
         }
     }
 
+    /**
+     * Adds predicted block ownership for one logical worker.
+     *
+     * @param workerIpPort logical worker identity in {@code ip:port@engineIndex} format
+     * @param blockCacheKeys predicted block hashes
+     * @return number of mappings rejected by the capacity limit
+     */
     int addWorkerBlockMappings(String workerIpPort, List<Long> blockCacheKeys) {
         if (workerIpPort == null || workerIpPort.isEmpty() || blockCacheKeys == null || blockCacheKeys.isEmpty()) {
             return 0;

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManager.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManager.java
@@ -76,6 +76,10 @@ public class LocalStandbyCacheManager {
                 enabled);
     }
 
+    /**
+     * Finds prefix matches keyed by logical worker identity in
+     * {@code ip:port@engineIndex} format.
+     */
     public Map<String, Integer> findMatchingEngines(List<Long> blockCacheKeys, RoleType roleType, String group) {
         if (!enabled || blockCacheKeys == null || blockCacheKeys.isEmpty()) {
             return Collections.emptyMap();
@@ -97,7 +101,7 @@ public class LocalStandbyCacheManager {
             if (workerStatus == null) {
                 continue;
             }
-            String workerIpPort = workerStatus.getIpPort();
+            String workerIpPort = workerStatus.getLogicalIpPort();
             if (StringUtils.isNotBlank(workerIpPort)) {
                 candidateWorkers.add(workerIpPort);
             }
@@ -149,7 +153,7 @@ public class LocalStandbyCacheManager {
             if (workerStatus == null || workerStatus.getCacheMatchRollbackBlocks() <= 0) {
                 continue;
             }
-            String workerIpPort = workerStatus.getIpPort();
+            String workerIpPort = workerStatus.getLogicalIpPort();
             Integer matchedBlocks = prefixMatches.get(workerIpPort);
             if (matchedBlocks != null) {
                 prefixMatches.put(workerIpPort,
@@ -158,6 +162,14 @@ public class LocalStandbyCacheManager {
         }
     }
 
+    /**
+     * Records predicted block ownership for a routed logical worker.
+     *
+     * @param workerIpPort logical worker identity in {@code ip:port@engineIndex} format; the
+     *                     index identifies one independently routable engine behind the physical
+     *                     frontend
+     * @param blockCacheKeys routed request block hashes
+     */
     public void addRoutedRequestBlocks(String workerIpPort, List<Long> blockCacheKeys) {
         int rejectedMappings = cacheIndex.addWorkerBlockMappings(workerIpPort, blockCacheKeys);
         if (rejectedMappings <= 0) {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProvider.java
@@ -135,7 +135,7 @@ public class LocalStandbyCacheMatchProvider implements CacheMatchProvider {
                 continue;
             }
             cacheManager.addRoutedRequestBlocks(
-                    selectedWorker.getServerIp() + ":" + selectedWorker.getHttpPort(),
+                    selectedWorker.getLogicalIpPort(),
                     cacheableBlockCacheKeys);
         }
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonService.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonService.java
@@ -93,7 +93,7 @@ public class LocalStandbyComparisonService {
     }
 
     private CacheHitComparisonResult withLocalStandbyPrediction(CacheHitFeedback feedback, StandbyPrediction standbyPrediction) {
-        String workerIpPort = feedback.workerIp() + ":" + feedback.workerPort();
+        String workerIpPort = feedback.logicalWorkerId();
         HostCacheMatch match = standbyPrediction.matches().get(workerIpPort);
         long localStandbyPredictedHitTokens = match == null
                 ? 0
@@ -138,7 +138,7 @@ public class LocalStandbyComparisonService {
                 feedback.cacheMatchSource(),
                 feedback.role(),
                 feedback.group(),
-                feedback.workerIp(),
+                feedback.workerIdentity(),
                 feedback.taskState(),
                 feedback.inputTokens(),
                 new CacheHitComparisonResult.Actual(feedback.actualHitTokens()),

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/EngineLocalView.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/EngineLocalView.java
@@ -2,7 +2,6 @@ package org.flexlb.cache.match.localsync;
 
 import lombok.extern.slf4j.Slf4j;
 import org.flexlb.cache.domain.DiffResult;
-import org.flexlb.cache.telemetry.CacheMetricsReporter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,12 +33,6 @@ public class EngineLocalView {
     private final ForkJoinPool customPool = new ForkJoinPool(Math.min(Runtime.getRuntime().availableProcessors(), 8));
 
     /**
-     * Cache metrics reporter
-     */
-    @Autowired
-    private CacheMetricsReporter cacheMetricsReporter;
-
-    /**
      * Dynamic sync interval manager
      */
     @Autowired
@@ -48,12 +41,11 @@ public class EngineLocalView {
     /**
      * Calculate diff result
      *
-     * @param engineIPort       Engine IP
+     * @param engineIPort    Engine IP
      * @param newCacheBlocks New cache block set
-     * @param role           Engine role
      * @return Diff calculation result
      */
-    public DiffResult calculateDiff(String engineIPort, Set<Long> newCacheBlocks, String role) {
+    public DiffResult calculateDiff(String engineIPort, Set<Long> newCacheBlocks) {
         if (engineIPort == null || newCacheBlocks == null) {
             return DiffResult.empty(engineIPort);
         }
@@ -79,8 +71,6 @@ public class EngineLocalView {
 
         addedTask.join();
         removedTask.join();
-
-        cacheMetricsReporter.reportCacheDiffMetrics(role, addedBlocks.size(), removedBlocks.size());
 
         // Update statistics in dynamic sync interval manager
         int diffSize = addedBlocks.size() + removedBlocks.size();

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/GlobalCacheIndex.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/GlobalCacheIndex.java
@@ -45,7 +45,9 @@ public class GlobalCacheIndex {
      * Add cache block to specified engine
      *
      * @param blockCacheKey Cache block hash value
-     * @param engineIpPort  Engine IP:Port
+     * @param engineIpPort  logical worker identity in {@code ip:port@engineIndex} format; the
+     *                      index identifies one independently routable engine behind the physical
+     *                      frontend
      */
     public void addCacheBlock(Long blockCacheKey, String engineIpPort) {
         if (blockCacheKey == null || engineIpPort == null) {
@@ -72,7 +74,7 @@ public class GlobalCacheIndex {
     /**
      * Remove cache block from specified engine
      *
-     * @param engineIp      Engine IP
+     * @param engineIp      logical worker identity in {@code ip:port@engineIndex} format
      * @param blockCacheKey Cache block hash value
      */
     public void removeCacheBlock(String engineIp, Long blockCacheKey) {
@@ -105,7 +107,7 @@ public class GlobalCacheIndex {
     /**
      * Remove an engine
      *
-     * @param engineIp Engine IP
+     * @param engineIp logical worker identity in {@code ip:port@engineIndex} format
      */
     public void removeAllCacheBlockOfEngine(String engineIp) {
         if (engineIp == null) {
@@ -134,9 +136,9 @@ public class GlobalCacheIndex {
     /**
      * Calculate engine prefix match length based on prefix matching
      *
-     * @param engineIpPorts  Engine IP:Port list
+     * @param engineIpPorts  logical worker identities in {@code ip:port@engineIndex} format
      * @param blockCacheKeys Ordered cache block hash value list
-     * @return Map<EngineIP:EnginePort, PrefixMatchLength>
+     * @return prefix match lengths keyed by logical worker identity
      */
     public Map<String, Integer> batchCalculatePrefixMatchLength(List<String> engineIpPorts,
                                                                 List<Long> blockCacheKeys) {
@@ -150,9 +152,9 @@ public class GlobalCacheIndex {
     /**
      * Prefix match calculation
      *
-     * @param engineIpPorts  Engine IP:Port list
+     * @param engineIpPorts  logical worker identities in {@code ip:port@engineIndex} format
      * @param blockCacheKeys Ordered cache block hash value list
-     * @return Map<EngineIP:EnginePort, PrefixMatchLength>
+     * @return prefix match lengths keyed by logical worker identity
      */
     private Map<String, Integer> calculatePrefixMatchLength(List<String> engineIpPorts,
                                                             List<Long> blockCacheKeys) {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
@@ -3,6 +3,7 @@ package org.flexlb.cache.match.localsync;
 import lombok.extern.slf4j.Slf4j;
 import org.flexlb.cache.domain.DiffResult;
 import org.flexlb.cache.telemetry.CacheMetricsReporter;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.master.WorkerStatusProvider;
 import org.flexlb.dao.route.RoleType;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * KV cache manager
@@ -45,6 +47,9 @@ public class KvCacheManager implements EngineCacheInvalidator {
      */
     @Autowired
     private CacheMetricsReporter cacheMetricsReporter;
+
+    private final Map<String, String> physicalIpPortByLogicalIpPort =
+            new ConcurrentHashMap<>();
 
     @PostConstruct
     public void init() {
@@ -96,7 +101,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
 
         List<String> engineIpPorts = workerStatusProvider.getWorkerStatuses(roleType, group)
                 .stream()
-                .map(WorkerStatus::getIpPort)
+                .map(WorkerStatus::getLogicalIpPort)
                 .toList();
 
         return globalCacheIndex.batchCalculatePrefixMatchLength(
@@ -106,17 +111,22 @@ public class KvCacheManager implements EngineCacheInvalidator {
     /**
      * Update engine cache status
      *
-     * @param engineIPort    Engine IP:Port
+     * @param identity       Worker identity
      * @param role           Engine role
      * @param newCacheBlocks New cache block set (blockCacheKeys)
      */
-    public void updateEngineCache(String engineIPort, String role, Set<Long> newCacheBlocks) {
+    public void updateEngineCache(WorkerIdentity identity, String role, Set<Long> newCacheBlocks) {
+        String engineIPort = identity == null ? null : identity.getLogicalIpPort();
         if (engineIPort == null || newCacheBlocks == null) {
             return;
         }
+        physicalIpPortByLogicalIpPort.put(engineIPort, identity.getPhysicalIpPort());
 
         // Calculate diff
-        DiffResult diffResult = engineLocalView.calculateDiff(engineIPort, newCacheBlocks, role);
+        DiffResult diffResult = engineLocalView.calculateDiff(engineIPort, newCacheBlocks);
+        cacheMetricsReporter.reportCacheDiffMetrics(
+                identity.getIpIndex(), role,
+                diffResult.getAddedBlocks().size(), diffResult.getRemovedBlocks().size());
         if (!diffResult.hasChanges()) {
             return;
         }
@@ -142,7 +152,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
 
         // Report metrics
         cacheMetricsReporter.reportEngineLocalMetrics(
-                engineIPort.split(":")[0], role, engineLocalView.size(engineIPort));
+                identity.getIpIndex(), role, engineLocalView.size(engineIPort));
         cacheMetricsReporter.reportGlobalCacheMetrics(globalCacheIndex.totalBlocks(), globalCacheIndex.totalMappings());
         cacheMetricsReporter.reportEngineViewsMapSize(engineLocalView.getEngineViewsMapSize());
     }
@@ -167,12 +177,15 @@ public class KvCacheManager implements EngineCacheInvalidator {
         if (activeEngineIpPorts == null) {
             return;
         }
+        Set<String> activePhysicalIpPorts = new HashSet<>(activeEngineIpPorts);
         Set<String> staleEngineIpPorts = new HashSet<>(engineLocalView.getAllEngineIpPorts());
-        staleEngineIpPorts.removeAll(new HashSet<>(activeEngineIpPorts));
+        staleEngineIpPorts.removeIf(engineIpPort -> activePhysicalIpPorts.contains(
+                physicalIpPortByLogicalIpPort.getOrDefault(engineIpPort, engineIpPort)));
         for (String staleEngineIpPort : staleEngineIpPorts) {
             long startTime = System.nanoTime() / 1000;
             engineLocalView.removeAllCacheBlockOfEngine(staleEngineIpPort);
             globalCacheIndex.removeAllCacheBlockOfEngine(staleEngineIpPort);
+            physicalIpPortByLogicalIpPort.remove(staleEngineIpPort);
             log.info("Removed stale engine cache: {}, cost={}us",
                     staleEngineIpPort, System.nanoTime() / 1000 - startTime);
         }
@@ -185,6 +198,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
 
         globalCacheIndex.clear();
         engineLocalView.clear();
+        physicalIpPortByLogicalIpPort.clear();
 
         // Report
         cacheMetricsReporter.reportGlobalCacheMetrics(globalCacheIndex.totalBlocks(), globalCacheIndex.totalMappings());

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
@@ -164,6 +164,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
         }
         engineLocalView.removeAllCacheBlockOfEngine(engineIpPort);
         globalCacheIndex.removeAllCacheBlockOfEngine(engineIpPort);
+        physicalIpPortByLogicalIpPort.remove(engineIpPort);
         cacheMetricsReporter.reportGlobalCacheMetrics(
                 globalCacheIndex.totalBlocks(),
                 globalCacheIndex.totalMappings());

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
@@ -125,7 +125,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
         // Calculate diff
         DiffResult diffResult = engineLocalView.calculateDiff(engineIPort, newCacheBlocks);
         cacheMetricsReporter.reportCacheDiffMetrics(
-                identity.getIpIndex(), role,
+                identity.getLogicalIpPort(), role,
                 diffResult.getAddedBlocks().size(), diffResult.getRemovedBlocks().size());
         if (!diffResult.hasChanges()) {
             return;
@@ -152,7 +152,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
 
         // Report metrics
         cacheMetricsReporter.reportEngineLocalMetrics(
-                identity.getIpIndex(), role, engineLocalView.size(engineIPort));
+                identity.getLogicalIpPort(), role, engineLocalView.size(engineIPort));
         cacheMetricsReporter.reportGlobalCacheMetrics(globalCacheIndex.totalBlocks(), globalCacheIndex.totalMappings());
         cacheMetricsReporter.reportEngineViewsMapSize(engineLocalView.getEngineViewsMapSize());
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProvider.java
@@ -48,32 +48,31 @@ public class LocalSyncCacheMatchProvider implements CacheMatchProvider {
     public WorkerCacheUpdateResult updateFromWorkerStatus(WorkerStatus workerStatus) {
         long startTime = System.nanoTime() / 1000;
         String logicalIpPort = workerStatus.getLogicalIpPort();
-        String ipIndex = workerStatus.getIpIndex();
         String role = workerStatus.getRole() == null ? null : workerStatus.getRole().name();
 
         try {
             CacheStatus cacheStatus = workerStatus.getCacheStatus();
             if (cacheStatus == null) {
                 WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, "Worker Cache Status is null");
-                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "0");
+                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "0");
                 return result;
             }
 
             Set<Long> cachedKeys = cacheStatus.getCachedKeys();
             if (cachedKeys == null) {
                 WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, "Worker Cached Keys is null");
-                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "0");
+                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "0");
                 return result;
             }
 
             kvCacheManager.updateEngineCache(workerStatus.getWorkerIdentity(), role, cachedKeys);
             WorkerCacheUpdateResult result = buildSuccessResult(workerStatus, cacheStatus);
-            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "1");
+            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "1");
             return result;
         } catch (Throwable e) {
             log.error("Error updating worker cache for: {}", logicalIpPort, e);
             WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, e.getMessage());
-            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "0");
+            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "0");
             return result;
         }
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProvider.java
@@ -47,34 +47,33 @@ public class LocalSyncCacheMatchProvider implements CacheMatchProvider {
 
     public WorkerCacheUpdateResult updateFromWorkerStatus(WorkerStatus workerStatus) {
         long startTime = System.nanoTime() / 1000;
-        String engineIpPort = workerStatus.getIpPort();
-        String role = workerStatus.getRole() == null
-                ? null
-                : workerStatus.getRole().name();
+        String logicalIpPort = workerStatus.getLogicalIpPort();
+        String ipIndex = workerStatus.getIpIndex();
+        String role = workerStatus.getRole() == null ? null : workerStatus.getRole().name();
 
         try {
             CacheStatus cacheStatus = workerStatus.getCacheStatus();
             if (cacheStatus == null) {
-                WorkerCacheUpdateResult result = buildFailureResult(engineIpPort, "Worker Cache Status is null");
-                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "0");
+                WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, "Worker Cache Status is null");
+                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "0");
                 return result;
             }
 
             Set<Long> cachedKeys = cacheStatus.getCachedKeys();
             if (cachedKeys == null) {
-                WorkerCacheUpdateResult result = buildFailureResult(engineIpPort, "Worker Cached Keys is null");
-                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "0");
+                WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, "Worker Cached Keys is null");
+                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "0");
                 return result;
             }
 
-            kvCacheManager.updateEngineCache(engineIpPort, role, cachedKeys);
+            kvCacheManager.updateEngineCache(workerStatus.getWorkerIdentity(), role, cachedKeys);
             WorkerCacheUpdateResult result = buildSuccessResult(workerStatus, cacheStatus);
-            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "1");
+            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "1");
             return result;
         } catch (Throwable e) {
-            log.error("Error updating worker cache for: {}", engineIpPort, e);
-            WorkerCacheUpdateResult result = buildFailureResult(engineIpPort, e.getMessage());
-            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "0");
+            log.error("Error updating worker cache for: {}", logicalIpPort, e);
+            WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, e.getMessage());
+            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(ipIndex, role, startTime, "0");
             return result;
         }
     }
@@ -86,7 +85,7 @@ public class LocalSyncCacheMatchProvider implements CacheMatchProvider {
     private WorkerCacheUpdateResult buildSuccessResult(WorkerStatus workerStatus, CacheStatus cacheStatus) {
         return WorkerCacheUpdateResult.builder()
                 .success(true)
-                .engineIpPort(workerStatus.getIpPort())
+                .logicalIpPort(workerStatus.getLogicalIpPort())
                 .cacheBlockCount(cacheStatus.getCachedKeys().size())
                 .availableKvCache(cacheStatus.getAvailableKvCache())
                 .totalKvCache(cacheStatus.getTotalKvCache())
@@ -94,10 +93,10 @@ public class LocalSyncCacheMatchProvider implements CacheMatchProvider {
                 .build();
     }
 
-    private WorkerCacheUpdateResult buildFailureResult(String engineIpPort, String errorMessage) {
+    private WorkerCacheUpdateResult buildFailureResult(String logicalIpPort, String errorMessage) {
         return WorkerCacheUpdateResult.builder()
                 .success(false)
-                .engineIpPort(engineIpPort)
+                .logicalIpPort(logicalIpPort)
                 .errorMessage(errorMessage)
                 .build();
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/telemetry/CacheMetricsReporter.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/telemetry/CacheMetricsReporter.java
@@ -135,19 +135,19 @@ public class CacheMetricsReporter {
     /**
      * Report local cache metrics for a single engine
      *
-     * @param engineIp   Engine IP
+     * @param ipIndex    metrics identity in {@code ip@engineIndex} format
      * @param role       Engine role
      * @param cacheCount Cache count
      */
-    public void reportEngineLocalMetrics(String engineIp, String role, int cacheCount) {
-        if (engineIp == null) {
+    public void reportEngineLocalMetrics(String ipIndex, String role, int cacheCount) {
+        if (ipIndex == null) {
             return;
         }
 
         // Calculate cache count and bytes
         long cacheBytes = calculateEngineCacheBytes(cacheCount);
 
-        FlexMetricTags tags = FlexMetricTags.of("engineIp", engineIp, "role", role);
+        FlexMetricTags tags = FlexMetricTags.of("engineIp", ipIndex, "role", role);
 
         monitor.report(CACHE_ENGINE_LOCAL_COUNT, tags, cacheCount);
         monitor.report(CACHE_ENGINE_LOCAL_BYTES, tags, cacheBytes);
@@ -172,13 +172,13 @@ public class CacheMetricsReporter {
      * Report cache hit rate metrics
      *
      * @param roleType  Role type
+     * @param ipIndex   indexed engine IP in {@code ip@engineIndex} format
      * @param hitTokens Number of hit tokens
      * @param hitRatio  Hit percentage
      */
-    public void reportCacheHitMetrics(RoleType roleType, long hitTokens, double hitRatio) {
-        FlexMetricTags baseTags = FlexMetricTags.of(
-                "role", roleType.name()
-        );
+    public void reportCacheHitMetrics(RoleType roleType, String ipIndex, long hitTokens, double hitRatio) {
+
+        FlexMetricTags baseTags = FlexMetricTags.of("role", roleType.name(), "engineIp", ipIndex);
 
         // Report hit token count and hit percentage
         monitor.report(CACHE_HIT_COUNT, baseTags, hitTokens);
@@ -187,13 +187,11 @@ public class CacheMetricsReporter {
     }
 
     public void reportKvcmSelectedMatch(RoleType roleType,
-                                        String engineIp,
+                                        String ipIndex,
                                         long localMatchTokens,
                                         long p2pFetchTokens,
                                         long p2pTotalMatchTokens) {
-        FlexMetricTags tags = FlexMetricTags.of(
-                "role", roleType.name(),
-                "engineIp", engineIp);
+        FlexMetricTags tags = FlexMetricTags.of("role", roleType.name(), "engineIp", ipIndex);
         monitor.report(CACHE_KVCM_SELECTED_LOCAL_MATCH_TOKENS, tags, localMatchTokens);
         monitor.report(CACHE_KVCM_SELECTED_P2P_FETCH_TOKENS, tags, p2pFetchTokens);
         monitor.report(CACHE_KVCM_SELECTED_P2P_TOTAL_MATCH_TOKENS, tags, p2pTotalMatchTokens);
@@ -454,20 +452,14 @@ public class CacheMetricsReporter {
     /**
      * Report local cache metadata update time in microseconds.
      *
-     * @param role         Engine role
-     * @param startTime    Start time in microseconds
-     * @param success      Whether successful
+     * @param ipIndex   metrics identity in {@code ip@engineIndex} format
+     * @param role      Engine role
+     * @param startTime Start time in microseconds
+     * @param success   Whether successful
      */
-    public void reportUpdateEngineBlockCacheRT(String role, long startTime, String success) {
-        FlexMetricTags tags = FlexMetricTags.of(
-                "role", role,
-                "success", success
-        );
-        monitor.report(CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT, tags, ((double) System.nanoTime() / 1000) - startTime);
-    }
-
-    public void reportUpdateEngineBlockCacheRT(String engineIpPort, String role, long startTime, String success) {
-        FlexMetricTags tags = FlexMetricTags.of("engineIpPort", engineIpPort, "role", role, "success", success);
+    public void reportUpdateEngineBlockCacheRT(
+            String ipIndex, String role, long startTime, String success) {
+        FlexMetricTags tags = FlexMetricTags.of("engineIp", ipIndex, "role", role, "success", success);
 
         monitor.report(CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT, tags, ((double) System.nanoTime() / 1000) - startTime);
     }
@@ -475,23 +467,20 @@ public class CacheMetricsReporter {
     /**
      * Report cache diff calculation metrics
      *
+     * @param ipIndex           metrics identity in {@code ip@engineIndex} format
      * @param role              Role
      * @param addedBlocksSize   Number of added blocks
      * @param removedBlocksSize Number of removed blocks
      */
-    public void reportCacheDiffMetrics(String role, int addedBlocksSize, int removedBlocksSize) {
-        FlexMetricTags tags = FlexMetricTags.of(
-                "role", role != null ? role : "unknown"
-        );
-        reportCacheDiffMetrics(tags, addedBlocksSize, removedBlocksSize);
-    }
-
-    public void reportCacheDiffMetrics(String engineIp, String role, int addedBlocksSize, int removedBlocksSize) {
-        if (engineIp == null) {
+    public void reportCacheDiffMetrics(
+            String ipIndex, String role, int addedBlocksSize, int removedBlocksSize) {
+        if (ipIndex == null) {
             return;
         }
 
-        FlexMetricTags tags = FlexMetricTags.of("engineIp", engineIp, "role", role != null ? role : "unknown");
+        FlexMetricTags tags = FlexMetricTags.of(
+                "engineIp", ipIndex,
+                "role", role != null ? role : "unknown");
 
         reportCacheDiffMetrics(tags, addedBlocksSize, removedBlocksSize);
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/telemetry/CacheMetricsReporter.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/telemetry/CacheMetricsReporter.java
@@ -135,7 +135,7 @@ public class CacheMetricsReporter {
     /**
      * Report local cache metrics for a single engine
      *
-     * @param ipIndex    metrics identity in {@code ip@engineIndex} format
+     * @param ipIndex    metrics identity in {@code ip:port@engineIndex} format
      * @param role       Engine role
      * @param cacheCount Cache count
      */
@@ -172,7 +172,7 @@ public class CacheMetricsReporter {
      * Report cache hit rate metrics
      *
      * @param roleType  Role type
-     * @param ipIndex   indexed engine IP in {@code ip@engineIndex} format
+     * @param ipIndex   logical engine address in {@code ip:port@engineIndex} format
      * @param hitTokens Number of hit tokens
      * @param hitRatio  Hit percentage
      */
@@ -452,7 +452,7 @@ public class CacheMetricsReporter {
     /**
      * Report local cache metadata update time in microseconds.
      *
-     * @param ipIndex   metrics identity in {@code ip@engineIndex} format
+     * @param ipIndex   metrics identity in {@code ip:port@engineIndex} format
      * @param role      Engine role
      * @param startTime Start time in microseconds
      * @param success   Whether successful
@@ -467,7 +467,7 @@ public class CacheMetricsReporter {
     /**
      * Report cache diff calculation metrics
      *
-     * @param ipIndex           metrics identity in {@code ip@engineIndex} format
+     * @param ipIndex           metrics identity in {@code ip:port@engineIndex} format
      * @param role              Role
      * @param addedBlocksSize   Number of added blocks
      * @param removedBlocksSize Number of removed blocks

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheHitComparisonResultTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheHitComparisonResultTest.java
@@ -1,5 +1,6 @@
 package org.flexlb.cache.domain;
 
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.util.JsonUtils;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ class CacheHitComparisonResultTest {
     void serializesNestedCacheHitComparison() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
                 "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "default",
-                "127.0.0.1", "running", 200,
+                new WorkerIdentity("127.0.0.1", 8080, 0), "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
                 new CacheHitComparisonResult.HitComparison(70, 50),
@@ -27,7 +28,7 @@ class CacheHitComparisonResultTest {
 
         assertTrue(json.contains("\"event\":\"cache_hit_comparison\""));
         assertTrue(json.contains("\"source\":\"KVCM\""));
-        assertTrue(json.contains("\"worker\":\"127.0.0.1\""));
+        assertTrue(json.contains("\"worker\":\"127.0.0.1:8080@0\""));
         assertTrue(json.contains("\"state\":\"running\""));
         assertTrue(json.contains("\"actual\":{\"hit\":120}"));
         assertTrue(json.contains(
@@ -45,13 +46,14 @@ class CacheHitComparisonResultTest {
         assertTrue(json.indexOf("\"kvcm\"") < json.indexOf("\"localStandby\""));
         assertFalse(json.contains("\"p2pFetch\""));
         assertFalse(json.contains("\"workerPort\""));
+        assertFalse(json.contains("\"ipIndex\""));
     }
 
     @Test
     void omitsUnavailableLocalStandbyPrediction() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
                 "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "default",
-                "127.0.0.1", "running", 200,
+                new WorkerIdentity("127.0.0.1", 8080, 0), "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
                 null,
@@ -66,7 +68,7 @@ class CacheHitComparisonResultTest {
     void omitsKvcmForNonKvcmSource() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
                 "cache_hit_comparison", "request-1", "LOCAL_SYNC", "PREFILL", "default",
-                "127.0.0.1", "running", 200,
+                new WorkerIdentity("127.0.0.1", 8080, 0), "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
                 null,

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheMatchResultTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheMatchResultTest.java
@@ -1,13 +1,61 @@
 package org.flexlb.cache.domain;
 
 import org.flexlb.dao.cache.HostCacheMatch;
+import org.flexlb.dao.master.WorkerStatus;
+import org.flexlb.dao.route.RoleType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class CacheMatchResultTest {
+
+    @Test
+    void shouldMatchLegacyPhysicalKvcmHostForSingleEngineWorker() {
+        HostCacheMatch legacyMatch = HostCacheMatch.local(2);
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080", legacyMatch), CacheMatchSource.KVCM, 0, 1000);
+        WorkerStatus worker = worker("10.0.0.1", 8080, 0, 1);
+
+        assertSame(legacyMatch, result.hostMatch(worker));
+    }
+
+    @Test
+    void shouldPreferLogicalKvcmHostForSingleEngineWorker() {
+        HostCacheMatch logicalMatch = HostCacheMatch.local(3);
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of(
+                        "10.0.0.1:8080@0", logicalMatch,
+                        "10.0.0.1:8080", HostCacheMatch.local(2)),
+                CacheMatchSource.KVCM,
+                0,
+                1000);
+
+        assertSame(logicalMatch, result.hostMatch(worker("10.0.0.1", 8080, 0, 1)));
+    }
+
+    @Test
+    void shouldIgnoreLegacyPhysicalKvcmHostForMultiEngineWorker() {
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
+
+        assertNull(result.hostMatch(worker("10.0.0.1", 8080, 0, 2)));
+    }
+
+    @Test
+    void shouldNotFallbackPhysicalHostOutsideKvcm() {
+        WorkerStatus worker = worker("10.0.0.1", 8080, 0, 1);
+        for (CacheMatchSource source : new CacheMatchSource[]{
+                CacheMatchSource.LOCAL_SYNC, CacheMatchSource.LOCAL_STANDBY}) {
+            CacheMatchResult result = new CacheMatchResult(
+                    Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), source, 0, 1000);
+
+            assertNull(result.hostMatch(worker));
+        }
+    }
 
     @Test
     void shouldPreserveRawKvcmP2pMatchFields() {
@@ -17,9 +65,9 @@ class CacheMatchResultTest {
                 0,
                 1000);
 
-        assertEquals(2, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
-        assertEquals(8, result.hostMatch("10.0.0.1:8080").p2pFetchBlocks());
-        assertEquals(10, result.hostMatch("10.0.0.1:8080").p2pTotalMatchBlocks());
+        assertEquals(2, result.exactHostMatch("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(8, result.exactHostMatch("10.0.0.1:8080").p2pFetchBlocks());
+        assertEquals(10, result.exactHostMatch("10.0.0.1:8080").p2pTotalMatchBlocks());
     }
 
     @Test
@@ -27,7 +75,29 @@ class CacheMatchResultTest {
         CacheMatchResult result = new CacheMatchResult(
                 Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
 
-        assertEquals(2, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(2, result.exactHostMatch("10.0.0.1:8080").localMatchBlocks());
+    }
+
+    @Test
+    void returnsNullHostMatchForNullWorker() {
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
+
+        assertNull(result.hostMatch((WorkerStatus) null));
+    }
+
+    @Test
+    void guardsMatchedTokensAgainstDegenerateInputs() {
+        assertEquals(0, CacheMatchResult.matchedTokens(0, 4096, 100));
+        assertEquals(0, CacheMatchResult.matchedTokens(2, 0, 100));
+    }
+
+    @Test
+    void pinsFallbackExpectationForSingleEngineWorker() {
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
+
+        assertEquals(2, result.hostMatch(worker("10.0.0.1", 8080, 0, 1)).localMatchBlocks());
     }
 
     @Test
@@ -38,5 +108,18 @@ class CacheMatchResultTest {
     @Test
     void shouldKeepMatchedTokensWhenRequestLengthIsUnknown() {
         assertEquals(8, CacheMatchResult.matchedTokens(2, 4, 0));
+    }
+
+    private static WorkerStatus worker(String ip, int port, int engineIndex, int multiEngineNum) {
+        return WorkerStatus.createDiscovered(
+                RoleType.PREFILL,
+                "default",
+                ip,
+                port,
+                port + 1,
+                "",
+                null,
+                engineIndex,
+                multiEngineNum);
     }
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/CacheMatchQueryOrchestratorTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/CacheMatchQueryOrchestratorTest.java
@@ -56,7 +56,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(query);
 
         assertEquals(CacheMatchSource.LOCAL_SYNC, result.source());
-        assertEquals(2, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(2, result.exactHostMatch("10.0.0.1:8080").localMatchBlocks());
         verify(kvcmProvider, never()).findMatchingEngines(
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.any(),
@@ -77,7 +77,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(query);
 
         assertEquals(CacheMatchSource.KVCM, result.source());
-        assertEquals(1, result.hostMatch("10.0.0.2:8080").localMatchBlocks());
+        assertEquals(1, result.exactHostMatch("10.0.0.2:8080").localMatchBlocks());
         verify(comparisonService).trackLocalStandbyPrediction(query);
     }
 
@@ -147,7 +147,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(query);
 
         assertEquals(CacheMatchSource.KVCM, result.source());
-        assertEquals(1, result.hostMatch("10.0.0.2:8080").localMatchBlocks());
+        assertEquals(1, result.exactHostMatch("10.0.0.2:8080").localMatchBlocks());
     }
 
     @Test
@@ -169,7 +169,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(standbyQuery);
 
         assertEquals(CacheMatchSource.LOCAL_STANDBY, result.source());
-        assertEquals(1, result.hostMatch("10.0.0.3:8080").localMatchBlocks());
+        assertEquals(1, result.exactHostMatch("10.0.0.3:8080").localMatchBlocks());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProviderTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProviderTest.java
@@ -23,13 +23,13 @@ class KvcmCacheMatchProviderTest {
         KvcmGrpcClient client = mock(KvcmGrpcClient.class);
         when(client.findMatchingEngines(
                 "request-1", List.of(11L), 2192, RoleType.PREFILL, "default"))
-                .thenReturn(Map.of("10.0.0.1:8080", new HostCacheMatch(1, 0, 1)));
+                .thenReturn(Map.of("10.0.0.1:8080@1", new HostCacheMatch(1, 0, 1)));
         KvcmCacheMatchProvider provider = new KvcmCacheMatchProvider(client);
 
         Map<String, HostCacheMatch> result = provider.findMatchingEngines(
                 "request-1", List.of(11L), 2192, RoleType.PREFILL, "default");
 
-        assertEquals(1, result.get("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(1, result.get("10.0.0.1:8080@1").localMatchBlocks());
         verify(client).findMatchingEngines(
                 "request-1", List.of(11L), 2192, RoleType.PREFILL, "default");
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManagerTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManagerTest.java
@@ -39,16 +39,16 @@ class LocalStandbyCacheManagerTest {
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
 
-        manager.addRoutedRequestBlocks(worker1.getIpPort(), List.of(11L, 22L, 33L));
-        manager.addRoutedRequestBlocks(worker2.getIpPort(), List.of(11L, 33L));
+        manager.addRoutedRequestBlocks(worker1.getLogicalIpPort(), List.of(11L, 22L, 33L));
+        manager.addRoutedRequestBlocks(worker2.getLogicalIpPort(), List.of(11L, 33L));
 
         Map<String, Integer> matches =
                 manager.findMatchingEngines(List.of(11L, 22L, 33L), RoleType.PREFILL, "default");
 
-        assertEquals(3, matches.get(worker1.getIpPort()));
-        assertEquals(1, matches.get(worker2.getIpPort()));
+        assertEquals(3, matches.get(worker1.getLogicalIpPort()));
+        assertEquals(1, matches.get(worker2.getLogicalIpPort()));
         assertEquals(
-                Map.of(worker1.getIpPort(), 1, worker2.getIpPort(), 1),
+                Map.of(worker1.getLogicalIpPort(), 1, worker2.getLogicalIpPort(), 1),
                 manager.findMatchingEngines(List.of(11L), RoleType.PREFILL, "default"));
         manager.shutdown();
     }
@@ -64,18 +64,18 @@ class LocalStandbyCacheManagerTest {
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
 
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L, 22L, 33L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L, 22L, 33L));
 
         assertEquals(
                 2,
                 manager.findMatchingEngines(
                                 List.of(11L, 22L, 33L), RoleType.PDFUSION, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         assertEquals(
                 0,
                 manager.findMatchingEngines(
                                 List.of(11L), RoleType.PDFUSION, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         manager.shutdown();
     }
 
@@ -89,13 +89,13 @@ class LocalStandbyCacheManagerTest {
                 configuration(300_000),
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L, 22L, 33L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L, 22L, 33L));
 
         assertEquals(
                 3,
                 manager.findMatchingEngines(
                                 List.of(11L, 22L, 33L), RoleType.PDFUSION, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         manager.shutdown();
     }
 
@@ -109,14 +109,14 @@ class LocalStandbyCacheManagerTest {
                 configuration(20),
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L));
 
         Thread.sleep(30);
 
         assertEquals(
                 0,
                 manager.findMatchingEngines(List.of(11L), RoleType.PREFILL, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         assertEquals(0, manager.mappingCount());
         manager.shutdown();
     }
@@ -141,7 +141,7 @@ class LocalStandbyCacheManagerTest {
                 mock(CacheMetricsReporter.class));
 
         manager.refreshCapacityLimits();
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L));
 
         assertEquals(1_000, manager.maximumEntryCount());
         manager.shutdown();
@@ -202,7 +202,7 @@ class LocalStandbyCacheManagerTest {
                 cacheMetricsReporter);
 
         manager.addRoutedRequestBlocks(
-                worker.getIpPort(),
+                worker.getLogicalIpPort(),
                 List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L));
 
         manager.reportMappingCount();

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProviderTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProviderTest.java
@@ -11,6 +11,8 @@ import org.flexlb.dao.route.KvcmConfig;
 import org.flexlb.dao.route.RoleType;
 import org.flexlb.dao.route.ServiceRoute;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.List;
 import java.util.Map;
@@ -42,7 +44,7 @@ class LocalStandbyCacheMatchProviderTest {
         CompletableFuture<LocalStandbyHashResult> pendingHash = new CompletableFuture<>();
         when(hashService.getHashResult("request-1", null, 4096)).thenReturn(pendingHash);
         when(cacheManager.findMatchingEngines(List.of(101L), RoleType.PREFILL, "default"))
-                .thenReturn(Map.of("10.0.0.1:8080", 1));
+                .thenReturn(Map.of("10.0.0.1:8080@0", 1));
 
         try {
             CompletableFuture<CacheMatchResult> match = provider.asyncLocalStandbyMatch(query);
@@ -51,7 +53,7 @@ class LocalStandbyCacheMatchProviderTest {
             pendingHash.complete(new LocalStandbyHashResult(List.of(101L), 4096));
             CacheMatchResult result = match.get(1, TimeUnit.SECONDS);
 
-            assertEquals(1, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
+            assertEquals(1, result.exactHostMatch("10.0.0.1:8080@0").localMatchBlocks());
             assertEquals(4096, result.blockSize());
             verify(cacheManager).findMatchingEngines(List.of(101L), RoleType.PREFILL, "default");
         } finally {
@@ -59,8 +61,10 @@ class LocalStandbyCacheMatchProviderTest {
         }
     }
 
-    @Test
-    void updatesRequestDerivedCacheMetadataAsynchronously() {
+    @ParameterizedTest
+    @CsvSource({"0, 1, 10.0.0.1:8080@0", "1, 2, 10.0.0.1:8080@1"})
+    void updatesRequestDerivedCacheMetadataAsynchronously(
+            int engineIndex, int multiEngineNum, String logicalIpPort) {
         LocalStandbyCacheManager cacheManager = mock(LocalStandbyCacheManager.class);
         LocalStandbyHashService hashService = mock(LocalStandbyHashService.class);
         LocalStandbyCacheMatchProvider provider =
@@ -82,6 +86,7 @@ class LocalStandbyCacheMatchProviderTest {
         selectedWorker.setHttpPort(8080);
         selectedWorker.setRole(RoleType.PREFILL);
         selectedWorker.setGroup("default");
+        selectedWorker.setSelectedEngineIndex(engineIndex, multiEngineNum);
 
         try {
             provider.updateFromRoutedRequest(request, List.of(selectedWorker));
@@ -90,7 +95,7 @@ class LocalStandbyCacheMatchProviderTest {
             pendingHash.complete(new LocalStandbyHashResult(List.of(11L, 22L), 4096));
 
             verify(cacheManager, timeout(1_000))
-                    .addRoutedRequestBlocks("10.0.0.1:8080", List.of(11L));
+                    .addRoutedRequestBlocks(logicalIpPort, List.of(11L));
         } finally {
             provider.shutdown();
         }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonServiceTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonServiceTest.java
@@ -47,7 +47,7 @@ class LocalStandbyComparisonServiceTest {
 
         verify(provider).asyncLocalStandbyMatch(query);
         pendingMatch.complete(new CacheMatchResult(
-                Map.of("10.0.0.1:8080", HostCacheMatch.local(1)),
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(1)),
                 CacheMatchSource.LOCAL_STANDBY,
                 10,
                 4096));
@@ -86,7 +86,7 @@ class LocalStandbyComparisonServiceTest {
                 RoleType.PREFILL,
                 "default");
         comparisonService.trackResolvedLocalStandbyPrediction(query, new CacheMatchResult(
-                Map.of("10.0.0.1:8080", HostCacheMatch.local(1)),
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(1)),
                 CacheMatchSource.LOCAL_STANDBY,
                 10,
                 4096));
@@ -104,6 +104,74 @@ class LocalStandbyComparisonServiceTest {
         assertNotNull(result.localStandby());
         assertEquals(4096, result.localStandby().hit());
         assertEquals(1904, result.localStandby().delta());
+    }
+
+    @Test
+    void matchesLocalStandbyPredictionByEngineIndex() throws Exception {
+        LocalStandbyCacheMatchProvider provider = mock(LocalStandbyCacheMatchProvider.class);
+        LocalStandbyComparisonService comparisonService = new LocalStandbyComparisonService(
+                kvcm(modelMetaConfig()), provider);
+        CacheMatchQuery query = new CacheMatchQuery(
+                "request-index-1",
+                List.of(11L),
+                1024,
+                List.of(101L),
+                4096,
+                RoleType.PREFILL,
+                "default");
+        comparisonService.trackResolvedLocalStandbyPrediction(query, new CacheMatchResult(
+                Map.of(
+                        "10.0.0.1:8080@0", HostCacheMatch.local(1),
+                        "10.0.0.1:8080@1", HostCacheMatch.local(2)),
+                CacheMatchSource.LOCAL_STANDBY,
+                10,
+                4096));
+
+        CacheHitFeedback feedback = new CacheHitFeedback(
+                "cache_hit_comparison", "request-index-1", "LOCAL_STANDBY", "PREFILL", "default",
+                "10.0.0.1", 8080, 1, "running", 12000, 4096, 4096,
+                false, 0, 0, 0,
+                9000, 4904);
+
+        CacheHitComparisonResult result =
+                comparisonService.buildCacheHitComparison(feedback).get(1, TimeUnit.SECONDS);
+
+        assertEquals("10.0.0.1:8080@1", result.worker());
+        assertEquals(8192, result.localStandby().hit());
+        assertEquals(808, result.localStandby().delta());
+    }
+
+    @Test
+    void degradesToZeroStandbyHitWhenPredictionMissesLogicalWorker() throws Exception {
+        LocalStandbyCacheMatchProvider provider = mock(LocalStandbyCacheMatchProvider.class);
+        LocalStandbyComparisonService comparisonService = new LocalStandbyComparisonService(
+                kvcm(modelMetaConfig()), provider);
+        CacheMatchQuery query = new CacheMatchQuery(
+                "request-miss-1",
+                List.of(11L),
+                1024,
+                List.of(101L),
+                4096,
+                RoleType.PREFILL,
+                "default");
+        comparisonService.trackResolvedLocalStandbyPrediction(query, new CacheMatchResult(
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(2)),
+                CacheMatchSource.LOCAL_STANDBY,
+                10,
+                4096));
+
+        CacheHitFeedback feedback = new CacheHitFeedback(
+                "cache_hit_comparison", "request-miss-1", "LOCAL_STANDBY", "PREFILL", "default",
+                "10.0.0.1", 8080, 1, "running", 12000, 4096, 4096,
+                false, 0, 0, 0,
+                9000, 4904);
+
+        CacheHitComparisonResult result =
+                comparisonService.buildCacheHitComparison(feedback).get(1, TimeUnit.SECONDS);
+
+        assertNotNull(result.localStandby());
+        assertEquals(0, result.localStandby().hit());
+        assertEquals(9000, result.localStandby().delta());
     }
 
     private ModelMetaConfig modelMetaConfig() {

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/KvCacheManagerTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/KvCacheManagerTest.java
@@ -1,6 +1,8 @@
 package org.flexlb.cache.match.localsync;
 
+import org.flexlb.cache.domain.DiffResult;
 import org.flexlb.cache.telemetry.CacheMetricsReporter;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatusProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +46,89 @@ class KvCacheManagerTest {
         verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080");
         verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080");
         verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.2:8080");
+    }
+
+    @Test
+    void keepsLogicalCacheWhenItsPhysicalEngineRemainsDiscoverable() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+    }
+
+    @Test
+    void removesLogicalCacheWhenItsPhysicalEngineDisappears() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.2:8080"));
+
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+    }
+
+    @Test
+    void keepsAllSiblingLogicalCachesWhenTheirPhysicalEngineRemainsDiscoverable() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0", "10.0.0.1:8080@1"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@1", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@1"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 1), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+        verify(globalCacheIndex, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+    }
+
+    @Test
+    void removesAllSiblingLogicalCachesWhenTheirPhysicalEngineDisappears() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0", "10.0.0.1:8080@1"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@1", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@1"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 1), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.2:8080"));
+
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+    }
+
+    @Test
+    void treatsUnmappedLogicalKeyAsStaleEvenWhenItsPhysicalEngineRemainsDiscoverable() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0"));
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/KvCacheManagerTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/KvCacheManagerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -76,6 +77,22 @@ class KvCacheManagerTest {
 
         verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
         verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+    }
+
+    @Test
+    void directRetirementRemovesTheLogicalToPhysicalMapping() {
+        String logicalIpPort = "10.0.0.1:8080@0";
+        when(engineLocalView.calculateDiff(logicalIpPort, Set.of()))
+                .thenReturn(DiffResult.empty(logicalIpPort));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+
+        kvCacheManager.removeEngineCache(logicalIpPort);
+        when(engineLocalView.getAllEngineIpPorts()).thenReturn(Set.of(logicalIpPort));
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView, times(2)).removeAllCacheBlockOfEngine(logicalIpPort);
+        verify(globalCacheIndex, times(2)).removeAllCacheBlockOfEngine(logicalIpPort);
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProviderTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProviderTest.java
@@ -3,6 +3,7 @@ package org.flexlb.cache.match.localsync;
 import org.flexlb.cache.domain.WorkerCacheUpdateResult;
 import org.flexlb.cache.telemetry.CacheMetricsReporter;
 import org.flexlb.dao.master.CacheStatus;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.route.RoleType;
 import org.junit.jupiter.api.Test;
@@ -11,11 +12,14 @@ import java.util.Set;
 
 import static org.flexlb.cache.WorkerStatusTestSupport.workerStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 class LocalSyncCacheMatchProviderTest {
 
@@ -31,8 +35,87 @@ class LocalSyncCacheMatchProviderTest {
 
         assertTrue(result.isSuccess());
         assertEquals(2, result.getCacheBlockCount());
-        verify(kvCacheManager).updateEngineCache("127.0.0.1:8080", "PREFILL", Set.of(11L, 22L));
-        verify(metricsReporter).reportUpdateEngineBlockCacheRT(eq("127.0.0.1:8080"), eq("PREFILL"), anyLong(), eq("1"));
+        assertEquals(100L, result.getAvailableKvCache());
+        assertEquals(200L, result.getTotalKvCache());
+        assertEquals(3L, result.getCacheVersion());
+        verify(kvCacheManager).updateEngineCache(
+                new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of(11L, 22L));
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("1"));
+    }
+
+    @Test
+    void rejectsMissingCacheStatus() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatus(
+                "127.0.0.1", 8080, RoleType.PREFILL, false, null);
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertFalse(result.isSuccess());
+        assertEquals("127.0.0.1:8080@0", result.getLogicalIpPort());
+        assertEquals("Worker Cache Status is null", result.getErrorMessage());
+        verifyNoInteractions(kvCacheManager);
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("0"));
+    }
+
+    @Test
+    void rejectsMissingCachedKeys() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatusWithCachedKeys(null);
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Worker Cached Keys is null", result.getErrorMessage());
+        verifyNoInteractions(kvCacheManager);
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("0"));
+    }
+
+    @Test
+    void acceptsEmptyCachedKeys() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatusWithCachedKeys(Set.of());
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertTrue(result.isSuccess());
+        assertEquals(0, result.getCacheBlockCount());
+        verify(kvCacheManager).updateEngineCache(
+                new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of());
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("1"));
+    }
+
+    @Test
+    void reportsCacheManagerFailure() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatusFixture();
+        doThrow(new IllegalStateException("cache update failed"))
+                .when(kvCacheManager)
+                .updateEngineCache(
+                        new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of(11L, 22L));
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertFalse(result.isSuccess());
+        assertEquals("cache update failed", result.getErrorMessage());
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("0"));
     }
 
     private WorkerStatus workerStatusFixture() {
@@ -43,5 +126,10 @@ class LocalSyncCacheMatchProviderTest {
                 .totalKvCache(200L)
                 .version(3L)
                 .build());
+    }
+
+    private WorkerStatus workerStatusWithCachedKeys(Set<Long> cachedKeys) {
+        return workerStatus("127.0.0.1", 8080, RoleType.PREFILL, false,
+                CacheStatus.builder().cachedKeys(cachedKeys).build());
     }
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProviderTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProviderTest.java
@@ -41,7 +41,7 @@ class LocalSyncCacheMatchProviderTest {
         verify(kvCacheManager).updateEngineCache(
                 new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of(11L, 22L));
         verify(metricsReporter).reportUpdateEngineBlockCacheRT(
-                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("1"));
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("1"));
     }
 
     @Test
@@ -60,7 +60,7 @@ class LocalSyncCacheMatchProviderTest {
         assertEquals("Worker Cache Status is null", result.getErrorMessage());
         verifyNoInteractions(kvCacheManager);
         verify(metricsReporter).reportUpdateEngineBlockCacheRT(
-                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("0"));
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("0"));
     }
 
     @Test
@@ -77,7 +77,7 @@ class LocalSyncCacheMatchProviderTest {
         assertEquals("Worker Cached Keys is null", result.getErrorMessage());
         verifyNoInteractions(kvCacheManager);
         verify(metricsReporter).reportUpdateEngineBlockCacheRT(
-                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("0"));
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("0"));
     }
 
     @Test
@@ -95,7 +95,7 @@ class LocalSyncCacheMatchProviderTest {
         verify(kvCacheManager).updateEngineCache(
                 new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of());
         verify(metricsReporter).reportUpdateEngineBlockCacheRT(
-                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("1"));
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("1"));
     }
 
     @Test
@@ -115,7 +115,7 @@ class LocalSyncCacheMatchProviderTest {
         assertFalse(result.isSuccess());
         assertEquals("cache update failed", result.getErrorMessage());
         verify(metricsReporter).reportUpdateEngineBlockCacheRT(
-                eq("127.0.0.1@0"), eq("PREFILL"), anyLong(), eq("0"));
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("0"));
     }
 
     private WorkerStatus workerStatusFixture() {

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/monitor/CacheMetricsReporterTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/monitor/CacheMetricsReporterTest.java
@@ -67,10 +67,10 @@ class CacheMetricsReporterTest {
     }
 
     @Test
-    void should_report_engine_local_metrics_without_engine_ip_port() {
-        reporter.reportEngineLocalMetrics("10.0.0.1", "PREFILL", 2);
+    void should_report_engine_local_metrics_with_logical_worker_address() {
+        reporter.reportEngineLocalMetrics("10.0.0.1:8080@0", "PREFILL", 2);
 
-        FlexMetricTags tags = FlexMetricTags.of("engineIp", "10.0.0.1", "role", "PREFILL");
+        FlexMetricTags tags = FlexMetricTags.of("engineIp", "10.0.0.1:8080@0", "role", "PREFILL");
         verify(monitor).report(CACHE_ENGINE_LOCAL_COUNT, tags, 2);
         verify(monitor).report(CACHE_ENGINE_LOCAL_BYTES, tags, 272L);
     }
@@ -119,22 +119,22 @@ class CacheMetricsReporterTest {
 
     @Test
     void should_report_cache_affinity_decision() {
-        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1", "CACHE_LEADER");
+        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1:8080@0", "CACHE_LEADER");
 
         FlexMetricTags tags = FlexMetricTags.of(
                 "role", "PREFILL",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "decision", "CACHE_LEADER");
         verify(monitor).report(CACHE_AFFINITY_DECISION, tags, 1.0);
     }
 
     @Test
     void reportsCacheUpdateLatencyWithIndexedEngineIp() {
-        reporter.reportUpdateEngineBlockCacheRT("10.0.0.8@1", "PREFILL", 0L, "1");
+        reporter.reportUpdateEngineBlockCacheRT("10.0.0.8:8080@1", "PREFILL", 0L, "1");
 
         verify(monitor).report(
                 eq(CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT),
-                eq(FlexMetricTags.of("engineIp", "10.0.0.8@1", "role", "PREFILL", "success", "1")),
+                eq(FlexMetricTags.of("engineIp", "10.0.0.8:8080@1", "role", "PREFILL", "success", "1")),
                 anyDouble());
     }
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/monitor/CacheMetricsReporterTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/monitor/CacheMetricsReporterTest.java
@@ -24,7 +24,10 @@ import static org.flexlb.constant.MetricConstant.CACHE_ROUTING_SELECTED_MATCH_TO
 import static org.flexlb.constant.MetricConstant.CACHE_THEORY_HIT_COUNT;
 import static org.flexlb.constant.MetricConstant.CACHE_THEORY_HIT_RATIO;
 import static org.flexlb.constant.MetricConstant.CACHE_THEORY_TOTAL_COUNT;
+import static org.flexlb.constant.MetricConstant.CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -123,5 +126,15 @@ class CacheMetricsReporterTest {
                 "engineIp", "10.0.0.1",
                 "decision", "CACHE_LEADER");
         verify(monitor).report(CACHE_AFFINITY_DECISION, tags, 1.0);
+    }
+
+    @Test
+    void reportsCacheUpdateLatencyWithIndexedEngineIp() {
+        reporter.reportUpdateEngineBlockCacheRT("10.0.0.8@1", "PREFILL", 0L, "1");
+
+        verify(monitor).report(
+                eq(CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT),
+                eq(FlexMetricTags.of("engineIp", "10.0.0.8@1", "role", "PREFILL", "success", "1")),
+                anyDouble());
     }
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/update/CacheMetadataUpdateOrchestratorTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/update/CacheMetadataUpdateOrchestratorTest.java
@@ -53,7 +53,7 @@ class CacheMetadataUpdateOrchestratorTest {
         WorkerCacheUpdateResult result = orchestrator().updateFromWorkerStatus(workerStatus);
 
         assertFalse(result.isSuccess());
-        assertEquals("127.0.0.1:8080", result.getEngineIpPort());
+        assertEquals("127.0.0.1:8080@0", result.getLogicalIpPort());
         verifyNoInteractions(localSyncProvider);
     }
 

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/config/ModelServiceConfiguration.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/config/ModelServiceConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Configuration;
 public class ModelServiceConfiguration {
 
     private static final String MODEL_SERVICE_CONFIG = "MODEL_SERVICE_CONFIG";
+    private static final int MAX_TCP_PORT = 65_535;
 
     @Bean
     public ModelMetaConfig modelMetaConfig(ConfigService configService, RoutingServiceDiscovery serviceDiscovery) {
@@ -49,11 +50,42 @@ public class ModelServiceConfiguration {
             throw new IllegalArgumentException("MODEL_SERVICE_CONFIG must contain at least one role endpoint");
         }
         for (Endpoint endpoint : endpoints) {
+            validateEngineEndpointConfiguration(endpoint);
             serviceDiscovery.validate(endpoint);
         }
 
         validateKvcm(serviceRoute.getKvcm(), serviceDiscovery);
         validateOptimizer(serviceRoute.getOptimizer(), serviceDiscovery);
+    }
+
+    private void validateEngineEndpointConfiguration(Endpoint endpoint) {
+        int multiEngineNum = endpoint.getMultiEngineNum();
+        if (multiEngineNum < 1) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint multi_engine_num must be greater than zero: "
+                            + endpoint.getAddress());
+        }
+        Integer workerStatusPort = endpoint.getWorkerStatusPort();
+        if (workerStatusPort != null && (workerStatusPort < 1 || workerStatusPort > MAX_TCP_PORT)) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint worker_status_port must be between 1 and "
+                            + MAX_TCP_PORT + ": "
+                            + endpoint.getAddress());
+        }
+        if (multiEngineNum == 1) {
+            return;
+        }
+        if (workerStatusPort == null) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint worker_status_port must be configured "
+                            + "when multi_engine_num is greater than one: " + endpoint.getAddress());
+        }
+        if ((long) workerStatusPort + multiEngineNum - 1 > MAX_TCP_PORT) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint worker_status_port range exceeds "
+                            + MAX_TCP_PORT + ": "
+                            + endpoint.getAddress());
+        }
     }
 
     private void validateKvcm(KvcmConfig kvcm, RoutingServiceDiscovery serviceDiscovery) {

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/constant/CommonConstants.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/constant/CommonConstants.java
@@ -8,6 +8,9 @@ public class CommonConstants {
 
     public static final String TIMEOUT_HANDLER = "timeoutHandler";
 
+    /** Separator between a physical {@code ip:port} address and its logical engine index. */
+    public static final String LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR = "@";
+
     /**
      * gRPC timeout message
      */

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/cache/HostCacheMatch.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/cache/HostCacheMatch.java
@@ -18,6 +18,9 @@ public record HostCacheMatch(
         return new HostCacheMatch(matchBlocks, 0, matchBlocks);
     }
 
+    /**
+     * Converts local match counts while preserving logical {@code ip:port@engineIndex} keys.
+     */
     public static Map<String, HostCacheMatch> fromLocalMatches(Map<String, Integer> localMatches) {
         return localMatches.entrySet().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
@@ -1,8 +1,16 @@
 package org.flexlb.dao.loadbalance;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.route.RoleType;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,6 +30,31 @@ public class ServerStatus {
 
     @JsonProperty("dp_rank")
     private long dpRank;
+
+    /**
+     * Selected logical engine index exposed in the schedule response. This field is present
+     * when a physical frontend owns multiple logical engines and omitted when there is only
+     * one engine.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("engine_index")
+    private Integer engineIndex;
+
+    /**
+     * Selected logical engine index used only inside FlexLB. Unlike {@link #engineIndex}, this
+     * value is always available, including {@code 0} for a single-engine frontend, so routing
+     * and rollback can address the exact logical worker.
+     */
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private int routingEngineIndex;
+
+    @JsonIgnore
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private WorkerIdentity workerIdentity = new WorkerIdentity(null, 0, 0);
 
     @JsonProperty("prefill_time")
     private long prefillTime;
@@ -50,5 +83,50 @@ public class ServerStatus {
         result.setCode(code.getErrorCode());
         result.setMessage(code.getErrorMsg());
         return result;
+    }
+
+    /**
+     * Sets the selected engine identity for internal routing and the schedule wire response.
+     * Single-engine routes keep the internal {@code @0} identity but omit the wire field.
+     */
+    public void setSelectedEngineIndex(int selectedEngineIndex, int multiEngineNum) {
+        if (multiEngineNum < 1
+                || selectedEngineIndex < 0
+                || selectedEngineIndex >= multiEngineNum) {
+            throw new IllegalArgumentException(
+                    "selected engine index must be in [0, multiEngineNum)");
+        }
+        routingEngineIndex = selectedEngineIndex;
+        engineIndex = multiEngineNum > 1 ? selectedEngineIndex : null;
+        refreshWorkerIdentity();
+    }
+
+    /**
+     * Returns the internal logical worker identity in {@code ip:port@engineIndex} format.
+     * The index identifies one independently routable engine behind the physical frontend.
+     */
+    @JsonIgnore
+    public String getLogicalIpPort() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    /** Returns the port-free metrics identity in {@code ip@engineIndex} format. */
+    @JsonIgnore
+    public String getIpIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public void setServerIp(String serverIp) {
+        this.serverIp = serverIp;
+        refreshWorkerIdentity();
+    }
+
+    public void setHttpPort(int httpPort) {
+        this.httpPort = httpPort;
+        refreshWorkerIdentity();
+    }
+
+    private void refreshWorkerIdentity() {
+        workerIdentity = new WorkerIdentity(serverIp, httpPort, routingEngineIndex);
     }
 }

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
@@ -50,6 +50,10 @@ public class ServerStatus {
     private int routingEngineIndex;
 
     @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private int routingMultiEngineNum = 1;
+
+    @JsonIgnore
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
     @EqualsAndHashCode.Exclude
@@ -97,8 +101,15 @@ public class ServerStatus {
                     "selected engine index must be in [0, multiEngineNum)");
         }
         routingEngineIndex = selectedEngineIndex;
+        routingMultiEngineNum = multiEngineNum;
         engineIndex = multiEngineNum > 1 ? selectedEngineIndex : null;
         refreshWorkerIdentity();
+    }
+
+    /** Returns the logical worker count used to derive the schedule response. */
+    @JsonIgnore
+    public int getRoutingMultiEngineNum() {
+        return routingMultiEngineNum;
     }
 
     /**

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
@@ -110,7 +110,7 @@ public class ServerStatus {
         return workerIdentity.getLogicalIpPort();
     }
 
-    /** Returns the port-free metrics identity in {@code ip@engineIndex} format. */
+    /** Returns the legacy port-free identity in {@code ip@engineIndex} format. */
     @JsonIgnore
     public String getIpIndex() {
         return workerIdentity.getIpIndex();

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/CacheHitFeedback.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/CacheHitFeedback.java
@@ -2,6 +2,8 @@ package org.flexlb.dao.master;
 
 /**
  * Engine feedback comparing the routing cache-hit prediction with the actual cache hit.
+ * The embedded {@link WorkerIdentity} preserves both the routing identity
+ * ({@code ip:port@engineIndex}) and metrics identity ({@code ip@engineIndex}).
  */
 public record CacheHitFeedback(
         String eventType,
@@ -9,8 +11,7 @@ public record CacheHitFeedback(
         String cacheMatchSource,
         String role,
         String group,
-        String workerIp,
-        int workerPort,
+        WorkerIdentity workerIdentity,
         String taskState,
         long inputTokens,
         long blockSize,
@@ -21,6 +22,83 @@ public record CacheHitFeedback(
         long kvcmP2pTotalMatchTokens,
         long actualHitTokens,
         long deltaHitTokens) {
+
+    public CacheHitFeedback(
+            String eventType,
+            String requestId,
+            String cacheMatchSource,
+            String role,
+            String group,
+            String workerIp,
+            int workerPort,
+            int engineIndex,
+            String taskState,
+            long inputTokens,
+            long blockSize,
+            long predictedHitTokens,
+            boolean kvcmMatchAvailable,
+            long kvcmLocalMatchTokens,
+            long kvcmP2pFetchTokens,
+            long kvcmP2pTotalMatchTokens,
+            long actualHitTokens,
+            long deltaHitTokens) {
+        this(
+                eventType,
+                requestId,
+                cacheMatchSource,
+                role,
+                group,
+                new WorkerIdentity(workerIp, workerPort, engineIndex),
+                taskState,
+                inputTokens,
+                blockSize,
+                predictedHitTokens,
+                kvcmMatchAvailable,
+                kvcmLocalMatchTokens,
+                kvcmP2pFetchTokens,
+                kvcmP2pTotalMatchTokens,
+                actualHitTokens,
+                deltaHitTokens);
+    }
+
+    public CacheHitFeedback(
+            String eventType,
+            String requestId,
+            String cacheMatchSource,
+            String role,
+            String group,
+            String workerIp,
+            int workerPort,
+            String taskState,
+            long inputTokens,
+            long blockSize,
+            long predictedHitTokens,
+            boolean kvcmMatchAvailable,
+            long kvcmLocalMatchTokens,
+            long kvcmP2pFetchTokens,
+            long kvcmP2pTotalMatchTokens,
+            long actualHitTokens,
+            long deltaHitTokens) {
+        this(
+                eventType,
+                requestId,
+                cacheMatchSource,
+                role,
+                group,
+                workerIp,
+                workerPort,
+                0,
+                taskState,
+                inputTokens,
+                blockSize,
+                predictedHitTokens,
+                kvcmMatchAvailable,
+                kvcmLocalMatchTokens,
+                kvcmP2pFetchTokens,
+                kvcmP2pTotalMatchTokens,
+                actualHitTokens,
+                deltaHitTokens);
+    }
 
     public CacheHitFeedback(
             String eventType,
@@ -44,6 +122,7 @@ public record CacheHitFeedback(
                 group,
                 workerIp,
                 workerPort,
+                0,
                 taskState,
                 inputTokens,
                 blockSize,
@@ -54,5 +133,26 @@ public record CacheHitFeedback(
                 0,
                 actualHitTokens,
                 deltaHitTokens);
+    }
+
+    /**
+     * Returns the feedback target in {@code ip:port@engineIndex} format. The index identifies
+     * one independently routable engine behind the physical frontend.
+     */
+    public String logicalWorkerId() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    /** Returns the metrics identity in {@code ip@engineIndex} format. */
+    public String ipIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public int workerPort() {
+        return workerIdentity.getPort();
+    }
+
+    public int engineIndex() {
+        return workerIdentity.getEngineIndex();
     }
 }

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/CacheHitFeedback.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/CacheHitFeedback.java
@@ -3,7 +3,7 @@ package org.flexlb.dao.master;
 /**
  * Engine feedback comparing the routing cache-hit prediction with the actual cache hit.
  * The embedded {@link WorkerIdentity} preserves both the routing identity
- * ({@code ip:port@engineIndex}) and metrics identity ({@code ip@engineIndex}).
+ * ({@code ip:port@engineIndex}) and legacy short identity ({@code ip@engineIndex}).
  */
 public record CacheHitFeedback(
         String eventType,
@@ -143,7 +143,7 @@ public record CacheHitFeedback(
         return workerIdentity.getLogicalIpPort();
     }
 
-    /** Returns the metrics identity in {@code ip@engineIndex} format. */
+    /** Returns the legacy short identity in {@code ip@engineIndex} format. */
     public String ipIndex() {
         return workerIdentity.getIpIndex();
     }

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerHost.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerHost.java
@@ -1,5 +1,6 @@
 package org.flexlb.dao.master;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 
 /**
@@ -29,9 +30,29 @@ public class WorkerHost {
      */
     private final int httpServerPort;
     /**
-     * gRPC port for GetWorkerStatus.
+     * Per-engine gRPC port for worker control RPCs, including GetWorkerStatus and GetCacheStatus.
      */
     private final int workerStatusPort;
+    /**
+     * Logical engine index behind the shared frontend.
+     */
+    private final int engineIndex;
+    /**
+     * Expected number of logical engines for this physical frontend.
+     */
+    private final int multiEngineNum;
+    /**
+     * Canonical identity for this logical worker. It precomputes the physical frontend
+     * identity ({@code ip:port}), routable/cache identity ({@code ip:port@engineIndex}), and
+     * metrics identity ({@code ip@engineIndex}); callers use the corresponding semantic getters
+     * exposed by {@link WorkerHost}.
+     */
+    @Getter(AccessLevel.NONE)
+    private final WorkerIdentity workerIdentity;
+    /**
+     * Endpoint configuration address that produced this host.
+     */
+    private final String endpointAddress;
     /**
      * Data center/site information
      */
@@ -68,11 +89,29 @@ public class WorkerHost {
 
     public WorkerHost(String ip, int httpPort, int grpcPort, int httpServerPort, int workerStatusPort,
                       String site, String group, String deploymentName) {
+        this(ip, httpPort, grpcPort, httpServerPort, workerStatusPort,
+                site, group, deploymentName, 0, 1, "");
+    }
+
+    public WorkerHost(String ip, int httpPort, int grpcPort, int httpServerPort, int workerStatusPort,
+                      String site, String group, String deploymentName,
+                      int engineIndex, int multiEngineNum) {
+        this(ip, httpPort, grpcPort, httpServerPort, workerStatusPort,
+                site, group, deploymentName, engineIndex, multiEngineNum, "");
+    }
+
+    public WorkerHost(String ip, int httpPort, int grpcPort, int httpServerPort, int workerStatusPort,
+                      String site, String group, String deploymentName,
+                      int engineIndex, int multiEngineNum, String endpointAddress) {
         this.ip = ip;
         this.httpPort = httpPort;
         this.grpcPort = grpcPort;
         this.httpServerPort = httpServerPort;
         this.workerStatusPort = workerStatusPort;
+        this.engineIndex = engineIndex;
+        this.multiEngineNum = multiEngineNum;
+        this.workerIdentity = new WorkerIdentity(ip, httpPort, engineIndex);
+        this.endpointAddress = endpointAddress != null ? endpointAddress : "";
         this.site = site != null ? site : "";
         this.group = group != null ? group : "";
         this.deploymentName = deploymentName != null ? deploymentName : "";
@@ -100,12 +139,34 @@ public class WorkerHost {
     }
 
     /**
-     * Get IP:Port format string
+     * Get the physical frontend address.
      *
-     * @return IP:Port format string
+     * @return physical address in {@code ip:port} format, without an engine index
      */
     public String getIpPort() {
-        return ip + ":" + httpPort;
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    /** Returns the physical frontend address in {@code ip:port} format. */
+    public String getPhysicalIpPort() {
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    /**
+     * Returns the logical worker identity in {@code ip:port@engineIndex} format. The index
+     * identifies one independently routable engine behind the physical frontend.
+     */
+    public String getLogicalIpPort() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    /** Returns the port-free metrics identity in {@code ip@engineIndex} format. */
+    public String getIpIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public String getPhysicalGroupKey() {
+        return endpointAddress + "|" + group + "|" + getPhysicalIpPort();
     }
 
     /**

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerHost.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerHost.java
@@ -44,7 +44,7 @@ public class WorkerHost {
     /**
      * Canonical identity for this logical worker. It precomputes the physical frontend
      * identity ({@code ip:port}), routable/cache identity ({@code ip:port@engineIndex}), and
-     * metrics identity ({@code ip@engineIndex}); callers use the corresponding semantic getters
+     * legacy short identity ({@code ip@engineIndex}); callers use the corresponding semantic getters
      * exposed by {@link WorkerHost}.
      */
     @Getter(AccessLevel.NONE)
@@ -160,7 +160,7 @@ public class WorkerHost {
         return workerIdentity.getLogicalIpPort();
     }
 
-    /** Returns the port-free metrics identity in {@code ip@engineIndex} format. */
+    /** Returns the legacy port-free identity in {@code ip@engineIndex} format. */
     public String getIpIndex() {
         return workerIdentity.getIpIndex();
     }

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerIdentity.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerIdentity.java
@@ -1,0 +1,51 @@
+package org.flexlb.dao.master;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import static org.flexlb.constant.CommonConstants.LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR;
+
+/**
+ * Immutable worker identity with all commonly used address representations precomputed.
+ *
+ * <ul>
+ *   <li>{@code ip}: raw host IP</li>
+ *   <li>{@code port}: raw shared frontend port</li>
+ *   <li>{@code engineIndex}: raw logical engine index</li>
+ *   <li>{@code physicalIpPort}: {@code ip:port}, identifying the shared frontend</li>
+ *   <li>{@code logicalIpPort}: {@code ip:port@engineIndex}, used by routing and cache matching</li>
+ *   <li>{@code ipIndex}: {@code ip@engineIndex}, used by per-engine metrics</li>
+ * </ul>
+ */
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class WorkerIdentity {
+
+    /** Raw host IP, without a port or engine index. */
+    private final String ip;
+    /** Raw shared frontend port. */
+    private final int port;
+    /** Raw logical engine index behind the shared frontend. */
+    private final int engineIndex;
+    /** Shared physical frontend identity in {@code ip:port} format. */
+    private final String physicalIpPort;
+    /** Routable/cache identity in {@code ip:port@engineIndex} format. */
+    private final String logicalIpPort;
+    /** Per-engine metrics identity in {@code ip@engineIndex} format. */
+    private final String ipIndex;
+
+    public WorkerIdentity(String ip, int port, int engineIndex) {
+        this.ip = ip;
+        this.port = port;
+        this.engineIndex = engineIndex;
+        this.physicalIpPort = ip == null ? null : ip + ":" + port;
+        this.logicalIpPort = physicalIpPort == null
+                ? null
+                : physicalIpPort + LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR + engineIndex;
+        this.ipIndex = ip == null
+                ? null
+                : ip + LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR + engineIndex;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerIdentity.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerIdentity.java
@@ -15,7 +15,8 @@ import static org.flexlb.constant.CommonConstants.LOGICAL_WORKER_ENGINE_INDEX_SE
  *   <li>{@code engineIndex}: raw logical engine index</li>
  *   <li>{@code physicalIpPort}: {@code ip:port}, identifying the shared frontend</li>
  *   <li>{@code logicalIpPort}: {@code ip:port@engineIndex}, used by routing and cache matching</li>
- *   <li>{@code ipIndex}: {@code ip@engineIndex}, used by per-engine metrics</li>
+ *   <li>{@code ipIndex}: legacy short form {@code ip@engineIndex}</li>
+ *   <li>{@code logicalIpPort}: {@code ip:port@engineIndex}, used by per-engine metrics</li>
  * </ul>
  */
 @Getter
@@ -33,7 +34,7 @@ public final class WorkerIdentity {
     private final String physicalIpPort;
     /** Routable/cache identity in {@code ip:port@engineIndex} format. */
     private final String logicalIpPort;
-    /** Per-engine metrics identity in {@code ip@engineIndex} format. */
+    /** Legacy short per-engine identity in {@code ip@engineIndex} format. */
     private final String ipIndex;
 
     public WorkerIdentity(String ip, int port, int engineIndex) {

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerStatus.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerStatus.java
@@ -52,7 +52,9 @@ public class WorkerStatus {
             int port,
             int grpcPort,
             String site,
-            String deploymentName) {
+            String deploymentName,
+            int engineIndex,
+            int multiEngineNum) {
 
         public TopologySnapshot(
                 String group,
@@ -60,7 +62,7 @@ public class WorkerStatus {
                 int port,
                 int grpcPort,
                 String site) {
-            this(group, ip, port, grpcPort, site, null);
+            this(group, ip, port, grpcPort, site, null, 0, 1);
         }
     }
 
@@ -293,6 +295,8 @@ public class WorkerStatus {
 
     private final AtomicReference<TopologySnapshot> topology;
 
+    private final WorkerIdentity workerIdentity;
+
     private final AtomicReference<CommittedWorkerStatus> committedStatus;
 
     private final AtomicReference<PollHealth> pollHealth;
@@ -340,6 +344,8 @@ public class WorkerStatus {
             TopologySnapshot initialTopology,
             EngineObservation initialStatus) {
         topology = new AtomicReference<>(initialTopology);
+        workerIdentity = new WorkerIdentity(
+                initialTopology.ip(), initialTopology.port(), initialTopology.engineIndex());
         committedStatus = new AtomicReference<>(new CommittedWorkerStatus(
                 initialStatus,
                 new AppliedStatusCursor(-1L, -1L)));
@@ -368,15 +374,33 @@ public class WorkerStatus {
             int grpcPort,
             String site,
             String deploymentName) {
+        return createDiscovered(
+                role, group, ip, port, grpcPort, site, deploymentName, 0, 1);
+    }
+
+    public static WorkerStatus createDiscovered(
+            RoleType role,
+            String group,
+            String ip,
+            int port,
+            int grpcPort,
+            String site,
+            String deploymentName,
+            int engineIndex,
+            int multiEngineNum) {
         Objects.requireNonNull(role, "role");
         Objects.requireNonNull(ip, "ip");
         if (port <= 0 || grpcPort <= 0) {
             throw new IllegalArgumentException(
                     "worker ports must be positive");
         }
+        if (engineIndex < 0 || multiEngineNum <= 0 || engineIndex >= multiEngineNum) {
+            throw new IllegalArgumentException("invalid logical worker index");
+        }
         return new WorkerStatus(
                 new TopologySnapshot(
-                        group, ip, port, grpcPort, site, deploymentName),
+                        group, ip, port, grpcPort, site, deploymentName,
+                        engineIndex, multiEngineNum),
                 new EngineObservation(
                         role,
                         null,
@@ -619,7 +643,9 @@ public class WorkerStatus {
                 current.port(),
                 current.grpcPort(),
                 site,
-                deploymentName));
+                deploymentName,
+                current.engineIndex(),
+                current.multiEngineNum()));
     }
 
     public RoleType getRole() {
@@ -788,11 +814,31 @@ public class WorkerStatus {
 
     /** Get the HTTP IP:PORT address. */
     public String getIpPort() {
-        TopologySnapshot current = topology.get();
-        if (current.ip() == null) {
-            return null;
-        }
-        return current.ip() + ":" + current.port();
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    public WorkerIdentity getWorkerIdentity() {
+        return workerIdentity;
+    }
+
+    public String getPhysicalIpPort() {
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    public String getLogicalIpPort() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    public String getIpIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public int getEngineIndex() {
+        return workerIdentity.getEngineIndex();
+    }
+
+    public int getMultiEngineNum() {
+        return topology.get().multiEngineNum();
     }
 
     private static Map<String, TaskObservation> freezeTaskMap(

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerStatus.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerStatus.java
@@ -53,6 +53,7 @@ public class WorkerStatus {
             int grpcPort,
             String site,
             String deploymentName,
+            String physicalGroupKey,
             int engineIndex,
             int multiEngineNum) {
 
@@ -62,7 +63,8 @@ public class WorkerStatus {
                 int port,
                 int grpcPort,
                 String site) {
-            this(group, ip, port, grpcPort, site, null, 0, 1);
+            this(group, ip, port, grpcPort, site, null,
+                    defaultPhysicalGroupKey(group, ip, port), 0, 1);
         }
     }
 
@@ -388,6 +390,23 @@ public class WorkerStatus {
             String deploymentName,
             int engineIndex,
             int multiEngineNum) {
+        return createDiscovered(
+                role, group, ip, port, grpcPort, site, deploymentName,
+                engineIndex, multiEngineNum,
+                defaultPhysicalGroupKey(group, ip, port));
+    }
+
+    public static WorkerStatus createDiscovered(
+            RoleType role,
+            String group,
+            String ip,
+            int port,
+            int grpcPort,
+            String site,
+            String deploymentName,
+            int engineIndex,
+            int multiEngineNum,
+            String physicalGroupKey) {
         Objects.requireNonNull(role, "role");
         Objects.requireNonNull(ip, "ip");
         if (port <= 0 || grpcPort <= 0) {
@@ -400,6 +419,8 @@ public class WorkerStatus {
         return new WorkerStatus(
                 new TopologySnapshot(
                         group, ip, port, grpcPort, site, deploymentName,
+                        normalizePhysicalGroupKey(
+                                physicalGroupKey, group, ip, port),
                         engineIndex, multiEngineNum),
                 new EngineObservation(
                         role,
@@ -416,6 +437,19 @@ public class WorkerStatus {
                         0L,
                         0L,
                         0L));
+    }
+
+    private static String defaultPhysicalGroupKey(
+            String group, String ip, int port) {
+        return normalizePhysicalGroupKey(null, group, ip, port);
+    }
+
+    private static String normalizePhysicalGroupKey(
+            String physicalGroupKey, String group, String ip, int port) {
+        if (physicalGroupKey != null && !physicalGroupKey.isBlank()) {
+            return physicalGroupKey;
+        }
+        return "|" + (group == null ? "" : group) + "|" + ip + ":" + port;
     }
 
     @JsonIgnore
@@ -644,6 +678,7 @@ public class WorkerStatus {
                 current.grpcPort(),
                 site,
                 deploymentName,
+                current.physicalGroupKey(),
                 current.engineIndex(),
                 current.multiEngineNum()));
     }
@@ -670,6 +705,10 @@ public class WorkerStatus {
 
     public String getDeploymentName() {
         return topology.get().deploymentName();
+    }
+
+    public String getPhysicalGroupKey() {
+        return topology.get().physicalGroupKey();
     }
 
     public String getSite() {

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/pv/ShortestTtftDecision.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/pv/ShortestTtftDecision.java
@@ -31,6 +31,8 @@ public record ShortestTtftDecision(
 
     /**
      * Cache-affinity-specific inputs for one routing decision. Null for other TTFT strategies.
+     * Both worker fields use logical {@code ip:port@engineIndex} identities so different engines
+     * behind the same physical frontend remain distinguishable.
      */
     public record CacheAffinityDecision(
             String cacheLeaderIpPort,

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/route/Endpoint.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/route/Endpoint.java
@@ -18,8 +18,23 @@ public class Endpoint {
     @JsonProperty("path")
     private String path;
 
+    /**
+     * Base TCP port of the per-engine worker-control gRPC endpoint. Engine with index i exposes
+     * its worker status and cache status RPCs at {@code workerStatusPort + i}. Required when
+     * {@code multiEngineNum > 1}; when unset for a single engine, discovery falls back to
+     * the engine gRPC port. Validated at config load against the port range.
+     */
     @JsonProperty("worker_status_port")
     private Integer workerStatusPort;
+
+    /**
+     * Number of engine processes sharing this physical endpoint (DS_LLM_MULTI_ENGINE_NUM).
+     * Service discovery expands one endpoint into this many logical workers, each identified
+     * by an engine index in {@code [0, multiEngineNum)} and its own worker status port.
+     * Defaults to 1 for single-engine deployments.
+     */
+    @JsonProperty("multi_engine_num")
+    private int multiEngineNum = 1;
 
     @JsonProperty("discovery")
     private DiscoveryConfig discovery;

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/discovery/RoutingServiceDiscovery.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/discovery/RoutingServiceDiscovery.java
@@ -117,23 +117,29 @@ public class RoutingServiceDiscovery implements ServiceDiscovery {
 
         boolean grpcEndpoint = BackendServiceProtocolEnum.GRPC.getName()
                 .equals(endpoint.getProtocol());
-        List<WorkerHost> normalizedHosts = new ArrayList<>(discoveredHosts.size());
+        int multiEngineNum = endpoint.getMultiEngineNum();
+        List<WorkerHost> normalizedHosts = new ArrayList<>(discoveredHosts.size() * multiEngineNum);
         for (WorkerHost host : discoveredHosts) {
             int discoveredPort = host.getPort();
             int httpPort = grpcEndpoint ? discoveredPort - 1 : discoveredPort;
             int grpcPort = grpcEndpoint ? discoveredPort : discoveredPort + 1;
-            int workerStatusPort = endpoint.getWorkerStatusPort() == null
+            int workerStatusBasePort = endpoint.getWorkerStatusPort() == null
                     ? grpcPort
                     : endpoint.getWorkerStatusPort();
-            normalizedHosts.add(new WorkerHost(
-                    host.getIp(),
-                    httpPort,
-                    grpcPort,
-                    httpPort + 5,
-                    workerStatusPort,
-                    host.getSite(),
-                    endpoint.getGroup(),
-                    host.getDeploymentName()));
+            for (int engineIndex = 0; engineIndex < multiEngineNum; engineIndex++) {
+                normalizedHosts.add(new WorkerHost(
+                        host.getIp(),
+                        httpPort,
+                        grpcPort,
+                        httpPort + 5,
+                        workerStatusBasePort + engineIndex,
+                        host.getSite(),
+                        endpoint.getGroup(),
+                        host.getDeploymentName(),
+                        engineIndex,
+                        multiEngineNum,
+                        endpoint.getAddress()));
+            }
         }
         return normalizedHosts;
     }

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/config/ModelServiceConfigurationTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/config/ModelServiceConfigurationTest.java
@@ -5,6 +5,8 @@ import org.flexlb.dao.route.ServiceRoute;
 import org.flexlb.discovery.ServiceDiscoveryType;
 import org.flexlb.util.JsonUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +50,70 @@ class ModelServiceConfigurationTest {
                     assertThat(endpoint.getDiscovery().getHosts())
                             .containsExactly("127.0.0.1:8080");
                     assertThat(endpoint.getWorkerStatusPort()).isEqualTo(18002);
+                    assertThat(endpoint.getMultiEngineNum()).isEqualTo(1);
                 });
+    }
+
+    @Test
+    void loadsMultiEngineEndpointConfiguration() {
+        withModelConfig(staticModelConfig().replace(
+                "\"worker_status_port\":18002,",
+                "\"worker_status_port\":18002,\"multi_engine_num\":2,"))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    var endpoint = context.getBean(ModelMetaConfig.class)
+                            .getServiceRoute("test-service")
+                            .getAllEndpoints()
+                            .getFirst();
+                    assertThat(endpoint.getMultiEngineNum()).isEqualTo(2);
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void rejectsNonPositiveMultiEngineCount(int multiEngineNum) {
+        assertEndpointRejected(
+                "\"worker_status_port\":18002,\"multi_engine_num\":" + multiEngineNum + ",",
+                "MODEL_SERVICE_CONFIG endpoint multi_engine_num must be greater than zero: service-a");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 65_536})
+    void rejectsWorkerStatusPortOutsideTcpRange(int workerStatusPort) {
+        assertEndpointRejected(
+                "\"worker_status_port\":" + workerStatusPort + ",",
+                "MODEL_SERVICE_CONFIG endpoint worker_status_port must be between 1 and 65535: service-a");
+    }
+
+    @Test
+    void acceptsMultiEngineWorkerStatusPortRangeEndingAtMaximumTcpPort() {
+        String config = staticModelConfig().replace(
+                "\"worker_status_port\":18002,",
+                "\"worker_status_port\":65534,\"multi_engine_num\":2,");
+
+        withModelConfig(config).run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    void rejectsMultiEngineEndpointWithoutWorkerStatusPort() {
+        String config = staticModelConfig()
+                .replace("\"worker_status_port\":18002,", "\"multi_engine_num\":2,");
+
+        withModelConfig(config)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseMessage(
+                                    "MODEL_SERVICE_CONFIG endpoint worker_status_port must be configured "
+                                            + "when multi_engine_num is greater than one: service-a");
+                });
+    }
+
+    @Test
+    void rejectsMultiEngineWorkerStatusPortOverflow() {
+        assertEndpointRejected(
+                "\"worker_status_port\":65535,\"multi_engine_num\":2,",
+                "MODEL_SERVICE_CONFIG endpoint worker_status_port range exceeds 65535: service-a");
     }
 
     @Test
@@ -164,6 +229,15 @@ class ModelServiceConfigurationTest {
 
     private void assertOptimizerRejected(String optimizerConfig, String message) {
         withModelConfig(modelConfig(optimizerConfig))
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).hasRootCauseMessage(message);
+                });
+    }
+
+    private void assertEndpointRejected(String endpointFields, String message) {
+        String config = staticModelConfig().replace("\"worker_status_port\":18002,", endpointFields);
+        withModelConfig(config)
                 .run(context -> {
                     assertThat(context).hasFailed();
                     assertThat(context.getStartupFailure()).hasRootCauseMessage(message);

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/loadbalance/ServerStatusTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/loadbalance/ServerStatusTest.java
@@ -1,0 +1,75 @@
+package org.flexlb.dao.loadbalance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServerStatusTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serializesSelectedEngineIndexWithoutChangingPhysicalAddress() {
+        ServerStatus status = new ServerStatus();
+        status.setServerIp("10.0.0.8");
+        status.setHttpPort(8080);
+        status.setGrpcPort(8081);
+        status.setSelectedEngineIndex(1, 2);
+
+        var json = objectMapper.valueToTree(status);
+
+        assertEquals("10.0.0.8", json.get("server_ip").asText());
+        assertEquals(8080, json.get("http_port").asInt());
+        assertEquals(8081, json.get("grpc_port").asInt());
+        assertEquals(1, json.get("engine_index").asInt());
+        assertFalse(json.has("routingEngineIndex"));
+        assertFalse(json.has("logicalIpPort"));
+        assertFalse(json.has("ipIndex"));
+        assertEquals("10.0.0.8:8080@1", status.getLogicalIpPort());
+        assertEquals("10.0.0.8@1", status.getIpIndex());
+    }
+
+    @Test
+    void omitsSingleEngineIndexButKeepsIndexedRoutingIdentity() {
+        ServerStatus status = new ServerStatus();
+        status.setServerIp("10.0.0.8");
+        status.setHttpPort(8080);
+        status.setSelectedEngineIndex(0, 1);
+
+        var json = objectMapper.valueToTree(status);
+
+        assertFalse(json.has("engine_index"));
+        assertFalse(json.has("routingEngineIndex"));
+        assertFalse(json.has("logicalIpPort"));
+        assertEquals("10.0.0.8:8080@0", status.getLogicalIpPort());
+    }
+
+    @Test
+    void serializesIndexZeroWhenItBelongsToAMultiEngineWorker() {
+        ServerStatus status = new ServerStatus();
+        status.setServerIp("10.0.0.8");
+        status.setHttpPort(8080);
+        status.setSelectedEngineIndex(0, 2);
+
+        var json = objectMapper.valueToTree(status);
+
+        assertEquals(0, json.get("engine_index").asInt());
+        assertFalse(json.has("logicalIpPort"));
+        assertEquals("10.0.0.8:8080@0", status.getLogicalIpPort());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"-1,1", "1,1", "0,0", "0,-1"})
+    void rejectsInvalidSelectedEngineIdentity(int engineIndex, int multiEngineNum) {
+        ServerStatus status = new ServerStatus();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> status.setSelectedEngineIndex(engineIndex, multiEngineNum));
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerHostTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerHostTest.java
@@ -1,0 +1,35 @@
+package org.flexlb.dao.master;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WorkerHostTest {
+
+    @Test
+    void exposesItsStoredIdentityRepresentations() {
+        WorkerHost host = new WorkerHost(
+                "10.0.0.8", 8080, 8081, 8085, 18003,
+                "site-a", "group-a", "deployment-a", 1, 2);
+
+        assertEquals("10.0.0.8", host.getIp());
+        assertEquals(8080, host.getPort());
+        assertEquals(1, host.getEngineIndex());
+        assertEquals("10.0.0.8:8080", host.getPhysicalIpPort());
+        assertEquals("10.0.0.8:8080@1", host.getLogicalIpPort());
+        assertEquals("10.0.0.8@1", host.getIpIndex());
+    }
+
+    @Test
+    void exposesMultiEnginePortsAndTopology() {
+        WorkerHost host = new WorkerHost(
+                "10.0.0.8", 8080, 8081, 8085, 18003,
+                "site-a", "group-a", "deployment-a", 1, 2);
+
+        assertEquals(18003, host.getWorkerStatusPort());
+        assertEquals(2, host.getMultiEngineNum());
+        assertEquals("site-a", host.getSite());
+        assertEquals("group-a", host.getGroup());
+        assertEquals("deployment-a", host.getDeploymentName());
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerIdentityTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerIdentityTest.java
@@ -1,0 +1,41 @@
+package org.flexlb.dao.master;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WorkerIdentityTest {
+
+    @Test
+    void storesEveryWorkerIdentityRepresentation() {
+        WorkerIdentity identity = new WorkerIdentity("10.0.0.8", 8080, 1);
+
+        assertEquals("10.0.0.8", identity.getIp());
+        assertEquals(8080, identity.getPort());
+        assertEquals(1, identity.getEngineIndex());
+        assertEquals("10.0.0.8:8080", identity.getPhysicalIpPort());
+        assertEquals("10.0.0.8:8080@1", identity.getLogicalIpPort());
+        assertEquals("10.0.0.8@1", identity.getIpIndex());
+    }
+
+    @Test
+    void leavesDerivedRepresentationsNullUntilIpIsKnown() {
+        WorkerIdentity identity = new WorkerIdentity(null, 8080, 1);
+
+        assertNull(identity.getPhysicalIpPort());
+        assertNull(identity.getLogicalIpPort());
+        assertNull(identity.getIpIndex());
+    }
+
+    @Test
+    void equalsAndHashCodeCompareAllIdentityFields() {
+        WorkerIdentity identity = new WorkerIdentity("10.0.0.8", 8080, 1);
+
+        assertEquals(identity, new WorkerIdentity("10.0.0.8", 8080, 1));
+        assertEquals(identity.hashCode(), new WorkerIdentity("10.0.0.8", 8080, 1).hashCode());
+        assertNotEquals(identity, new WorkerIdentity("10.0.0.8", 8080, 0));
+        assertNotEquals(identity, new WorkerIdentity("10.0.0.9", 8080, 1));
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerStatusTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerStatusTest.java
@@ -44,6 +44,21 @@ class WorkerStatusTest {
                 RoleType.PREFILL, "group-a", "10.0.0.1", 8080, 9090, "site-a");
     }
 
+    @Test
+    @DisplayName("Discovery identity keeps a physical transport address and logical engine key")
+    void discoveredWorkerSeparatesPhysicalAndLogicalIdentity() {
+        WorkerStatus status = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-a", "10.0.0.1", 8080, 9090,
+                "site-a", "deployment-a", 1, 2);
+
+        assertEquals("10.0.0.1:8080", status.getIpPort());
+        assertEquals("10.0.0.1:8080", status.getPhysicalIpPort());
+        assertEquals("10.0.0.1:8080@1", status.getLogicalIpPort());
+        assertEquals("10.0.0.1@1", status.getIpIndex());
+        assertEquals(1, status.getEngineIndex());
+        assertEquals(2, status.getMultiEngineNum());
+    }
+
     /**
      * Run one whole status transaction exactly as the production reducers do:
      * freeze the RPC response, prepare a strictly-newer committed holder under

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/discovery/RoutingServiceDiscoveryTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/discovery/RoutingServiceDiscoveryTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 class RoutingServiceDiscoveryTest {
 
@@ -48,6 +49,10 @@ class RoutingServiceDiscoveryTest {
         assertEquals("site-a", normalizedHost.getSite());
         assertEquals("group-a", normalizedHost.getGroup());
         assertEquals("deployment-a", normalizedHost.getDeploymentName());
+        assertEquals(0, normalizedHost.getEngineIndex());
+        assertEquals(1, normalizedHost.getMultiEngineNum());
+        assertEquals("10.0.0.1:8080", normalizedHost.getPhysicalIpPort());
+        assertEquals("10.0.0.1:8080@0", normalizedHost.getLogicalIpPort());
     }
 
     @Test
@@ -80,6 +85,29 @@ class RoutingServiceDiscoveryTest {
 
         current.set(runtimeConfig(900));
         assertEquals(900, endpoint.getDiscovery().getConnectTimeoutMs());
+    }
+
+    @Test
+    void expandsDiscoveredHostIntoIndexedLogicalWorkers() {
+        WorkerHost discoveredHost = WorkerHost.of("10.0.0.1", 8080);
+        RecordingProvider provider = new RecordingProvider(List.of(discoveredHost));
+        RoutingServiceDiscovery discovery = new RoutingServiceDiscovery(List.of(provider));
+        Endpoint endpoint = endpoint();
+        endpoint.setProtocol("http");
+        endpoint.setWorkerStatusPort(18002);
+        endpoint.setMultiEngineNum(2);
+
+        List<WorkerHost> hosts = discovery.getHosts(endpoint);
+
+        assertEquals(2, hosts.size());
+        assertIterableEquals(List.of(0, 1), hosts.stream().map(WorkerHost::getEngineIndex).toList());
+        assertIterableEquals(List.of(18002, 18003),
+                hosts.stream().map(WorkerHost::getWorkerStatusPort).toList());
+        assertIterableEquals(List.of("10.0.0.1:8080@0", "10.0.0.1:8080@1"),
+                hosts.stream().map(WorkerHost::getLogicalIpPort).toList());
+        assertIterableEquals(List.of("10.0.0.1:8080", "10.0.0.1:8080"),
+                hosts.stream().map(WorkerHost::getPhysicalIpPort).toList());
+        assertIterableEquals(List.of(2, 2), hosts.stream().map(WorkerHost::getMultiEngineNum).toList());
     }
 
     private Endpoint endpoint() {

--- a/rtp_llm/flexlb/flexlb-grpc/src/main/proto/kvcm_meta_service.proto
+++ b/rtp_llm/flexlb/flexlb-grpc/src/main/proto/kvcm_meta_service.proto
@@ -77,7 +77,9 @@ message GetHostCacheStateRequest {
 }
 
 message HostCacheMatch {
-  string host_ip_port = 1;            // Must match WorkerStatus#getIpPort().
+  // Logical worker identity emitted by the KVCM subscriber: ip:port@engineIndex.
+  // A legacy physical ip:port key is accepted only for an unambiguous N=1 worker.
+  string host_ip_port = 1;
   int64 local = 2;                    // Local continuous prefix matches.
   int64 p2p_1_fetch = 3;              // Local-miss blocks fetched from one remote peer.
   int64 p2p_1_total_match = 4;        // Continuous prefix matches after that P2P fetch.

--- a/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/FlexlbScheduleProtocolTest.java
+++ b/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/FlexlbScheduleProtocolTest.java
@@ -9,8 +9,10 @@ import java.io.ByteArrayOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FlexlbScheduleProtocolTest {
 
@@ -45,6 +47,30 @@ class FlexlbScheduleProtocolTest {
         assertEquals(Descriptors.FieldDescriptor.Type.STRING,
                 EngineRpcService.WorkerStatusPB.getDescriptor().findFieldByNumber(1).getType());
         assertNull(FlexlbScheduleProtocol.FlexlbServerStatusPB.getDescriptor().findFieldByNumber(5));
+    }
+
+    @Test
+    void engineIndexDistinguishesAbsentFromExplicitZeroOnTheWire() throws Exception {
+        var descriptor = FlexlbScheduleProtocol.FlexlbServerStatusPB.getDescriptor();
+        var field = descriptor.findFieldByName("engine_index");
+        assertNotNull(field);
+        assertEquals(6, field.getNumber());
+        assertEquals(Descriptors.FieldDescriptor.Type.INT32, field.getType());
+        assertTrue(field.hasPresence());
+        assertNull(descriptor.findFieldByNumber(5));
+
+        var absent = FlexlbScheduleProtocol.FlexlbServerStatusPB.parseFrom(new byte[0]);
+        assertFalse(absent.hasField(field));
+        for (int index : new int[]{0, 1}) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            CodedOutputStream coded = CodedOutputStream.newInstance(output);
+            coded.writeInt32(6, index);
+            coded.flush();
+            var parsed = FlexlbScheduleProtocol.FlexlbServerStatusPB.parseFrom(output.toByteArray());
+            assertTrue(parsed.hasField(field));
+            assertEquals(index, parsed.getField(field));
+            assertArrayEquals(output.toByteArray(), parsed.toByteArray());
+        }
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/client/KvcmGrpcClientTest.java
+++ b/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/client/KvcmGrpcClientTest.java
@@ -37,7 +37,7 @@ class KvcmGrpcClientTest {
     }
 
     @Test
-    void returnsP2pAwareMatches() {
+    void preservesLogicalWorkerIdentitiesInP2pAwareMatches() {
         CacheMatchConfiguration configuration = mock(CacheMatchConfiguration.class);
         KvcmConfig config = new KvcmConfig();
         KvcmCacheMatchingConfig runtimeConfig = new KvcmCacheMatchingConfig();
@@ -60,7 +60,7 @@ class KvcmGrpcClientTest {
                 .thenReturn(GetHostCacheStateResponse.newBuilder()
                         .setHeader(okHeader())
                         .addHosts(HostCacheMatch.newBuilder()
-                                .setHostIpPort("10.0.0.1:8601")
+                                .setHostIpPort("10.0.0.1:8601@1")
                                 .setLocal(2)
                                 .setP2P1Fetch(8)
                                 .setP2P1TotalMatch(10))
@@ -78,9 +78,9 @@ class KvcmGrpcClientTest {
                         "request-1", List.of(11L, 22L), 2192L,
                         RoleType.PREFILL, "default");
 
-        assertEquals(2, result.get("10.0.0.1:8601").localMatchBlocks());
-        assertEquals(8, result.get("10.0.0.1:8601").p2pFetchBlocks());
-        assertEquals(10, result.get("10.0.0.1:8601").p2pTotalMatchBlocks());
+        assertEquals(2, result.get("10.0.0.1:8601@1").localMatchBlocks());
+        assertEquals(8, result.get("10.0.0.1:8601@1").p2pFetchBlocks());
+        assertEquals(10, result.get("10.0.0.1:8601@1").p2pTotalMatchBlocks());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/delivery/DeliveryMetrics.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/delivery/DeliveryMetrics.java
@@ -87,7 +87,7 @@ public final class DeliveryMetrics {
     }
 
     private static String prefillIp(ScheduledRequest item) {
-        return item.prefillEp().getIp();
+        return item.prefillEp().getStatus().getLogicalIpPort();
     }
 
     private static long saturatedAdd(long left, long right) {

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/DecodeEndpoint.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/DecodeEndpoint.java
@@ -2952,11 +2952,12 @@ public class DecodeEndpoint extends WorkerEndpoint {
      * Called periodically by {@link org.flexlb.balance.scheduler.RequestScheduler}.
      */
     public void reportBatchMetrics(BatchSchedulerReporter reporter) {
-        reporter.reportInflightRequestCount(RoleType.DECODE.name(), getIp(), getInflightCount());
-        reporter.reportDecodeTotalLoad(getIp(), getTotalLoad());
-        reporter.reportDecodeInflightKvReserved(getIp(), inflightKvReserved());
-        reporter.reportDecodeInflightHardKvReserved(getIp(), inflightHardKvReserved());
-        reporter.reportInflightMaxAgeMs(RoleType.DECODE.name(), getIp(),
+        String engineIp = getStatus().getLogicalIpPort();
+        reporter.reportInflightRequestCount(RoleType.DECODE.name(), engineIp, getInflightCount());
+        reporter.reportDecodeTotalLoad(engineIp, getTotalLoad());
+        reporter.reportDecodeInflightKvReserved(engineIp, inflightKvReserved());
+        reporter.reportDecodeInflightHardKvReserved(engineIp, inflightHardKvReserved());
+        reporter.reportInflightMaxAgeMs(RoleType.DECODE.name(), engineIp,
                 inflightMaxAgeMs(System.currentTimeMillis()));
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/EndpointRegistry.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/EndpointRegistry.java
@@ -771,10 +771,10 @@ public class EndpointRegistry {
 
     private void prepareEndpointMetrics(RoleType roleType, WorkerStatus status) {
         try {
-            reporter.prepareEndpointMetrics(roleType.name(), status.getIp());
+            reporter.prepareEndpointMetrics(roleType.name(), status.getLogicalIpPort());
         } catch (RuntimeException telemetryFailure) {
             Logger.warn("Endpoint metric preparation failed: role={}, engine={}",
-                    roleType, status.getIp(), telemetryFailure);
+                    roleType, status.getLogicalIpPort(), telemetryFailure);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/PrefillEndpoint.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/PrefillEndpoint.java
@@ -100,7 +100,7 @@ public class PrefillEndpoint extends WorkerEndpoint {
         this.maximumDirectRequests = configuredLimit == null ? 0 : configuredLimit;
         this.predictor = createPredictor(config);
         this.runtime = new WorkerBatcher(
-                status.getIpPort(), this, config,
+                status.getLogicalIpPort(), this, config,
                 deliveryStrategy, endpointEvents);
         this.prefillState = runtime.ownedState();
     }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/PrefillEndpoint.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/PrefillEndpoint.java
@@ -566,23 +566,24 @@ public class PrefillEndpoint extends WorkerEndpoint {
      * Called periodically by {@link org.flexlb.balance.scheduler.RequestScheduler}.
      */
     public void reportBatchMetrics(BatchSchedulerReporter reporter) {
+        String engineIp = getStatus().getLogicalIpPort();
         int queueSize = runtime.queueSize();
-        reporter.reportBatcherQueueSize(RoleType.PREFILL.name(), getIp(), queueSize);
+        reporter.reportBatcherQueueSize(RoleType.PREFILL.name(), engineIp, queueSize);
         // Priority-bucketed batch queue length — single-report with priority tag.
         // Empty queue fallback: report priority=0 depth=0 so tagged panels don't gap.
         Map<Integer, Integer> sizeByPriority =
                 runtime.queueSizeByPriority();
         if (sizeByPriority.isEmpty()) {
-            reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), getIp(), 0, 0);
+            reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), engineIp, 0, 0);
         } else {
             sizeByPriority.forEach((priority, size) ->
-                    reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), getIp(), priority, size));
+                    reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), engineIp, priority, size));
         }
-        reporter.reportInflightBatchCount(RoleType.PREFILL.name(), getIp(), getInflightBatchCount());
-        reporter.reportInflightRequestCount(RoleType.PREFILL.name(), getIp(), getLocallyOwnedRequestCount());
+        reporter.reportInflightBatchCount(RoleType.PREFILL.name(), engineIp, getInflightBatchCount());
+        reporter.reportInflightRequestCount(RoleType.PREFILL.name(), engineIp, getLocallyOwnedRequestCount());
         reporter.reportInflightMaxAgeMs(
                 RoleType.PREFILL.name(),
-                getIp(),
+                engineIp,
                 prefillState.stats().maxObservedAgeMs());
     }
 
@@ -633,19 +634,22 @@ public class PrefillEndpoint extends WorkerEndpoint {
         // a metrics outage cannot suppress the scheduler's WorkerStatus
         // reducer or prevent the remaining observations.
         try {
-            reporter.reportBatchPredictedTimeMs(RoleType.PREFILL.name(), getIp(), predictedMs);
+            reporter.reportBatchPredictedTimeMs(
+                    RoleType.PREFILL.name(), getStatus().getLogicalIpPort(), predictedMs);
         } catch (RuntimeException telemetryFailure) {
             logger.warn("batch predicted-time metric failed: batchId={} engine={}",
                     batchId, getIp(), telemetryFailure);
         }
         try {
-            reporter.reportBatchActualTimeMs(RoleType.PREFILL.name(), getIp(), actualMs);
+            reporter.reportBatchActualTimeMs(
+                    RoleType.PREFILL.name(), getStatus().getLogicalIpPort(), actualMs);
         } catch (RuntimeException telemetryFailure) {
             logger.warn("batch actual-time metric failed: batchId={} engine={}",
                     batchId, getIp(), telemetryFailure);
         }
         try {
-            reporter.reportBatchPredictGapMs(RoleType.PREFILL.name(), getIp(), gapMs);
+            reporter.reportBatchPredictGapMs(
+                    RoleType.PREFILL.name(), getStatus().getLogicalIpPort(), gapMs);
         } catch (RuntimeException telemetryFailure) {
             logger.warn("batch prediction-gap metric failed: batchId={} engine={}",
                     batchId, getIp(), telemetryFailure);

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/WorkerEndpoint.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/WorkerEndpoint.java
@@ -56,7 +56,7 @@ public class WorkerEndpoint {
     // ==================== identity (delegated to status) ====================
 
     public String ipPort() {
-        return status.getIpPort();
+        return status.getLogicalIpPort();
     }
 
     public String getIp() {

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/eviction/EvictionManager.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/eviction/EvictionManager.java
@@ -481,7 +481,7 @@ public class EvictionManager {
         try {
             deliveryReporter.reportRouteSubmitTimeMs(
                     org.flexlb.dao.route.RoleType.PREFILL.name(),
-                    item.prefillEp().getIp(),
+                    item.prefillEp().ipPort(),
                     System.currentTimeMillis() - context.getStartTime());
         } catch (RuntimeException telemetryFailure) {
             Logger.warn(

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/BatchDeliveryStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/BatchDeliveryStrategy.java
@@ -81,9 +81,7 @@ public final class BatchDeliveryStrategy implements DeliveryStrategy {
         ScheduledRequest head = candidates.get(0);
 
         CapacityBoundary.Attempt<BatchTransaction> groupAttempt =
-                requests.prepareIfOwned(head, () -> prepareAdmission(head))
-                        .orElseGet(() -> BatchDeliveryStrategy
-                                .<BatchTransaction>ownershipLost());
+                prepareHeadAdmission(head);
         if (!groupAttempt.accepted()) {
             return BatchTransaction.blocked(
                     this,
@@ -191,6 +189,23 @@ public final class BatchDeliveryStrategy implements DeliveryStrategy {
         } catch (Throwable failure) {
             return failed(failure);
         }
+    }
+
+    private CapacityBoundary.Attempt<BatchTransaction> prepareHeadAdmission(
+            ScheduledRequest head) {
+        if (requests.prepareIfOwned(head, () -> Boolean.TRUE).isEmpty()) {
+            return ownershipLost();
+        }
+        CapacityBoundary.Attempt<BatchTransaction> attempt =
+                prepareAdmission(head);
+        if (!attempt.accepted()) {
+            return attempt;
+        }
+        if (requests.prepareIfOwned(head, () -> Boolean.TRUE).isPresent()) {
+            return attempt;
+        }
+        Throwable cleanup = close(attempt.value());
+        return cleanup == null ? ownershipLost() : failed(cleanup);
     }
 
     @Override

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/GlobalQueueCoordinator.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/GlobalQueueCoordinator.java
@@ -639,7 +639,7 @@ final class GlobalQueueCoordinator implements AutoCloseable {
         try {
             reporter.reportRouteSubmitTimeMs(
                     item.prefill().getRole().name(),
-                    item.prefillEp().getIp(),
+                    item.prefillEp().ipPort(),
                     System.currentTimeMillis() - context.getStartTime());
         } catch (Throwable failure) {
             Logger.warn("Failed to record route-submit telemetry", failure);

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/RequestRegistry.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/RequestRegistry.java
@@ -2535,6 +2535,9 @@ public class RequestRegistry {
         status.setHttpPort(src.getHttpPort());
         status.setGrpcPort(src.getGrpcPort());
         status.setDpRank(src.getDpRank());
+        status.setSelectedEngineIndex(
+                src.getRoutingEngineIndex(),
+                src.getRoutingMultiEngineNum());
         status.setPrefillTime(src.getPrefillTime());
         status.setGroup(src.getGroup());
         status.setDebugInfo(copyOf(src.getDebugInfo()));

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
@@ -484,6 +484,8 @@ public class CostBasedDecodeStrategy {
             result.setDpRank(status.dpRank());
             result.setGroup(topology.group());
             result.setRequestId(balanceContext.getRequestId());
+            result.setSelectedEngineIndex(
+                    topology.engineIndex(), topology.multiEngineNum());
 
             // SelectedRole consumes the pin even if its validation rejects.
             WorkerEndpoint.GenerationPin factoryPin = selectedPin;

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
@@ -659,7 +659,7 @@ public class CostBasedDecodeStrategy {
         }
     }
 
-    private interface DecodeDirectoryView {
+    interface DecodeDirectoryView {
 
         List<DecodeRoutingView> decodeRoutingSnapshot(String group);
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
@@ -33,10 +33,14 @@ public class CostBasedDecodeStrategy {
     private static final ThreadLocal<CandidateBuffer> CANDIDATES =
             ThreadLocal.withInitial(CandidateBuffer::new);
 
-    private final WorkerDirectory workerDirectory;
+    private final DecodeDirectoryView workerDirectory;
     private final AtomicLong equalCostCursor = new AtomicLong();
 
     public CostBasedDecodeStrategy(WorkerDirectory workerDirectory) {
+        this(new WorkerDirectoryDecodeView(workerDirectory));
+    }
+
+    CostBasedDecodeStrategy(DecodeDirectoryView workerDirectory) {
         this.workerDirectory = workerDirectory;
     }
 
@@ -101,6 +105,10 @@ public class CostBasedDecodeStrategy {
             WorkerEndpoint.GenerationPin pin =
                     workerDirectory.captureDecodeGeneration(selected);
             if (pin != null) {
+                if (!workerDirectory.isPhysicalGroupHealthy(pin.endpoint())) {
+                    pin.close();
+                    continue;
+                }
                 return PlacementResult.success(buildSelectedRole(
                         selected, pin, roleType, balanceContext));
             }
@@ -629,5 +637,35 @@ public class CostBasedDecodeStrategy {
             tierCounts = java.util.Arrays.copyOf(
                     tierCounts, capacity);
         }
+    }
+
+    private record WorkerDirectoryDecodeView(
+            WorkerDirectory delegate) implements DecodeDirectoryView {
+
+        @Override
+        public List<DecodeRoutingView> decodeRoutingSnapshot(String group) {
+            return delegate.decodeRoutingSnapshot(group);
+        }
+
+        @Override
+        public WorkerEndpoint.GenerationPin captureDecodeGeneration(
+                DecodeRoutingView expected) {
+            return delegate.captureDecodeGeneration(expected);
+        }
+
+        @Override
+        public boolean isPhysicalGroupHealthy(WorkerEndpoint endpoint) {
+            return delegate.isPhysicalGroupHealthy(endpoint);
+        }
+    }
+
+    private interface DecodeDirectoryView {
+
+        List<DecodeRoutingView> decodeRoutingSnapshot(String group);
+
+        WorkerEndpoint.GenerationPin captureDecodeGeneration(
+                DecodeRoutingView expected);
+
+        boolean isPhysicalGroupHealthy(WorkerEndpoint endpoint);
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
@@ -963,6 +963,8 @@ public class CostBasedPrefillStrategy {
             result.setDpRank(status.dpRank());
             result.setDebugInfo(debugInfo);
             result.setSuccess(true);
+            result.setSelectedEngineIndex(
+                    topology.engineIndex(), topology.multiEngineNum());
             WorkerEndpoint.GenerationPin ownedPin = selectedPin;
             selectedPin = null;
             return SelectedRole.prefill(

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
@@ -158,7 +158,7 @@ public class CostBasedPrefillStrategy {
                 selectedTtft,
                 selectedPrefillMs);
         reportCacheHitMetrics(
-                roleType, best.getStatus().getIpIndex(), bestCacheHit, seqLen);
+                roleType, best.getStatus().getLogicalIpPort(), bestCacheHit, seqLen);
         reportRoutingCacheMatchMetrics(
                 roleType,
                 survivors.routingCacheMatchTokens(selectedIndex),
@@ -281,7 +281,7 @@ public class CostBasedPrefillStrategy {
 
         if (selectedIndex >= 0 && cacheAffinity != null) {
             reportCacheAffinityDecision(
-                    roleType, survivors.endpoint(selectedIndex).getIp(),
+                    roleType, survivors.endpoint(selectedIndex).getStatus().getLogicalIpPort(),
                     affinityReason);
             if (Logger.isDebugEnabled()) {
                 Logger.debug(
@@ -338,7 +338,7 @@ public class CostBasedPrefillStrategy {
                     ? "CACHE_LEADER"
                     : affinityReason;
             reportCacheAffinityDecision(
-                    roleType, candidates.endpoint(selectedIndex).getIp(), reason);
+                    roleType, candidates.endpoint(selectedIndex).getStatus().getLogicalIpPort(), reason);
             if (Logger.isDebugEnabled()) {
                 Logger.debug(
                         "Prefill LRU cache-affinity decision - role: {}, group: {}, "
@@ -903,7 +903,7 @@ public class CostBasedPrefillStrategy {
         try {
             engineHealthReporter.reportPrefillSelectedEstimates(
                     roleType,
-                    endpoint.getIp(),
+                    endpoint.getStatus().getLogicalIpPort(),
                     deliveryMode,
                     projectedTtftMs.getAsLong(),
                     executionTimeMs);

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
@@ -129,7 +129,8 @@ public class CostBasedPrefillStrategy {
                 workerDirectory.captureEndpoint(
                         roleType,
                         survivors.endpointAddress(selectedIndex));
-        if (selectedPin == null || selectedPin.endpoint() != best) {
+        if (selectedPin == null || selectedPin.endpoint() != best
+                || !workerDirectory.isPhysicalGroupHealthy(best)) {
             if (selectedPin != null) {
                 selectedPin.close();
             }
@@ -156,7 +157,8 @@ public class CostBasedPrefillStrategy {
                 config,
                 selectedTtft,
                 selectedPrefillMs);
-        reportCacheHitMetrics(roleType, bestCacheHit, seqLen);
+        reportCacheHitMetrics(
+                roleType, best.getStatus().getIpIndex(), bestCacheHit, seqLen);
         reportRoutingCacheMatchMetrics(
                 roleType,
                 survivors.routingCacheMatchTokens(selectedIndex),
@@ -554,7 +556,7 @@ public class CostBasedPrefillStrategy {
             String endpointAddress = routingEntry.address();
             CacheTokenMatch cacheMatch =
                     calculateCacheMatch(
-                            ep, endpointAddress, cacheMatchResult, request, config);
+                            ep, cacheMatchResult, request, config);
             long cacheHit = cacheMatch.effectiveHitTokens();
             long routingCacheMatchTokens = cacheMatch.routingHitTokens();
             RouteProjection.Inputs projectionInputs =
@@ -825,7 +827,6 @@ public class CostBasedPrefillStrategy {
 
     private CacheTokenMatch calculateCacheMatch(
             PrefillEndpoint ep,
-            String endpointAddress,
             CacheMatchResult cacheMatchResult,
             Request request,
             FlexlbConfig config) {
@@ -836,7 +837,7 @@ public class CostBasedPrefillStrategy {
         if (seqLen <= 0L) {
             return CacheTokenMatch.NONE;
         }
-        HostCacheMatch match = cacheMatchResult.hostMatch(endpointAddress);
+        HostCacheMatch match = cacheMatchResult.hostMatch(ep.getStatus());
         if (match == null) {
             return CacheTokenMatch.NONE;
         }
@@ -878,9 +879,10 @@ public class CostBasedPrefillStrategy {
         return new CacheTokenMatch(effectiveHit, routingHit);
     }
 
-    private void reportCacheHitMetrics(RoleType roleType, long hitCacheTokens, long seqLen) {
+    private void reportCacheHitMetrics(
+            RoleType roleType, String ipIndex, long hitCacheTokens, long seqLen) {
         double hitRate = seqLen > 0 ? hitCacheTokens / (double) seqLen : 0.0;
-        engineHealthReporter.reportCacheHitMetrics(roleType, hitCacheTokens, hitRate);
+        engineHealthReporter.reportCacheHitMetrics(roleType, ipIndex, hitCacheTokens, hitRate);
     }
 
     /**

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/RandomStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/RandomStrategy.java
@@ -47,6 +47,9 @@ public final class RandomStrategy {
                 continue;
             }
             try {
+                if (!workerDirectory.isPhysicalGroupHealthy(pin.endpoint())) {
+                    continue;
+                }
                 WorkerStatus status = pin.endpoint().getStatus();
                 WorkerStatus.TopologySnapshot topology =
                         status.topologySnapshot();

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/RandomStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/RandomStrategy.java
@@ -92,6 +92,8 @@ public final class RandomStrategy {
             result.setHttpPort(topology.port());
             result.setGrpcPort(CommonUtils.toGrpcPort(topology.port()));
             result.setDpRank(engine.dpRank());
+            result.setSelectedEngineIndex(
+                    topology.engineIndex(), topology.multiEngineNum());
 
             WorkerEndpoint.GenerationPin owned = pin;
             pin = null;

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/monitor/EngineHealthReporter.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/monitor/EngineHealthReporter.java
@@ -464,20 +464,30 @@ public class EngineHealthReporter {
         monitor.report(CACHE_STATUS_CHECK_FAIL, metricTags, 1.0);
     }
 
+    public void reportCacheStatusCheckerFail(String modelName,
+                                             WorkerStatus workerStatus,
+                                             BalanceStatusEnum errorEnum) {
+        FlexMetricTags metricTags = FlexMetricTags.of(
+                "model", modelName,
+                "engineIp", workerStatus.getLogicalIpPort(),
+                "code", String.valueOf(errorEnum.getCode()),
+                "role", workerStatus.getRole().getCode());
+        monitor.report(CACHE_STATUS_CHECK_FAIL, metricTags, 1.0);
+    }
+
     public void reportStatusCheckerSuccess(String modelName,
                                            WorkerStatus workerStatus,
                                            WorkerEndpoint ep,
                                            int runningTaskInfoSize,
                                            int finishedTaskListSize) {
 
-        WorkerStatus.TopologySnapshot topology = workerStatus.topologySnapshot();
         WorkerStatus.EngineObservation status =
                 workerStatus.committedEngineObservation();
         WorkerStatus.PollHealth pollHealth = workerStatus.pollHealth();
 
         FlexMetricTags metricTags = FlexMetricTags.of(
                 "model", modelName,
-                "engineIp", topology.ip(),
+                "engineIp", workerStatus.getLogicalIpPort(),
                 "role", status.role().name());
 
         Long availableConcurrency = status.availableConcurrency();
@@ -503,14 +513,13 @@ public class EngineHealthReporter {
             String modelName,
             WorkerStatus workerStatus,
             long successfulPollIntervalUs) {
-        WorkerStatus.TopologySnapshot topology = workerStatus.topologySnapshot();
         WorkerStatus.EngineObservation status =
                 workerStatus.committedEngineObservation();
         CacheStatus cacheStatus = workerStatus.getCacheStatus();
         if (successfulPollIntervalUs > 0L) {
             FlexMetricTags metricTags = FlexMetricTags.of(
                     "model", modelName,
-                    "engineIp", topology.ip(),
+                    "engineIp", workerStatus.getLogicalIpPort(),
                     "role", status.role().name());
             monitor.report(
                     CACHE_STATUS_CHECK_SUCCESS_PERIOD,
@@ -525,7 +534,7 @@ public class EngineHealthReporter {
                     "role", status.role().name());
             FlexMetricTags engineMetricTags = FlexMetricTags.of(
                     "model", modelName,
-                    "engineIp", topology.ip(),
+                    "engineIp", workerStatus.getLogicalIpPort(),
                     "role", status.role().name());
             monitor.report(CACHE_BLOCK_SIZE, roleMetricTags, blockSize);
             reportLocalStandbyBlockSize(engineMetricTags, blockSize);
@@ -538,7 +547,7 @@ public class EngineHealthReporter {
 
         FlexMetricTags kvCacheMetricTags = FlexMetricTags.of(
                 "model", modelName,
-                "engineIp", topology.ip(),
+                "engineIp", workerStatus.getLogicalIpPort(),
                 "role", status.role().name());
 
         monitor.report(CACHE_USED_KV_CACHE_TOKENS, kvCacheMetricTags, usedKvCacheTokens);
@@ -588,7 +597,7 @@ public class EngineHealthReporter {
                     FlexMetricTags serverSelectionTags = FlexMetricTags.of(
                             "role", serverStatus.getRole().name(),
                             "strategy", strategyName(ctx, serverStatus.getRole()),
-                            "engineIp", serverStatus.getServerIp(),
+                            "engineIp", serverStatus.getLogicalIpPort(),
                             "success", String.valueOf(isSuccess),
                             "code", String.valueOf(code)
                     );
@@ -746,7 +755,7 @@ public class EngineHealthReporter {
         CacheHitComparisonResult.KvcmDetails kvcmDetails = comparison.kvcmDetails();
         FlexMetricTags metricTags = FlexMetricTags.of(
                 "model", modelName,
-                "engineIp", comparison.ipIndex(),
+                "engineIp", comparison.worker(),
                 "role", comparison.role(),
                 "group", comparison.group(),
                 "taskState", comparison.state(),

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/monitor/EngineHealthReporter.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/monitor/EngineHealthReporter.java
@@ -680,8 +680,9 @@ public class EngineHealthReporter {
         monitor.report(org.flexlb.constant.MetricConstant.ENGINE_BALANCING_EVENT_LOOP_GROUP_INFO, FlexMetricTags.of(metricMap), totalPendingTask);
     }
 
-    public void reportCacheHitMetrics(RoleType roleType, long hitTokens, double hitRatio) {
-        cacheMetricsReporter.reportCacheHitMetrics(roleType, hitTokens, hitRatio);
+    public void reportCacheHitMetrics(
+            RoleType roleType, String ipIndex, long hitTokens, double hitRatio) {
+        cacheMetricsReporter.reportCacheHitMetrics(roleType, ipIndex, hitTokens, hitRatio);
     }
 
     /**
@@ -745,7 +746,7 @@ public class EngineHealthReporter {
         CacheHitComparisonResult.KvcmDetails kvcmDetails = comparison.kvcmDetails();
         FlexMetricTags metricTags = FlexMetricTags.of(
                 "model", modelName,
-                "engineIp", comparison.worker(),
+                "engineIp", comparison.ipIndex(),
                 "role", comparison.role(),
                 "group", comparison.group(),
                 "taskState", comparison.state(),

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/EngineSyncRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/EngineSyncRunner.java
@@ -127,7 +127,9 @@ public class EngineSyncRunner implements Runnable {
         logger.debug("EngineSyncRunner start for model: {}, role: {}", modelName, roleType.toString());
         try {
             long startTimeInUs = System.nanoTime() / 1000;
-            List<WorkerHost> latestEngineWorkerList = workerAddressService.getEngineWorkerList(modelName, roleType);
+            List<WorkerHost> latestEngineWorkerList =
+                    workerAddressService.getEngineWorkerList(
+                            modelName, roleType);
             logger.debug("workerAddressService getEngineWorkerList, model: {}, role: {}, size: {}", modelName, roleType, latestEngineWorkerList.size());
             engineHealthReporter.reportServiceDiscoveryResult(modelName, latestEngineWorkerList.size(), roleType.toString());
             if (CollectionUtils.isEmpty(latestEngineWorkerList)) {
@@ -175,7 +177,8 @@ public class EngineSyncRunner implements Runnable {
                         host.getHttpPort(),
                         host.getGrpcPort(),
                         host.getEngineIndex(),
-                        host.getMultiEngineNum());
+                        host.getMultiEngineNum(),
+                        host.getPhysicalGroupKey());
 
                 if (!workerStatus.isActiveGeneration()) {
                     logger.debug(
@@ -327,13 +330,15 @@ public class EngineSyncRunner implements Runnable {
             int port,
             int grpcPort,
             int engineIndex,
-            int multiEngineNum) {
+            int multiEngineNum,
+            String physicalGroupKey) {
         while (true) {
             WorkerStatus workerStatus = workerDirectory.currentOrDiscover(
                     roleType, workerIpPort,
                     () -> createWorkerStatus(
                             workerIpPort, site, group, deploymentName,
-                            ip, port, grpcPort, engineIndex, multiEngineNum));
+                            ip, port, grpcPort, engineIndex, multiEngineNum,
+                            physicalGroupKey));
 
             EndpointRegistry.DetachedGeneration endpointToRetire = null;
             RoleType generationRole = null;
@@ -352,7 +357,9 @@ public class EngineSyncRunner implements Runnable {
                 String currentGroup = workerStatus.getGroup();
                 boolean roleChanged = currentRole != roleType;
                 boolean groupChanged = !Objects.equals(currentGroup, group);
-                if (!roleChanged && !groupChanged) {
+                boolean physicalGroupChanged = !Objects.equals(
+                        workerStatus.getPhysicalGroupKey(), physicalGroupKey);
+                if (!roleChanged && !groupChanged && !physicalGroupChanged) {
                     // Site changes do not change scheduling ownership. Publish
                     // the discovery labels atomically on the same generation.
                     workerStatus.updateDiscoveryLabels(
@@ -400,7 +407,8 @@ public class EngineSyncRunner implements Runnable {
             int port,
             int grpcPort,
             int engineIndex,
-            int multiEngineNum) {
+            int multiEngineNum,
+            String physicalGroupKey) {
         WorkerStatus discovered = WorkerStatus.createDiscovered(
                 roleType,
                 group,
@@ -410,7 +418,8 @@ public class EngineSyncRunner implements Runnable {
                 site,
                 deploymentName,
                 engineIndex,
-                multiEngineNum);
+                multiEngineNum,
+                physicalGroupKey);
         logger.info("Created WorkerStatus generation {} for worker: {}",
                 discovered.getGenerationId(), workerIpPort);
         return discovered;

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/EngineSyncRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/EngineSyncRunner.java
@@ -12,7 +12,6 @@ import org.flexlb.service.address.WorkerAddressService;
 import org.flexlb.service.grpc.EngineGrpcService;
 import org.flexlb.service.monitor.EngineHealthReporter;
 import org.flexlb.sync.status.WorkerDirectory;
-import org.flexlb.util.CommonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -144,7 +143,7 @@ public class EngineSyncRunner implements Runnable {
 
             // Remove if not in latest engine list
             Set<String> latestValidIpPorts = latestEngineWorkerList.stream()
-                    .map(WorkerHost::getIpPort)
+                    .map(WorkerHost::getLogicalIpPort)
                     .collect(Collectors.toSet());
             logger.debug("Current cached worker size: {}, latest worker list size: {}", cachedWorkerStatuses.size(), latestEngineWorkerList.size());
             for (Map.Entry<String, WorkerStatus> entry: cachedWorkerStatuses.entrySet()) {
@@ -164,14 +163,19 @@ public class EngineSyncRunner implements Runnable {
 
             logger.debug("Submitting status check tasks for {} workers", latestEngineWorkerList.size());
             for (WorkerHost host : latestEngineWorkerList) {
-                String workerIpPort = host.getIpPort();
+                String workerIpPort = host.getLogicalIpPort();
                 String site = host.getSite();
 
                 WorkerStatus workerStatus = getOrCreateWorkerStatus(
                         workerIpPort,
                         site,
                         host.getGroup(),
-                        host.getDeploymentName());
+                        host.getDeploymentName(),
+                        host.getIp(),
+                        host.getHttpPort(),
+                        host.getGrpcPort(),
+                        host.getEngineIndex(),
+                        host.getMultiEngineNum());
 
                 if (!workerStatus.isActiveGeneration()) {
                     logger.debug(
@@ -213,7 +217,8 @@ public class EngineSyncRunner implements Runnable {
                     try {
                         logger.debug("Submitting GrpcCacheStatusCheckRunner for worker: {}, site: {}", workerIpPort, site);
                         GrpcCacheStatusCheckRunner grpcCacheStatusCheckRunner
-                                = new GrpcCacheStatusCheckRunner(modelName, workerIpPort, site, roleType,
+                                = new GrpcCacheStatusCheckRunner(modelName, workerIpPort,
+                                host.getWorkerStatusPort(), site, roleType,
                                 workerStatus, cachePollLease, workerDirectory,
                                 engineHealthReporter, engineGrpcService,
                                 cacheAwareService, cacheIntervalService,
@@ -317,12 +322,18 @@ public class EngineSyncRunner implements Runnable {
             String workerIpPort,
             String site,
             String group,
-            String deploymentName) {
+            String deploymentName,
+            String ip,
+            int port,
+            int grpcPort,
+            int engineIndex,
+            int multiEngineNum) {
         while (true) {
             WorkerStatus workerStatus = workerDirectory.currentOrDiscover(
                     roleType, workerIpPort,
                     () -> createWorkerStatus(
-                            workerIpPort, site, group, deploymentName));
+                            workerIpPort, site, group, deploymentName,
+                            ip, port, grpcPort, engineIndex, multiEngineNum));
 
             EndpointRegistry.DetachedGeneration endpointToRetire = null;
             RoleType generationRole = null;
@@ -384,22 +395,22 @@ public class EngineSyncRunner implements Runnable {
             String workerIpPort,
             String site,
             String group,
-            String deploymentName) {
-        int separator = workerIpPort.lastIndexOf(':');
-        if (separator <= 0 || separator == workerIpPort.length() - 1) {
-            throw new IllegalArgumentException(
-                    "Invalid worker address: " + workerIpPort);
-        }
-        String ip = workerIpPort.substring(0, separator);
-        int port = Integer.parseInt(workerIpPort.substring(separator + 1));
+            String deploymentName,
+            String ip,
+            int port,
+            int grpcPort,
+            int engineIndex,
+            int multiEngineNum) {
         WorkerStatus discovered = WorkerStatus.createDiscovered(
                 roleType,
                 group,
                 ip,
                 port,
-                CommonUtils.toGrpcPort(port),
+                grpcPort,
                 site,
-                deploymentName);
+                deploymentName,
+                engineIndex,
+                multiEngineNum);
         logger.info("Created WorkerStatus generation {} for worker: {}",
                 discovered.getGenerationId(), workerIpPort);
         return discovered;

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunner.java
@@ -11,7 +11,6 @@ import org.flexlb.service.grpc.EngineGrpcService;
 import org.flexlb.service.grpc.EngineStatusConverter;
 import org.flexlb.service.monitor.EngineHealthReporter;
 import org.flexlb.sync.status.WorkerDirectory;
-import org.flexlb.util.CommonUtils;
 import org.flexlb.util.IdUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,11 +62,32 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
                                       boolean fullSnapshotDebugMode,
                                       Executor callbackExecutor) {
 
+        this(modelName, ipPort, workerStatus.getGrpcPort(), site, roleType,
+                workerStatus, pollLease, workerDirectory, engineHealthReporter,
+                engineGrpcService, cacheAwareService, cacheIntervalService,
+                requestTimeoutMs, syncCount, syncEngineStatusInterval,
+                fullSnapshotDebugMode, callbackExecutor);
+    }
+
+    public GrpcCacheStatusCheckRunner(String modelName, String ipPort, int workerStatusPort,
+                                      String site, RoleType roleType,
+                                      WorkerStatus workerStatus,
+                                      WorkerStatus.PollLease pollLease,
+                                      WorkerDirectory workerDirectory,
+                                      EngineHealthReporter engineHealthReporter,
+                                      EngineGrpcService engineGrpcService,
+                                      CacheAwareService cacheAwareService,
+                                      DynamicCacheIntervalService cacheIntervalService,
+                                      long requestTimeoutMs,
+                                      LongAdder syncCount,
+                                      Long syncEngineStatusInterval,
+                                      boolean fullSnapshotDebugMode,
+                                      Executor callbackExecutor) {
+
         this.ipPort = ipPort;
-        String[] split = ipPort.split(":");
-        this.ip = split[0];
+        this.ip = workerStatus.getIp();
         this.roleType = roleType;
-        this.grpcPort = CommonUtils.toGrpcPort(Integer.parseInt(split[1]));
+        this.grpcPort = workerStatusPort;
         this.modelName = modelName;
         this.workerStatus = workerStatus;
         this.workerDirectory = java.util.Objects.requireNonNull(

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunner.java
@@ -227,13 +227,13 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
             }
 
             engineHealthReporter.reportCacheStatusCheckRemoteInfo(
-                    modelName, roleType.name(), startTime);
+                    modelName, workerStatus.getLogicalIpPort(), roleType.name(), startTime);
             engineHealthReporter.reportCacheStatusCheckerSuccess(
                     modelName, workerStatus, successfulIntervalUs);
         } catch (Throwable e) {
             log("engine cache status check via gRPC exception, msg: " + e.getMessage(), e);
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE);
         }
     }
 
@@ -274,7 +274,7 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
                         "Cache service returned no update result for {}#{}",
                         ipPort, generationId);
                 engineHealthReporter.reportCacheStatusCheckerFail(
-                        modelName, BalanceStatusEnum.CACHE_UPDATE_FAILED, roleType);
+                        modelName, workerStatus, BalanceStatusEnum.CACHE_UPDATE_FAILED);
                 return null;
             }
             if (!result.isSuccess()) {
@@ -285,15 +285,15 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
                         result.getErrorMessage());
                 engineHealthReporter.reportCacheStatusCheckerFail(
                         modelName,
-                        BalanceStatusEnum.CACHE_UPDATE_FAILED,
-                        roleType);
+                        workerStatus,
+                        BalanceStatusEnum.CACHE_UPDATE_FAILED);
             }
             return result;
         } catch (Exception e) {
             logger.debug("Exception to update worker cache for {}#{}: {}",
                     ipPort, generationId, e.getMessage());
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_UPDATE_FAILED, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_UPDATE_FAILED);
             return null;
         }
     }
@@ -329,10 +329,10 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
         // Report specific error based on exception type
         if (ex.getMessage() != null && ex.getMessage().toLowerCase().contains(DEADLINE_EXCEEDED_MESSAGE.toLowerCase())) {
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_GRPC_TIMEOUT, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_GRPC_TIMEOUT);
         } else {
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcWorkerStatusRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcWorkerStatusRunner.java
@@ -154,7 +154,8 @@ public class GrpcWorkerStatusRunner implements Runnable {
             if (observation == null) {
                 logger.debug("query engine worker status via gRPC, response body is null");
                 engineHealthReporter.reportStatusCheckerFail(
-                        modelName, BalanceStatusEnum.RESPONSE_NULL, roleType);
+                        modelName, BalanceStatusEnum.RESPONSE_NULL,
+                        workerStatus.getLogicalIpPort(), roleType);
                 return;
             }
             if (!workerDirectory.isCurrentStatus(
@@ -299,7 +300,8 @@ public class GrpcWorkerStatusRunner implements Runnable {
             logger.error("Worker status response handling failed after callback for {}",
                     ipPort, e);
             engineHealthReporter.reportStatusCheckerFail(
-                    modelName, BalanceStatusEnum.UNKNOWN_ERROR, roleType);
+                    modelName, BalanceStatusEnum.UNKNOWN_ERROR,
+                    workerStatus.getLogicalIpPort(), roleType);
         }
     }
 
@@ -381,7 +383,8 @@ public class GrpcWorkerStatusRunner implements Runnable {
             WorkerEndpoint endpoint) {
         try {
             engineHealthReporter.reportStatusCheckRemoteInfo(
-                    modelName, observation.role().name(), startTime);
+                    modelName, workerStatus.getLogicalIpPort(),
+                    observation.role().name(), startTime);
             engineHealthReporter.reportStatusCheckerSuccess(
                     modelName,
                     workerStatus,
@@ -431,10 +434,12 @@ public class GrpcWorkerStatusRunner implements Runnable {
         if (ex.getMessage() != null && ex.getMessage().toLowerCase().contains(DEADLINE_EXCEEDED_MESSAGE.toLowerCase())) {
             logger.debug("gRPC worker status check timeout, msg={}, ipPort: {}, rt: {}", ex.getMessage(), ipPort, System.nanoTime() / 1000 - createTimeUs);
             engineHealthReporter.reportStatusCheckerFail(
-                    modelName, BalanceStatusEnum.WORKER_STATUS_GRPC_TIMEOUT, roleType);
+                    modelName, BalanceStatusEnum.WORKER_STATUS_GRPC_TIMEOUT,
+                    workerStatus.getLogicalIpPort(), roleType);
         } else {
             engineHealthReporter.reportStatusCheckerFail(
-                    modelName, BalanceStatusEnum.WORKER_SERVICE_UNAVAILABLE, roleType);
+                    modelName, BalanceStatusEnum.WORKER_SERVICE_UNAVAILABLE,
+                    workerStatus.getLogicalIpPort(), roleType);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcWorkerStatusRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcWorkerStatusRunner.java
@@ -10,7 +10,6 @@ import org.flexlb.service.grpc.EngineGrpcService;
 import org.flexlb.service.grpc.EngineStatusConverter;
 import org.flexlb.service.monitor.EngineHealthReporter;
 import org.flexlb.sync.status.WorkerDirectory;
-import org.flexlb.util.CommonUtils;
 import org.flexlb.util.IdUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,8 +56,7 @@ public class GrpcWorkerStatusRunner implements Runnable {
                                   CacheAwareService cacheAwareService,
                                   Executor callbackExecutor) {
         this.ipPort = ipPort;
-        String[] split = ipPort.split(":");
-        this.ip = split[0];
+        this.ip = workerStatus.getIp();
         this.workerStatusPort = workerStatusPort;
         this.modelName = modelName;
         this.workerStatus = workerStatus;
@@ -86,15 +84,14 @@ public class GrpcWorkerStatusRunner implements Runnable {
                                   long syncRequestTimeoutMs,
                                   CacheAwareService cacheAwareService,
                                   Executor callbackExecutor) {
-        this(modelName, ipPort, defaultWorkerStatusPort(ipPort), site, roleType,
+        this(modelName, ipPort, defaultWorkerStatusPort(workerStatus), site, roleType,
                 ignoredGroup, workerStatus, pollLease, workerDirectory,
                 engineHealthReporter, engineGrpcService, syncRequestTimeoutMs,
                 cacheAwareService, callbackExecutor);
     }
 
-    private static int defaultWorkerStatusPort(String ipPort) {
-        String[] split = ipPort.split(":");
-        return CommonUtils.toGrpcPort(Integer.parseInt(split[1]));
+    private static int defaultWorkerStatusPort(WorkerStatus workerStatus) {
+        return workerStatus.getGrpcPort();
     }
 
     @Override

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/status/WorkerDirectory.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/status/WorkerDirectory.java
@@ -89,7 +89,7 @@ public final class WorkerDirectory implements WorkerStatusProvider {
             WorkerStatus discovered = Objects.requireNonNull(
                     discoveredFactory.get(), "discovered status");
             if (discovered.getRole() != role
-                    || !address.equals(discovered.getIpPort())) {
+                    || !address.equals(discovered.getLogicalIpPort())) {
                 throw new IllegalArgumentException(
                         "Discovered WorkerStatus identity does not match directory key");
             }
@@ -237,7 +237,19 @@ public final class WorkerDirectory implements WorkerStatusProvider {
 
     /** Immutable, non-owning address snapshot for lazy selection. */
     public List<String> endpointAddressSnapshot(RoleType role) {
-        return endpointRegistry.endpointAddressSnapshot(role);
+        List<String> addresses = endpointRegistry.endpointAddressSnapshot(role);
+        if (addresses.isEmpty()) {
+            return addresses;
+        }
+        List<String> routable = new ArrayList<>(addresses.size());
+        for (String address : addresses) {
+            WorkerEndpoint endpoint = endpointRegistry.get(role, address);
+            if (isPhysicalGroupHealthy(endpoint)) {
+                routable.add(address);
+            }
+        }
+        return routable.size() == addresses.size()
+                ? addresses : List.copyOf(routable);
     }
 
     /**
@@ -246,7 +258,20 @@ public final class WorkerDirectory implements WorkerStatusProvider {
      */
     public List<EndpointRegistry.PrefillRoutingEntry> prefillRoutingSnapshot(
             RoleType role) {
-        return endpointRegistry.prefillRoutingSnapshot(role);
+        List<EndpointRegistry.PrefillRoutingEntry> entries =
+                endpointRegistry.prefillRoutingSnapshot(role);
+        if (entries.isEmpty()) {
+            return entries;
+        }
+        List<EndpointRegistry.PrefillRoutingEntry> routable =
+                new ArrayList<>(entries.size());
+        for (EndpointRegistry.PrefillRoutingEntry entry : entries) {
+            if (isPhysicalGroupHealthy(entry.endpoint())) {
+                routable.add(entry);
+            }
+        }
+        return routable.size() == entries.size()
+                ? entries : List.copyOf(routable);
     }
 
     /** Capture one exact currently published endpoint generation by address. */
@@ -263,18 +288,65 @@ public final class WorkerDirectory implements WorkerStatusProvider {
         // group filter is needed.
         List<DecodeEndpoint.DecodeRoutingView> snapshots =
                 endpointRegistry.decodeRoutingSnapshot();
-        if (group == null || snapshots.isEmpty()) {
+        if (snapshots.isEmpty()) {
             return snapshots;
         }
         ArrayList<DecodeEndpoint.DecodeRoutingView> matching =
                 new ArrayList<>(snapshots.size());
         for (int index = 0; index < snapshots.size(); index++) {
             DecodeEndpoint.DecodeRoutingView snapshot = snapshots.get(index);
-            if (group.equals(snapshot.topology().group())) {
+            WorkerEndpoint endpoint = endpointRegistry.get(
+                    RoleType.DECODE, snapshot.address());
+            if (isPhysicalGroupHealthy(endpoint)
+                    && (group == null
+                    || group.equals(snapshot.topology().group()))) {
                 matching.add(snapshot);
             }
         }
-        return List.copyOf(matching);
+        return matching.size() == snapshots.size()
+                ? snapshots : List.copyOf(matching);
+    }
+
+    /**
+     * A logical worker behind a shared frontend is routable only when every
+     * expected sibling is currently published and alive. Single-engine RTP-LLM
+     * workers keep their existing one-worker health behavior.
+     */
+    public boolean isPhysicalGroupHealthy(WorkerEndpoint endpoint) {
+        WorkerStatus worker = endpoint == null ? null : endpoint.getStatus();
+        if (worker == null || !worker.isAlive()) {
+            return false;
+        }
+        int expected = worker.getMultiEngineNum();
+        if (expected == 1) {
+            return true;
+        }
+        if (expected < 1) {
+            return false;
+        }
+
+        boolean[] observedIndexes = new boolean[expected];
+        int count = 0;
+        Map<String, WorkerStatus> statuses = statusesByRole.get(worker.getRole());
+        for (Map.Entry<String, WorkerStatus> entry : statuses.entrySet()) {
+            WorkerStatus sibling = entry.getValue();
+            if (!worker.getPhysicalIpPort().equals(sibling.getPhysicalIpPort())) {
+                continue;
+            }
+            int engineIndex = sibling.getEngineIndex();
+            if (sibling.getMultiEngineNum() != expected
+                    || engineIndex < 0
+                    || engineIndex >= expected
+                    || observedIndexes[engineIndex]
+                    || !sibling.isAlive()
+                    || endpointRegistry.get(
+                    worker.getRole(), entry.getKey(), sibling) == null) {
+                return false;
+            }
+            observedIndexes[engineIndex] = true;
+            count++;
+        }
+        return count == expected;
     }
 
     /** Pin the exact generation represented by a Decode routing snapshot. */
@@ -294,7 +366,8 @@ public final class WorkerDirectory implements WorkerStatusProvider {
                 WorkerEndpoint.GenerationPin pin = captured.get(index);
                 WorkerStatus.TopologySnapshot topology =
                         pin.endpoint().getStatus().topologySnapshot();
-                if (group != null && !group.equals(topology.group())) {
+                if (!isPhysicalGroupHealthy(pin.endpoint())
+                        || group != null && !group.equals(topology.group())) {
                     pin.close();
                     captured.set(index, null);
                     continue;

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/status/WorkerDirectory.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/status/WorkerDirectory.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -241,10 +242,12 @@ public final class WorkerDirectory implements WorkerStatusProvider {
         if (addresses.isEmpty()) {
             return addresses;
         }
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(role);
         List<String> routable = new ArrayList<>(addresses.size());
         for (String address : addresses) {
             WorkerEndpoint endpoint = endpointRegistry.get(role, address);
-            if (isPhysicalGroupHealthy(endpoint)) {
+            if (isPhysicalGroupHealthy(endpoint, physicalHealth)) {
                 routable.add(address);
             }
         }
@@ -263,10 +266,12 @@ public final class WorkerDirectory implements WorkerStatusProvider {
         if (entries.isEmpty()) {
             return entries;
         }
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(role);
         List<EndpointRegistry.PrefillRoutingEntry> routable =
                 new ArrayList<>(entries.size());
         for (EndpointRegistry.PrefillRoutingEntry entry : entries) {
-            if (isPhysicalGroupHealthy(entry.endpoint())) {
+            if (isPhysicalGroupHealthy(entry.endpoint(), physicalHealth)) {
                 routable.add(entry);
             }
         }
@@ -291,13 +296,15 @@ public final class WorkerDirectory implements WorkerStatusProvider {
         if (snapshots.isEmpty()) {
             return snapshots;
         }
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(RoleType.DECODE);
         ArrayList<DecodeEndpoint.DecodeRoutingView> matching =
                 new ArrayList<>(snapshots.size());
         for (int index = 0; index < snapshots.size(); index++) {
             DecodeEndpoint.DecodeRoutingView snapshot = snapshots.get(index);
             WorkerEndpoint endpoint = endpointRegistry.get(
                     RoleType.DECODE, snapshot.address());
-            if (isPhysicalGroupHealthy(endpoint)
+            if (isPhysicalGroupHealthy(endpoint, physicalHealth)
                     && (group == null
                     || group.equals(snapshot.topology().group()))) {
                 matching.add(snapshot);
@@ -314,39 +321,8 @@ public final class WorkerDirectory implements WorkerStatusProvider {
      */
     public boolean isPhysicalGroupHealthy(WorkerEndpoint endpoint) {
         WorkerStatus worker = endpoint == null ? null : endpoint.getStatus();
-        if (worker == null || !worker.isAlive()) {
-            return false;
-        }
-        int expected = worker.getMultiEngineNum();
-        if (expected == 1) {
-            return true;
-        }
-        if (expected < 1) {
-            return false;
-        }
-
-        boolean[] observedIndexes = new boolean[expected];
-        int count = 0;
-        Map<String, WorkerStatus> statuses = statusesByRole.get(worker.getRole());
-        for (Map.Entry<String, WorkerStatus> entry : statuses.entrySet()) {
-            WorkerStatus sibling = entry.getValue();
-            if (!worker.getPhysicalIpPort().equals(sibling.getPhysicalIpPort())) {
-                continue;
-            }
-            int engineIndex = sibling.getEngineIndex();
-            if (sibling.getMultiEngineNum() != expected
-                    || engineIndex < 0
-                    || engineIndex >= expected
-                    || observedIndexes[engineIndex]
-                    || !sibling.isAlive()
-                    || endpointRegistry.get(
-                    worker.getRole(), entry.getKey(), sibling) == null) {
-                return false;
-            }
-            observedIndexes[engineIndex] = true;
-            count++;
-        }
-        return count == expected;
+        return worker != null && isPhysicalGroupHealthy(
+                endpoint, physicalGroupHealthSnapshot(worker.getRole()));
     }
 
     /** Pin the exact generation represented by a Decode routing snapshot. */
@@ -361,12 +337,14 @@ public final class WorkerDirectory implements WorkerStatusProvider {
         List<WorkerEndpoint.GenerationPin> captured = endpointRegistry.capture(role);
         List<WorkerEndpoint.GenerationPin> matching =
                 new ArrayList<>(captured.size());
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(role);
         try {
             for (int index = 0; index < captured.size(); index++) {
                 WorkerEndpoint.GenerationPin pin = captured.get(index);
                 WorkerStatus.TopologySnapshot topology =
                         pin.endpoint().getStatus().topologySnapshot();
-                if (!isPhysicalGroupHealthy(pin.endpoint())
+                if (!isPhysicalGroupHealthy(pin.endpoint(), physicalHealth)
                         || group != null && !group.equals(topology.group())) {
                     pin.close();
                     captured.set(index, null);
@@ -402,6 +380,72 @@ public final class WorkerDirectory implements WorkerStatusProvider {
             if (pin != null) {
                 pin.close();
             }
+        }
+    }
+
+    private boolean isPhysicalGroupHealthy(
+            WorkerEndpoint endpoint, Map<String, Boolean> physicalHealth) {
+        WorkerStatus worker = endpoint == null ? null : endpoint.getStatus();
+        return worker != null && worker.isAlive()
+                && (worker.getMultiEngineNum() == 1
+                || physicalHealth.getOrDefault(
+                        worker.getPhysicalGroupKey(), false));
+    }
+
+    private Map<String, Boolean> physicalGroupHealthSnapshot(RoleType role) {
+        if (role == null) {
+            return Map.of();
+        }
+        Map<String, WorkerStatus> statuses = statusesByRole.get(role);
+        if (statuses.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, PhysicalGroupHealth> groups = new HashMap<>();
+        for (Map.Entry<String, WorkerStatus> entry : statuses.entrySet()) {
+            WorkerStatus sibling = entry.getValue();
+            groups.computeIfAbsent(
+                    sibling.getPhysicalGroupKey(), ignored ->
+                            new PhysicalGroupHealth())
+                    .observe(
+                            sibling,
+                            endpointRegistry.get(role, entry.getKey(), sibling)
+                                    != null);
+        }
+        Map<String, Boolean> health = new HashMap<>(groups.size());
+        for (Map.Entry<String, PhysicalGroupHealth> entry : groups.entrySet()) {
+            health.put(entry.getKey(), entry.getValue().healthy());
+        }
+        return health;
+    }
+
+    private static final class PhysicalGroupHealth {
+        private int expected = -1;
+        private boolean[] observedIndexes;
+        private int observedCount;
+        private boolean invalid;
+
+        private void observe(WorkerStatus worker, boolean endpointPublished) {
+            int engineCount = worker.getMultiEngineNum();
+            int engineIndex = worker.getEngineIndex();
+            if (expected == -1) {
+                expected = engineCount;
+                observedIndexes = new boolean[Math.max(0, engineCount)];
+            }
+            if (engineCount != expected
+                    || engineIndex < 0
+                    || engineIndex >= expected
+                    || !worker.isAlive()
+                    || !endpointPublished
+                    || observedIndexes[engineIndex]) {
+                invalid = true;
+                return;
+            }
+            observedIndexes[engineIndex] = true;
+            observedCount++;
+        }
+
+        private boolean healthy() {
+            return !invalid && expected > 0 && observedCount == expected;
         }
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointAdmissionTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointAdmissionTest.java
@@ -110,7 +110,7 @@ class DecodeEndpointAdmissionTest {
         }
         exactEndpoint.releaseReservationExact(speculative);
         verify(availability).capacityChanged(
-                RoleType.DECODE, null, "10.0.0.1:8080");
+                RoleType.DECODE, null, "10.0.0.1:8080@0");
 
         DecodeEndpoint.ReservationHandle published;
         try (WorkerEndpoint.GenerationPin pin =
@@ -121,7 +121,7 @@ class DecodeEndpointAdmissionTest {
         }
         exactEndpoint.releaseReservationExact(published);
         verify(availability, times(2)).capacityChanged(
-                RoleType.DECODE, null, "10.0.0.1:8080");
+                RoleType.DECODE, null, "10.0.0.1:8080@0");
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointLayeredViewTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointLayeredViewTest.java
@@ -117,7 +117,7 @@ class DecodeEndpointLayeredViewTest {
 
         endpoint.reportAdmissionMetrics(reporter);
 
-        String endpointKey = "10.0.0.1:8080";
+        String endpointKey = "10.0.0.1:8080@0";
         org.mockito.Mockito.verify(reporter)
                 .reportDecodeReservedCount(endpointKey, 1);
         org.mockito.Mockito.verify(reporter)

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointTest.java
@@ -122,7 +122,7 @@ class DecodeEndpointTest {
 
     @Test
     void ipPort_format() {
-        assertEquals("10.0.0.1:8080", endpoint.ipPort());
+        assertEquals("10.0.0.1:8080@0", endpoint.ipPort());
     }
 
     // ==================== PR-C: getEngineLoad O(1) + queuedPhaseCount drift ===========

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointTest.java
@@ -1,10 +1,14 @@
 package org.flexlb.balance.endpoint;
 
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.flexlb.dao.master.TaskInfo;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.master.WorkerStatusResponse;
 import org.flexlb.dao.route.RoleType;
 import org.flexlb.enums.TaskPhase;
+import org.flexlb.metric.MicrometerFlexMonitor;
+import org.flexlb.service.monitor.BatchSchedulerReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +36,50 @@ class DecodeEndpointTest {
                 RoleType.DECODE, "10.0.0.1", 8080, 8081);
         endpoint = new DecodeEndpoint(
                 status, EndpointTestSupport.noopEventSink());
+    }
+
+    @Test
+    void batchMetricsKeepSiblingEngineReservationsSeparate() {
+        WorkerStatus firstStatus = WorkerStatus.createDiscovered(
+                RoleType.DECODE, null, "10.0.0.1", 8080, 8081,
+                null, null, 0, 2);
+        WorkerStatus siblingStatus = WorkerStatus.createDiscovered(
+                RoleType.DECODE, null, "10.0.0.1", 8080, 8081,
+                null, null, 1, 2);
+        DecodeEndpoint first = new DecodeEndpoint(
+                firstStatus, EndpointTestSupport.noopEventSink());
+        DecodeEndpoint sibling = new DecodeEndpoint(
+                siblingStatus, EndpointTestSupport.noopEventSink());
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        try {
+            BatchSchedulerReporter reporter =
+                    new BatchSchedulerReporter(
+                            new MicrometerFlexMonitor(registry));
+            reporter.init();
+            reserve(first, 100L, 500, 500);
+            reserve(sibling, 200L, 300, 300);
+            reserve(sibling, 201L, 400, 400);
+
+            first.reportBatchMetrics(reporter);
+            sibling.reportBatchMetrics(reporter);
+
+            Gauge firstInflight = registry.find("flexlb.app.flexlb.inflight.request.count")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@0").gauge();
+            Gauge secondInflight = registry.find("flexlb.app.flexlb.inflight.request.count")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@1").gauge();
+            assertNotNull(firstInflight, "engine 0 must expose its own inflight gauge");
+            assertNotNull(secondInflight, "engine 1 must expose its own inflight gauge");
+            assertEquals(1.0, firstInflight.value());
+            assertEquals(2.0, secondInflight.value());
+            assertEquals(500.0, registry.get("flexlb.app.flexlb.decode.inflight.kv.reserved.tokens")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@0").gauge().value());
+            assertEquals(700.0, registry.get("flexlb.app.flexlb.decode.inflight.kv.reserved.tokens")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@1").gauge().value());
+        } finally {
+            registry.close();
+            first.close();
+            sibling.close();
+        }
     }
 
     @Test
@@ -272,13 +320,21 @@ class DecodeEndpointTest {
 
     private DecodeEndpoint.ReservationHandle reserve(
             long requestId, long hardKv, long expectedKv) {
-        try (WorkerEndpoint.GenerationPin pin = endpoint.tryPinGeneration()) {
+        DecodeEndpoint.ReservationHandle reservation =
+                reserve(endpoint, requestId, hardKv, expectedKv);
+        reservations.put(requestId, reservation);
+        return reservation;
+    }
+
+    private static DecodeEndpoint.ReservationHandle reserve(
+            DecodeEndpoint target,
+            long requestId,
+            long hardKv,
+            long expectedKv) {
+        try (WorkerEndpoint.GenerationPin pin = target.tryPinGeneration()) {
             assertNotNull(pin);
-            DecodeEndpoint.ReservationHandle reservation =
-                    endpoint.reservePinned(
-                            pin, Long.toString(requestId), hardKv, expectedKv, 0);
-            reservations.put(requestId, reservation);
-            return reservation;
+            return target.reservePinned(
+                    pin, Long.toString(requestId), hardKv, expectedKv, 0);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/PrefillEndpointTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/PrefillEndpointTest.java
@@ -327,15 +327,15 @@ class PrefillEndpointTest {
         registerBatch(endpoint, 9L, 100, List.of(createScheduledRequest(9L, 500, 200)));
         doThrow(new IllegalStateException("metrics unavailable"))
                 .when(endpointReporter)
-                .reportBatchPredictedTimeMs("PREFILL", "127.0.0.1", 100);
+                .reportBatchPredictedTimeMs("PREFILL", "127.0.0.1:8080@0", 100);
 
         TaskInfo finished = taskInfo("9", 9L, null, 0, 125);
         assertDoesNotThrow(() -> calibrate(Map.of("9", finished), Map.of()));
 
         assertEquals(0, endpoint.getInflightBatchCount());
         assertEquals(0, endpoint.admissionPendingRequestCount());
-        verify(endpointReporter).reportBatchActualTimeMs("PREFILL", "127.0.0.1", 125);
-        verify(endpointReporter).reportBatchPredictGapMs("PREFILL", "127.0.0.1", 25);
+        verify(endpointReporter).reportBatchActualTimeMs("PREFILL", "127.0.0.1:8080@0", 125);
+        verify(endpointReporter).reportBatchPredictGapMs("PREFILL", "127.0.0.1:8080@0", 25);
     }
 
     @Test
@@ -1219,10 +1219,10 @@ class PrefillEndpointTest {
             slowEndpoint.reportBatchMetrics(reporter);
 
             // Single-report with priority tag (no global untagged series)
-            verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1", 2);
+            verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1:8080@0", 2);
             // Priority buckets on the same routing.queue.length metric
-            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1", 70, 1);
-            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1", 0, 1);
+            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1:8080@0", 70, 1);
+            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1:8080@0", 0, 1);
         } finally {
             slowEndpoint.close();
         }
@@ -1233,9 +1233,9 @@ class PrefillEndpointTest {
         BatchSchedulerReporter reporter = mock(BatchSchedulerReporter.class);
         endpoint.reportBatchMetrics(reporter);
 
-        verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1", 0);
+        verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1:8080@0", 0);
         // Empty queue fallback: single priority=0 depth=0 report so tagged panels don't gap
-        verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1", 0, 0);
+        verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1:8080@0", 0, 0);
     }
 
     // ---- WorkerEndpoint inherited behavior ----

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/WorkerEndpointTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/WorkerEndpointTest.java
@@ -186,7 +186,7 @@ class WorkerEndpointTest {
 
     @Test
     void ipPort_format() {
-        assertEquals("10.0.0.1:8080", endpoint.ipPort());
+        assertEquals("10.0.0.1:8080@0", endpoint.ipPort());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/PdfusionSchedulingTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/PdfusionSchedulingTest.java
@@ -102,7 +102,7 @@ class PdfusionSchedulingTest {
         status.setMaxBatchTokensSize(10000L);
         worker.lock.lock();
         try {
-            endpoints.publishPreparedEndpoint(worker.getIpPort(), worker,
+            endpoints.publishPreparedEndpoint(worker.getLogicalIpPort(), worker,
                     worker.prepareNewStatus(worker.freezeStatusResponse(status)));
         } finally {
             worker.lock.unlock();

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/PdfusionSchedulingTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/PdfusionSchedulingTest.java
@@ -104,6 +104,7 @@ class PdfusionSchedulingTest {
         try {
             endpoints.publishPreparedEndpoint(worker.getLogicalIpPort(), worker,
                     worker.prepareNewStatus(worker.freezeStatusResponse(status)));
+            worker.recordSuccessfulPoll(true);
         } finally {
             worker.lock.unlock();
         }
@@ -130,7 +131,8 @@ class PdfusionSchedulingTest {
                     .map(ServerStatus::getRole).toList());
             assertEquals(0, endpoints.getEndpointCount(RoleType.DECODE));
             assertEquals(0, lifecycle.decodeAcceptanceCount());
-            PrefillEndpoint endpoint = (PrefillEndpoint) endpoints.get(RoleType.PDFUSION, worker.getIpPort());
+            PrefillEndpoint endpoint = (PrefillEndpoint) endpoints.get(
+                    RoleType.PDFUSION, worker.getLogicalIpPort());
             assertEquals(1, endpoint.admissionPendingRequestCount());
             var committedWork = endpoint.captureRouteProjectionInputs().work();
             assertTrue(committedWork.containsRequest(Long.toString(requestId)));

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/RequestLifecycleDeliveryLockContractTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/RequestLifecycleDeliveryLockContractTest.java
@@ -9,6 +9,7 @@ import org.flexlb.config.ConfigService;
 import org.flexlb.config.FlexlbConfig;
 import org.flexlb.dao.BalanceContext;
 import org.flexlb.dao.loadbalance.Response;
+import org.flexlb.dao.loadbalance.ServerStatus;
 import org.flexlb.service.monitor.BatchSchedulerReporter;
 import org.flexlb.service.monitor.RequestSchedulerReporter;
 import org.junit.jupiter.api.AfterEach;
@@ -135,6 +136,20 @@ class RequestLifecycleDeliveryLockContractTest {
                     return true;
                 }));
         assertFalse(publicationCalled[0]);
+    }
+
+    @Test
+    void queueAdmissionCopyRetainsLogicalEngineIdentity() {
+        ServerStatus source = new ServerStatus();
+        source.setServerIp("127.0.0.1");
+        source.setHttpPort(8080);
+        source.setSelectedEngineIndex(0, 2);
+
+        ServerStatus copy = RequestRegistry.copyOf(source);
+
+        assertEquals("127.0.0.1:8080@0", copy.getLogicalIpPort());
+        assertEquals(0, copy.getEngineIndex());
+        assertEquals(2, copy.getRoutingMultiEngineNum());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
@@ -120,13 +120,15 @@ class CostBasedDecodeStrategyTest {
                 decodeEndpoint(registry, replacement.address()));
         Mockito.when(replacementPin.generationId()).thenReturn(
                 replacement.generationId());
-        WorkerDirectory racing = Mockito.mock(WorkerDirectory.class);
+        DecodeDirectoryView racing = Mockito.mock(DecodeDirectoryView.class);
         Mockito.when(racing.decodeRoutingSnapshot(null))
                 .thenReturn(List.of(stale))
                 .thenReturn(List.of(replacement));
         Mockito.when(racing.captureDecodeGeneration(stale)).thenReturn(null);
         Mockito.when(racing.captureDecodeGeneration(replacement))
                 .thenReturn(replacementPin);
+        Mockito.when(racing.isPhysicalGroupHealthy(Mockito.any()))
+                .thenReturn(true);
 
         PlacementResult<SelectedRole, RoleType> result =
                 new CostBasedDecodeStrategy(racing).select(
@@ -227,12 +229,14 @@ class CostBasedDecodeStrategyTest {
         ordered.add(globalMinimum);
         Assertions.assertEquals(workerCount, ordered.size(),
                 "the decode selector must retain the complete live fleet");
-        WorkerDirectory fullFleet = Mockito.mock(WorkerDirectory.class);
+        DecodeDirectoryView fullFleet = Mockito.mock(DecodeDirectoryView.class);
         Mockito.when(fullFleet.decodeRoutingSnapshot(null)).thenReturn(ordered);
         Mockito.when(fullFleet.captureDecodeGeneration(any()))
                 .thenAnswer(invocation -> actual.captureDecodeGeneration(
                         invocation.getArgument(
                                 0, DecodeEndpoint.DecodeRoutingView.class)));
+        Mockito.when(fullFleet.isPhysicalGroupHealthy(Mockito.any()))
+                .thenReturn(true);
         CostBasedDecodeStrategy costBasedDecodeStrategy =
                 new CostBasedDecodeStrategy(fullFleet);
         BalanceContext balanceContext = context(1, 10_000L);

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
@@ -72,7 +72,14 @@ class CostBasedDecodeStrategyTest {
     }
 
     private CostBasedDecodeStrategy availableStrategy(EndpointRegistry registry) {
-        return new CostBasedDecodeStrategy(new WorkerDirectory(registry));
+        WorkerDirectory directory = new WorkerDirectory(registry);
+        for (String address : registry.endpointAddressSnapshot(RoleType.DECODE)) {
+            WorkerStatus status = registry.get(RoleType.DECODE, address)
+                    .getStatus();
+            directory.currentOrDiscover(
+                    RoleType.DECODE, status.getLogicalIpPort(), () -> status);
+        }
+        return new CostBasedDecodeStrategy(directory);
     }
 
     private BalanceContext context(long sequenceLength, long requestId) {
@@ -176,6 +183,29 @@ class CostBasedDecodeStrategyTest {
 
         Assertions.assertTrue(status.isSuccess());
         Assertions.assertEquals("127.0.0.1", status.getServerIp());
+    }
+
+    @Test
+    void selectedMultiEngineDecodePreservesLogicalIdentity() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.DECODE, "group-a", "127.0.0.1", 8080, 9090,
+                "test-site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.DECODE, "group-a", "127.0.0.1", 8080, 9090,
+                "test-site", null, 1, 2);
+        setKv(first, 10_000L, 10_000L);
+        setKv(second, 10_000L, 10_000L);
+        decodeStatuses.put(first.getLogicalIpPort(), first);
+        decodeStatuses.put(second.getLogicalIpPort(), second);
+
+        ServerStatus status = selectStatus(
+                availableStrategy(decodeRegistry()),
+                context(1_000L, 1_001L), RoleType.DECODE, "group-a");
+
+        Assertions.assertNotNull(status);
+        Assertions.assertNotNull(status.getEngineIndex());
+        Assertions.assertEquals("127.0.0.1:8080@" + status.getEngineIndex(),
+                status.getLogicalIpPort());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
@@ -120,7 +120,8 @@ class CostBasedDecodeStrategyTest {
                 decodeEndpoint(registry, replacement.address()));
         Mockito.when(replacementPin.generationId()).thenReturn(
                 replacement.generationId());
-        DecodeDirectoryView racing = Mockito.mock(DecodeDirectoryView.class);
+        CostBasedDecodeStrategy.DecodeDirectoryView racing =
+                Mockito.mock(CostBasedDecodeStrategy.DecodeDirectoryView.class);
         Mockito.when(racing.decodeRoutingSnapshot(null))
                 .thenReturn(List.of(stale))
                 .thenReturn(List.of(replacement));
@@ -229,7 +230,8 @@ class CostBasedDecodeStrategyTest {
         ordered.add(globalMinimum);
         Assertions.assertEquals(workerCount, ordered.size(),
                 "the decode selector must retain the complete live fleet");
-        DecodeDirectoryView fullFleet = Mockito.mock(DecodeDirectoryView.class);
+        CostBasedDecodeStrategy.DecodeDirectoryView fullFleet =
+                Mockito.mock(CostBasedDecodeStrategy.DecodeDirectoryView.class);
         Mockito.when(fullFleet.decodeRoutingSnapshot(null)).thenReturn(ordered);
         Mockito.when(fullFleet.captureDecodeGeneration(any()))
                 .thenAnswer(invocation -> actual.captureDecodeGeneration(

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
@@ -107,7 +107,7 @@ class CostBasedPrefillSelectionMetricTest {
             ArgumentCaptor<Long> ttft = ArgumentCaptor.forClass(Long.class);
             ArgumentCaptor<Long> execution = ArgumentCaptor.forClass(Long.class);
             verify(reporter).reportPrefillSelectedEstimates(
-                    Mockito.eq(RoleType.PREFILL), Mockito.eq("10.0.0.1"),
+                    Mockito.eq(RoleType.PREFILL), Mockito.eq("10.0.0.1:8080@0"),
                     Mockito.eq(deliveryMode), ttft.capture(), execution.capture());
             assertEquals(selected.serverStatus().getPrefillTime(), ttft.getValue());
             assertEquals(selected.prefillWorkMs(), execution.getValue());
@@ -134,7 +134,7 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertEquals("10.0.0.2", selected.serverStatus().getServerIp());
             verify(reporter).reportCacheAffinityDecision(
-                    RoleType.PREFILL, "10.0.0.2", "CACHE_LEADER");
+                    RoleType.PREFILL, "10.0.0.2:8080@0", "CACHE_LEADER");
         }
     }
 
@@ -157,7 +157,7 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertEquals("10.0.0.2", selected.serverStatus().getServerIp());
             verify(reporter).reportCacheHitMetrics(
-                    RoleType.PREFILL, "10.0.0.2@0", 200L, 0.2);
+                    RoleType.PREFILL, "10.0.0.2:8080@0", 200L, 0.2);
         }
     }
 
@@ -206,7 +206,7 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertEquals("10.0.0.1", selected.serverStatus().getServerIp());
             verify(reporter).reportCacheAffinityDecision(
-                    RoleType.PREFILL, "10.0.0.1", reason);
+                    RoleType.PREFILL, "10.0.0.1:8080@0", reason);
         }
     }
 
@@ -229,7 +229,7 @@ class CostBasedPrefillSelectionMetricTest {
         assertEquals(Long.MAX_VALUE, cacheEndpoint.getLastSelectedTime().get());
         verify(reporter, times(2))
                 .reportCacheAffinityDecision(
-                        RoleType.PREFILL, "10.0.0.2", "CACHE_LEADER");
+                        RoleType.PREFILL, "10.0.0.2:8080@0", "CACHE_LEADER");
     }
 
     private SelectedRole select() {

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
@@ -157,7 +157,7 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertEquals("10.0.0.2", selected.serverStatus().getServerIp());
             verify(reporter).reportCacheHitMetrics(
-                    RoleType.PREFILL, 200L, 0.2);
+                    RoleType.PREFILL, "10.0.0.2@0", 200L, 0.2);
         }
     }
 
@@ -219,7 +219,7 @@ class CostBasedPrefillSelectionMetricTest {
             assertEquals("10.0.0.2", selected.serverStatus().getServerIp());
         }
         PrefillEndpoint cacheEndpoint = (PrefillEndpoint)
-                registry.get(RoleType.PREFILL, "10.0.0.2:8080");
+                registry.get(RoleType.PREFILL, "10.0.0.2:8080@0");
         cacheEndpoint.getLastSelectedTime().set(Long.MAX_VALUE);
         context.getRequest().setRequestId("20002");
 
@@ -269,7 +269,7 @@ class CostBasedPrefillSelectionMetricTest {
     private static CacheMatchResult localCacheMatch(
             String workerIpPort, long matchedBlocks) {
         return new CacheMatchResult(
-                Map.of(workerIpPort, HostCacheMatch.local(matchedBlocks)),
+                Map.of(workerIpPort + "@0", HostCacheMatch.local(matchedBlocks)),
                 CacheMatchSource.LOCAL_SYNC,
                 0L,
                 100L);
@@ -280,6 +280,6 @@ class CostBasedPrefillSelectionMetricTest {
                 RoleType.PREFILL, null, ip, port, port + 1,
                 true, 1_000_000L, 1_000_000L);
         StrategyTestSupport.publishEndpoint(
-                registry, RoleType.PREFILL, ip + ":" + port, status);
+                registry, RoleType.PREFILL, status.getLogicalIpPort(), status);
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
@@ -14,6 +14,7 @@ import org.flexlb.dao.BalanceContext;
 import org.flexlb.dao.SchedulingMetadata;
 import org.flexlb.dao.cache.HostCacheMatch;
 import org.flexlb.dao.loadbalance.Request;
+import org.flexlb.dao.loadbalance.ServerStatus;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.route.RoleType;
 import org.flexlb.service.monitor.EngineHealthReporter;
@@ -123,6 +124,54 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertTrue(selected.serverStatus().isSuccess());
             assertEquals("10.0.0.1", selected.serverStatus().getServerIp());
+        }
+    }
+
+    @Test
+    void selectedMultiEnginePrefillPreservesLogicalIdentity() {
+        ConfigService localConfigService = mock(ConfigService.class);
+        when(localConfigService.loadBalanceConfig()).thenReturn(config);
+        EndpointRegistry localRegistry = StrategyTestSupport.endpointRegistry(
+                localConfigService);
+        try {
+            WorkerStatus first = WorkerStatus.createDiscovered(
+                    RoleType.PREFILL, null, "10.0.0.8", 8080, 8081,
+                    "test-site", null, 0, 2);
+            WorkerStatus second = WorkerStatus.createDiscovered(
+                    RoleType.PREFILL, null, "10.0.0.8", 8080, 8081,
+                    "test-site", null, 1, 2);
+            StrategyTestSupport.publish(first, StrategyTestSupport.response(
+                    RoleType.PREFILL, true, 1_000_000L, 1_000_000L, 1L));
+            StrategyTestSupport.publish(second, StrategyTestSupport.response(
+                    RoleType.PREFILL, true, 1_000_000L, 1_000_000L, 1L));
+            StrategyTestSupport.publishEndpoint(localRegistry,
+                    RoleType.PREFILL, first.getLogicalIpPort(), first);
+            StrategyTestSupport.publishEndpoint(localRegistry,
+                    RoleType.PREFILL, second.getLogicalIpPort(), second);
+            WorkerDirectory directory = new WorkerDirectory(localRegistry);
+            for (String address : localRegistry.endpointAddressSnapshot(
+                    RoleType.PREFILL)) {
+                WorkerStatus endpointStatus = localRegistry.get(
+                        RoleType.PREFILL, address).getStatus();
+                directory.currentOrDiscover(
+                        RoleType.PREFILL, address, () -> endpointStatus);
+            }
+            CostBasedPrefillStrategy localStrategy =
+                    new CostBasedPrefillStrategy(directory, cache, reporter);
+
+            PlacementResult<SelectedRole, RoleType> result = localStrategy.select(
+                    context, RoleType.PREFILL, null);
+
+            assertEquals(PlacementResult.Status.SUCCESS, result.status());
+            try (SelectedRole selected = result.value()) {
+                ServerStatus selectedStatus = selected.serverStatus();
+                assertTrue(selectedStatus.getEngineIndex() != null);
+                assertEquals("10.0.0.8:8080@"
+                                + selectedStatus.getEngineIndex(),
+                        selectedStatus.getLogicalIpPort());
+            }
+        } finally {
+            localRegistry.close();
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/RandomStrategyTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/RandomStrategyTest.java
@@ -69,6 +69,41 @@ class RandomStrategyTest {
     }
 
     @Test
+    void selectedMultiEngineVitPreservesLogicalIdentity() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.VIT, "group-a", "127.0.0.3", 8080, 8081,
+                "test-site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.VIT, "group-a", "127.0.0.3", 8080, 8081,
+                "test-site", null, 1, 2);
+        StrategyTestSupport.publish(first, StrategyTestSupport.response(
+                RoleType.VIT, true, 0L, 0L, 1L));
+        StrategyTestSupport.publish(second, StrategyTestSupport.response(
+                RoleType.VIT, true, 0L, 0L, 1L));
+        StrategyTestSupport.publishEndpoint(endpoints,
+                RoleType.VIT, first.getLogicalIpPort(), first);
+        StrategyTestSupport.publishEndpoint(endpoints,
+                RoleType.VIT, second.getLogicalIpPort(), second);
+        WorkerDirectory directory = new WorkerDirectory(endpoints);
+        for (String address : endpoints.endpointAddressSnapshot(RoleType.VIT)) {
+            WorkerStatus endpointStatus = endpoints.get(
+                    RoleType.VIT, address).getStatus();
+            directory.currentOrDiscover(
+                    RoleType.VIT, address, () -> endpointStatus);
+        }
+        strategy = new RandomStrategy(directory);
+
+        try (SelectedRole selected = strategy.select(
+                context(31L), RoleType.VIT, "group-a")) {
+            assertNotNull(selected);
+            assertNotNull(selected.serverStatus().getEngineIndex());
+            assertEquals("127.0.0.3:8080@"
+                            + selected.serverStatus().getEngineIndex(),
+                    selected.serverStatus().getLogicalIpPort());
+        }
+    }
+
+    @Test
     void skipsOtherGroups() {
         registerVit("127.0.0.4", 8080, "group-a");
         assertNull(strategy.select(

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/StrategyTestSupport.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/StrategyTestSupport.java
@@ -99,7 +99,11 @@ final class StrategyTestSupport {
                 source.getIp(),
                 source.getPort(),
                 source.getGrpcPort(),
-                source.getSite());
+                source.getSite(),
+                source.getDeploymentName(),
+                source.getEngineIndex(),
+                source.getMultiEngineNum(),
+                source.getPhysicalGroupKey());
         WorkerStatus.StatusObservation observation =
                 status.bindStatusObservation(
                         source.committedEngineObservation(),

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/StrategyTestSupport.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/StrategyTestSupport.java
@@ -111,8 +111,10 @@ final class StrategyTestSupport {
         try {
             WorkerStatus.PreparedStatus prepared =
                     status.prepareNewStatus(observation);
-            return registry.publishPreparedEndpoint(
+            WorkerEndpoint endpoint = registry.publishPreparedEndpoint(
                     address, status, prepared).endpoint();
+            status.recordSuccessfulPoll(observation.alive());
+            return endpoint;
         } finally {
             status.lock.unlock();
         }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterSelectionMetricTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterSelectionMetricTest.java
@@ -69,10 +69,10 @@ class EngineHealthReporterSelectionMetricTest {
     @Test
     void reportsSelectedPrefillEstimatesWithDeliveryMode() {
         reporter.reportPrefillSelectedEstimates(
-                RoleType.PREFILL, "10.0.0.1", "NON_BATCH", 1_250L, 400L);
+                RoleType.PREFILL, "10.0.0.1:8080@0", "NON_BATCH", 1_250L, 400L);
 
         FlexMetricTags tags = FlexMetricTags.of(
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "delivery_mode", "NON_BATCH");
         verify(monitor).report(PREFILL_SELECTED_ESTIMATED_TTFT_MS, tags, 1_250.0);

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterTest.java
@@ -12,8 +12,8 @@ import org.flexlb.dao.BalanceContext;
 import org.flexlb.dao.loadbalance.Response;
 import org.flexlb.dao.loadbalance.ServerStatus;
 import org.flexlb.dao.master.CacheStatus;
-import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.TaskInfo;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.master.WorkerStatusResponse;
 import org.flexlb.dao.route.RoleType;
@@ -108,12 +108,12 @@ class EngineHealthReporterTest {
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
                 "code", String.valueOf(failure.getCode()),
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", RoleType.PREFILL.getCode());
 
-        reporter.reportStatusCheckerFail("test-model", failure, "10.0.0.1", RoleType.PREFILL);
+        reporter.reportStatusCheckerFail("test-model", failure, "10.0.0.1:8080@0", RoleType.PREFILL);
         reporter.reportStatusCheckFailureLatency(
-                "test-model", failure, "10.0.0.1", RoleType.PREFILL, 201_234);
+                "test-model", failure, "10.0.0.1:8080@0", RoleType.PREFILL, 201_234);
 
         verify(monitor).report("app.engine.health.check.fail", expectedTags, 1.0);
         verify(monitor).report("app.engine.health.check.fail.total", expectedTags, 1.0);
@@ -157,6 +157,7 @@ class EngineHealthReporterTest {
         ServerStatus serverStatus = new ServerStatus();
         serverStatus.setRole(RoleType.PREFILL);
         serverStatus.setServerIp("10.0.0.1");
+        serverStatus.setHttpPort(8080);
         Response response = new Response();
         response.setSuccess(true);
         response.setCode(200);
@@ -173,17 +174,17 @@ class EngineHealthReporterTest {
         verify(monitor).report("app.engine.balancing.master.select.detail", FlexMetricTags.of(
                 "role", "PREFILL",
                 "strategy", "LEAST_RECENTLY_USED_IN_POOL",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "success", "true",
                 "code", "200"), 1.0);
     }
 
     @Test
     void shouldReportCacheAffinityDecisionBySelectedEngine() {
-        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1", "CACHE_LEADER");
+        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1:8080@0", "CACHE_LEADER");
 
         verify(cacheMetricsReporter).reportCacheAffinityDecision(
-                RoleType.PREFILL, "10.0.0.1", "CACHE_LEADER");
+                RoleType.PREFILL, "10.0.0.1:8080@0", "CACHE_LEADER");
     }
 
     @Test
@@ -197,11 +198,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportMasterDecisionToWaitingConfirmationLatency() {
         reporter.reportFlexlbObservedMasterDecisionToWaitingConfirmationLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 53);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 53);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.observed.decision.to.waiting.ms",
@@ -219,11 +220,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportWaitingToRunningLatency() {
         reporter.reportFlexlbObservedWaitingToRunningLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 42);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 42);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.observed.waiting.to.running.ms",
@@ -241,11 +242,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportEngineObservedWaitingToRunningLatency() {
         reporter.reportEngineObservedWaitingToRunningLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 42);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 42);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.engine.waiting.to.running.ms",
@@ -263,11 +264,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportEngineObservedReceivedToWaitingLatency() {
         reporter.reportEngineObservedReceivedToWaitingLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 42);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 42);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.engine.received.to.waiting.ms",
@@ -290,11 +291,11 @@ class EngineHealthReporterTest {
         task.setPrefillNonfinalChunkTokensMax(256);
 
         reporter.reportPrefillWorkerStatusTask(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", task);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", task);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.input.queue.wait.ms", expectedTags, 100.0);
@@ -330,7 +331,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.engine.health.check.running.task.info.size", expectedTags, 3.0);
         verify(monitor).report("app.engine.health.check.finished.task.list.size", expectedTags, 4.0);
@@ -344,7 +345,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.cache.block.size",
                 FlexMetricTags.of("model", "test-model", "role", "PREFILL"), 64.0);
@@ -355,6 +356,20 @@ class EngineHealthReporterTest {
                 FlexMetricTags.of("model", "test-model", "role", "PREFILL"), 1000.0);
         verify(monitor).report("app.cache.used.kv.cache.ratio", expectedTags, 20.0);
         verify(monitor).report("app.cache.key.size", expectedTags, 7.0);
+    }
+
+    @Test
+    void shouldReportCacheStatusFailuresWithLogicalWorkerIdentity() {
+        WorkerStatus workerStatus = workerStatus("10.0.0.1", RoleType.PREFILL);
+        BalanceStatusEnum failure = BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE;
+
+        reporter.reportCacheStatusCheckerFail("test-model", workerStatus, failure);
+
+        verify(monitor).report("app.cache.status.check.fail", FlexMetricTags.of(
+                "model", "test-model",
+                "engineIp", "10.0.0.1:8080@0",
+                "code", String.valueOf(failure.getCode()),
+                "role", "PREFILL"), 1.0);
     }
 
     @Test
@@ -378,7 +393,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.cache.local.standby.block.size", expectedTags, 4096.0);
     }
@@ -402,7 +417,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.cache.key.size", expectedTags, 7.0);
     }
@@ -422,7 +437,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1@0",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -437,7 +452,7 @@ class EngineHealthReporterTest {
         verify(monitor).report("app.cache.hit.comparison.local.standby.predicted.ratio", expectedTags, 0.4);
         assertEquals(Map.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1@0",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -446,15 +461,15 @@ class EngineHealthReporterTest {
 
     @Test
     void shouldReportSelectedKvcmP2pMatchDetails() {
-        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1", 40, 80, 100, true);
+        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1:8080@0", 40, 80, 100, true);
 
         verify(cacheMetricsReporter).reportKvcmSelectedMatch(
-                RoleType.PREFILL, "10.0.0.1", 40, 80, 100);
+                RoleType.PREFILL, "10.0.0.1:8080@0", 40, 80, 100);
     }
 
     @Test
     void shouldSkipSelectedKvcmP2pMetricsWhenDetailsAreUnavailable() {
-        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1", 0, 0, 0, false);
+        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1:8080@0", 0, 0, 0, false);
 
         verify(cacheMetricsReporter, never()).reportKvcmSelectedMatch(
                 org.mockito.ArgumentMatchers.any(),
@@ -479,7 +494,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1@0",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -526,7 +541,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1@0",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterTest.java
@@ -12,6 +12,7 @@ import org.flexlb.dao.BalanceContext;
 import org.flexlb.dao.loadbalance.Response;
 import org.flexlb.dao.loadbalance.ServerStatus;
 import org.flexlb.dao.master.CacheStatus;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.TaskInfo;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.master.WorkerStatusResponse;
@@ -409,7 +410,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportCacheHitComparisonTokenMetricsWithStableDimensions() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
@@ -420,7 +422,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -435,7 +437,7 @@ class EngineHealthReporterTest {
         verify(monitor).report("app.cache.hit.comparison.local.standby.predicted.ratio", expectedTags, 0.4);
         assertEquals(Map.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -465,7 +467,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldNotReportLocalStandbyMetricsWhenPredictionIsUnavailable() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "LOCAL_SYNC", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "LOCAL_SYNC", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
@@ -476,7 +479,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -509,7 +512,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportKvcmLocalAndP2pDeltasWhenAvailable() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(60, 60),
@@ -522,7 +526,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -534,7 +538,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldNotReportRatiosWithoutInputTokens() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 0,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/EngineSyncRunnerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/EngineSyncRunnerTest.java
@@ -498,6 +498,7 @@ class EngineSyncRunnerTest {
         assertNotNull(status);
         assertEquals(1, status.getEngineIndex());
         assertEquals(2, status.getMultiEngineNum());
+        assertEquals(host.getPhysicalGroupKey(), status.getPhysicalGroupKey());
         ArgumentCaptor<Runnable> submittedTasks = ArgumentCaptor.forClass(Runnable.class);
         verify(statusCheckExecutor, times(2)).submit(submittedTasks.capture());
         submittedTasks.getAllValues().get(0).run();

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/EngineSyncRunnerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/EngineSyncRunnerTest.java
@@ -139,7 +139,7 @@ class EngineSyncRunnerTest {
 
     @Test
     void should_start_new_worker_expiration_window_at_discovery_time() {
-        String ipPort = "127.0.0.1:8080";
+        String ipPort = "127.0.0.1:8080@0";
         Mockito.when(workerAddressService.getEngineWorkerList(modelName, RoleType.VIT))
                 .thenReturn(List.of(WorkerHost.of("127.0.0.1", 8080)));
         EngineSyncRunner runner = new EngineSyncRunner(
@@ -158,7 +158,7 @@ class EngineSyncRunnerTest {
 
     @Test
     void executorRejectionReturnsBothExactPollLeases() {
-        String ipPort = "127.0.0.1:8080";
+        String ipPort = "127.0.0.1:8080@0";
         when(workerAddressService.getEngineWorkerList(
                 modelName, RoleType.PREFILL))
                 .thenReturn(List.of(WorkerHost.of("127.0.0.1", 8080)));
@@ -189,7 +189,7 @@ class EngineSyncRunnerTest {
         Mockito.when(configService.loadBalanceConfig()).thenReturn(new FlexlbConfig());
         EndpointRegistry registry = RunnerTestSupport.endpointRegistry(configService);
         WorkerDirectory directory = new WorkerDirectory(registry);
-        String ipPort = "127.0.0.1:8080";
+        String ipPort = "127.0.0.1:8080@0";
         WorkerStatus status = Mockito.spy(RunnerTestSupport.discovered(
                 RoleType.PREFILL, null, "127.0.0.1",
                 8080, 8081, "test-site"));
@@ -252,11 +252,11 @@ class EngineSyncRunnerTest {
             runner.run();
 
             WorkerStatus discovered = directory.statusSnapshot(RoleType.PREFILL)
-                    .get("127.0.0.1:61000");
+                    .get("127.0.0.1:61000@0");
             assertEquals(RoleType.PREFILL, discovered.getRole());
             assertFalse(discovered.pollHealth().reportedAlive(),
                     "service discovery alone must not make a worker routable");
-            assertNull(registry.get(RoleType.PREFILL, "127.0.0.1:61000"),
+            assertNull(registry.get(RoleType.PREFILL, "127.0.0.1:61000@0"),
                     "an endpoint is published only by a committed status response");
             verify(statusCheckExecutor, times(2)).submit(any(Runnable.class));
         } finally {
@@ -288,9 +288,9 @@ class EngineSyncRunnerTest {
                 .thenReturn(List.of(
                         WorkerHost.of(first.getIp(), first.getPort()),
                         WorkerHost.of(second.getIp(), second.getPort())));
-        when(registry.get(RoleType.PREFILL, first.getIpPort(), first))
+        when(registry.get(RoleType.PREFILL, first.getLogicalIpPort(), first))
                 .thenReturn(firstEndpoint);
-        when(registry.get(RoleType.PREFILL, second.getIpPort(), second))
+        when(registry.get(RoleType.PREFILL, second.getLogicalIpPort(), second))
                 .thenReturn(secondEndpoint);
         when(firstEndpoint.getLoadMetric()).thenReturn(OptionalLong.of(10L));
         when(secondEndpoint.getLoadMetric()).thenReturn(OptionalLong.empty());
@@ -319,9 +319,9 @@ class EngineSyncRunnerTest {
                 .thenReturn(List.of(
                         WorkerHost.of(first.getIp(), first.getPort()),
                         WorkerHost.of(second.getIp(), second.getPort())));
-        when(registry.get(RoleType.PREFILL, first.getIpPort(), first))
+        when(registry.get(RoleType.PREFILL, first.getLogicalIpPort(), first))
                 .thenReturn(firstEndpoint);
-        when(registry.get(RoleType.PREFILL, second.getIpPort(), second))
+        when(registry.get(RoleType.PREFILL, second.getLogicalIpPort(), second))
                 .thenReturn(secondEndpoint);
         when(firstEndpoint.getLoadMetric()).thenReturn(OptionalLong.of(10L));
         when(secondEndpoint.getLoadMetric()).thenReturn(OptionalLong.of(30L));
@@ -351,7 +351,7 @@ class EngineSyncRunnerTest {
                 .thenReturn(new FlexlbConfig());
         EndpointRegistry registry = RunnerTestSupport.endpointRegistry(configService);
         WorkerDirectory directory = new WorkerDirectory(registry);
-        String ipPort = "127.0.0.1:61000";
+        String ipPort = "127.0.0.1:61000@0";
         WorkerStatus oldStatus = RunnerTestSupport.discovered(
                 RoleType.PREFILL, oldGroup, "127.0.0.1",
                 61000, 61001, "site-a");
@@ -431,7 +431,7 @@ class EngineSyncRunnerTest {
     private static void discover(
             WorkerDirectory directory, WorkerStatus status) {
         directory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
     }
 
     @Test
@@ -457,7 +457,52 @@ class EngineSyncRunnerTest {
         verify(engineGrpcService).getWorkerStatusAsync(
                 "127.0.0.1", 18081, -1L, syncRequestTimeoutMs, RoleType.PREFILL);
         assertEquals(8081, workerDirectory.statusSnapshot(RoleType.PREFILL)
-                .get("127.0.0.1:8080").getGrpcPort());
+                .get("127.0.0.1:8080@0").getGrpcPort());
+    }
+
+    @Test
+    void singleEngineWorkerWithoutStatusPortUsesGrpcPortForStatusRunner() {
+        WorkerHost host = new WorkerHost("127.0.0.1", 8080);
+        when(workerAddressService.getEngineWorkerList(modelName, RoleType.PREFILL))
+                .thenReturn(List.of(host));
+        when(engineGrpcService.getWorkerStatusAsync(any(), anyInt(), anyLong(), anyLong(), any()))
+                .thenReturn(new java.util.concurrent.CompletableFuture<>());
+
+        engineSyncRunner.run();
+
+        ArgumentCaptor<Runnable> submittedTasks = ArgumentCaptor.forClass(Runnable.class);
+        verify(statusCheckExecutor, times(2)).submit(submittedTasks.capture());
+        submittedTasks.getAllValues().get(0).run();
+        verify(engineGrpcService).getWorkerStatusAsync(
+                "127.0.0.1", 8081, -1L, syncRequestTimeoutMs, RoleType.PREFILL);
+        WorkerStatus status = workerDirectory.statusSnapshot(RoleType.PREFILL)
+                .get("127.0.0.1:8080@0");
+        assertNotNull(status);
+        assertEquals(0, status.getEngineIndex());
+        assertEquals(1, status.getMultiEngineNum());
+    }
+
+    @Test
+    void discoversLogicalWorkerAndUsesItsIndexedStatusPort() {
+        WorkerHost host = new WorkerHost("127.0.0.1", 8080, 8081, 8085,
+                18082, "", "", "", 1, 2);
+        when(workerAddressService.getEngineWorkerList(modelName, RoleType.PREFILL))
+                .thenReturn(List.of(host));
+        when(engineGrpcService.getWorkerStatusAsync(any(), anyInt(), anyLong(), anyLong(), any()))
+                .thenReturn(new java.util.concurrent.CompletableFuture<>());
+
+        engineSyncRunner.run();
+
+        WorkerStatus status = workerDirectory.statusSnapshot(RoleType.PREFILL)
+                .get("127.0.0.1:8080@1");
+        assertNotNull(status);
+        assertEquals(1, status.getEngineIndex());
+        assertEquals(2, status.getMultiEngineNum());
+        ArgumentCaptor<Runnable> submittedTasks = ArgumentCaptor.forClass(Runnable.class);
+        verify(statusCheckExecutor, times(2)).submit(submittedTasks.capture());
+        submittedTasks.getAllValues().get(0).run();
+        verify(engineGrpcService).getWorkerStatusAsync(
+                "127.0.0.1", 18082, -1L, syncRequestTimeoutMs, RoleType.PREFILL);
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunnerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunnerTest.java
@@ -39,10 +39,10 @@ class GrpcCacheStatusCheckRunnerTest {
     void testGrpcCacheStatusCheckRunner() {
         // Arrange
         String modelName = "test-model";
-        String ipPort = "127.0.0.1:8080";
         String site = "test-site";
 
         WorkerStatus workerStatus = workerStatus();
+        String ipPort = workerStatus.getLogicalIpPort();
         WorkerDirectory directory = directory(workerStatus);
 
         EngineRpcService.CacheStatusPB cacheStatusPB = EngineRpcService.CacheStatusPB.newBuilder()
@@ -76,8 +76,8 @@ class GrpcCacheStatusCheckRunnerTest {
 
     @Test
     void staleGenerationCallbackCannotPublishAddressCache() {
-        String ipPort = "127.0.0.1:8080";
         WorkerStatus oldStatus = workerStatus();
+        String ipPort = oldStatus.getLogicalIpPort();
         WorkerDirectory directory = Mockito.mock(WorkerDirectory.class);
         when(directory.isCurrentStatus(
                 RoleType.PREFILL, ipPort, oldStatus)).thenReturn(false);
@@ -116,7 +116,7 @@ class GrpcCacheStatusCheckRunnerTest {
         WorkerDirectory directory = new WorkerDirectory(
                 Mockito.mock(EndpointRegistry.class));
         directory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
         return directory;
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcWorkerStatusRunnerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcWorkerStatusRunnerTest.java
@@ -29,10 +29,10 @@ class GrpcWorkerStatusRunnerTest {
 
     @Test
     void newGenerationProjectionRunsOutsideWorkerStatusLock() {
-        String ipPort = "127.0.0.1:8080";
         WorkerStatus status = RunnerTestSupport.discovered(
                 RoleType.DECODE, null, "127.0.0.1",
                 8080, 8081, "test-site");
+        String ipPort = status.getLogicalIpPort();
         WorkerStatus.PollLease pollLease = status.tryBeginStatusPoll();
         assertNotNull(pollLease);
 
@@ -83,10 +83,10 @@ class GrpcWorkerStatusRunnerTest {
 
     @Test
     void sameVersionResponseProjectsExactEndpointActivity() {
-        String ipPort = "127.0.0.1:8080";
         WorkerStatus status = RunnerTestSupport.alive(
                 RoleType.DECODE, null, "127.0.0.1",
                 8080, 8081, "test-site");
+        String ipPort = status.getLogicalIpPort();
         WorkerStatus.PollLease pollLease = status.tryBeginStatusPoll();
         assertNotNull(pollLease);
 
@@ -141,7 +141,7 @@ class GrpcWorkerStatusRunnerTest {
             EndpointRegistry registry, WorkerStatus status) {
         WorkerDirectory directory = new WorkerDirectory(registry);
         directory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
         return directory;
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/schedule/ExpirationCleanerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/schedule/ExpirationCleanerTest.java
@@ -33,9 +33,9 @@ class ExpirationCleanerTest {
         WorkerStatus second = status("127.0.0.2", 8080);
         WorkerDirectory directory = new WorkerDirectory(registry);
         directory.currentOrDiscover(
-                RoleType.PREFILL, first.getIpPort(), () -> first);
+                RoleType.PREFILL, first.getLogicalIpPort(), () -> first);
         directory.currentOrDiscover(
-                RoleType.PREFILL, second.getIpPort(), () -> second);
+                RoleType.PREFILL, second.getLogicalIpPort(), () -> second);
 
         EndpointRegistry.DetachedGeneration firstDetached =
                 mock(EndpointRegistry.DetachedGeneration.class);
@@ -74,8 +74,8 @@ class ExpirationCleanerTest {
             releaseFirstAwait.countDown();
             cleaning.get(5, TimeUnit.SECONDS);
             assertTrue(directory.statusSnapshot(RoleType.PREFILL).isEmpty());
-            verify(cache).removeEngineBlockCache(first.getIpPort());
-            verify(cache).removeEngineBlockCache(second.getIpPort());
+            verify(cache).removeEngineBlockCache(first.getLogicalIpPort());
+            verify(cache).removeEngineBlockCache(second.getLogicalIpPort());
         } finally {
             releaseFirstAwait.countDown();
             executor.shutdownNow();
@@ -88,11 +88,11 @@ class ExpirationCleanerTest {
             WorkerEndpoint endpoint,
             EndpointRegistry.DetachedGeneration detached) {
         when(registry.get(
-                RoleType.PREFILL, status.getIpPort(), status))
+                RoleType.PREFILL, status.getLogicalIpPort(), status))
                 .thenReturn(endpoint);
         when(detached.ownsEndpoint(endpoint)).thenReturn(true);
         when(registry.detachAndBeginRetirement(
-                RoleType.PREFILL, status.getIpPort(), status))
+                RoleType.PREFILL, status.getLogicalIpPort(), status))
                 .thenAnswer(invocation -> {
                     status.beginRetirementAfterEndpointGateClosed();
                     return detached;

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/status/WorkerDirectoryTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/status/WorkerDirectoryTest.java
@@ -41,9 +41,9 @@ class WorkerDirectoryTest {
         WorkerStatus matching = status(RoleType.DECODE, "group1", 8080);
         WorkerStatus filtered = status(RoleType.DECODE, "group2", 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, matching.getIpPort(), matching);
+                RoleType.DECODE, matching.getLogicalIpPort(), matching);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, filtered.getIpPort(), filtered);
+                RoleType.DECODE, filtered.getLogicalIpPort(), filtered);
 
         List<WorkerEndpoint.GenerationPin> result =
                 workerDirectory.captureEndpoints(
@@ -51,7 +51,7 @@ class WorkerDirectoryTest {
         try {
             assertEquals(1, result.size());
             assertSame(matching, result.getFirst().endpoint().getStatus());
-            assertEquals(matching.getIpPort(),
+            assertEquals(matching.getLogicalIpPort(),
                     result.getFirst().endpoint().ipPort());
         } finally {
             closePins(result);
@@ -63,9 +63,9 @@ class WorkerDirectoryTest {
         WorkerStatus first = status(RoleType.PREFILL, "group1", 8080);
         WorkerStatus second = status(RoleType.PREFILL, "group2", 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.PREFILL, first.getIpPort(), first);
+                RoleType.PREFILL, first.getLogicalIpPort(), first);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.PREFILL, second.getIpPort(), second);
+                RoleType.PREFILL, second.getLogicalIpPort(), second);
 
         List<WorkerEndpoint.GenerationPin> result =
                 workerDirectory.captureEndpoints(
@@ -95,14 +95,14 @@ class WorkerDirectoryTest {
     void should_close_filtered_pins_when_no_group_matches() {
         WorkerStatus status = status(RoleType.VIT, "group1", 8080);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.VIT, status.getIpPort(), status);
+                RoleType.VIT, status.getLogicalIpPort(), status);
 
         List<WorkerEndpoint.GenerationPin> result =
                 workerDirectory.captureEndpoints(
                         RoleType.VIT, "nonExistentGroup");
 
         assertTrue(result.isEmpty());
-        assertEquals(List.of(status.getIpPort()),
+        assertEquals(List.of(status.getLogicalIpPort()),
                 workerDirectory.endpointAddresses(
                         RoleType.VIT, null));
     }
@@ -112,15 +112,15 @@ class WorkerDirectoryTest {
         WorkerStatus matching = status(RoleType.DECODE, "groupA", 8080);
         WorkerStatus ungrouped = status(RoleType.DECODE, null, 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, matching.getIpPort(), matching);
+                RoleType.DECODE, matching.getLogicalIpPort(), matching);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, ungrouped.getIpPort(), ungrouped);
+                RoleType.DECODE, ungrouped.getLogicalIpPort(), ungrouped);
 
         List<String> result = workerDirectory.endpointAddresses(
                 RoleType.DECODE, "groupA");
 
-        assertEquals(List.of(matching.getIpPort()), result);
-        assertFalse(result.contains(ungrouped.getIpPort()));
+        assertEquals(List.of(matching.getLogicalIpPort()), result);
+        assertFalse(result.contains(ungrouped.getLogicalIpPort()));
     }
 
     @Test
@@ -128,16 +128,16 @@ class WorkerDirectoryTest {
         WorkerStatus grouped = status(RoleType.DECODE, "groupA", 8080);
         WorkerStatus ungrouped = status(RoleType.DECODE, null, 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, grouped.getIpPort(), grouped);
+                RoleType.DECODE, grouped.getLogicalIpPort(), grouped);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, ungrouped.getIpPort(), ungrouped);
+                RoleType.DECODE, ungrouped.getLogicalIpPort(), ungrouped);
 
         List<String> result = workerDirectory.endpointAddresses(
                 RoleType.DECODE, null);
 
         assertEquals(2, result.size());
-        assertTrue(result.contains(grouped.getIpPort()));
-        assertTrue(result.contains(ungrouped.getIpPort()));
+        assertTrue(result.contains(grouped.getLogicalIpPort()));
+        assertTrue(result.contains(ungrouped.getLogicalIpPort()));
     }
 
     @Test
@@ -147,11 +147,11 @@ class WorkerDirectoryTest {
         discover(matching);
         discover(filtered);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, matching.getIpPort(), matching);
+                RoleType.DECODE, matching.getLogicalIpPort(), matching);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, filtered.getIpPort(), filtered);
+                RoleType.DECODE, filtered.getLogicalIpPort(), filtered);
 
-        assertEquals(List.of(matching.getIpPort()),
+        assertEquals(List.of(matching.getLogicalIpPort()),
                 workerDirectory.endpointAddresses(
                         RoleType.DECODE, "group1"));
         assertEquals(2,
@@ -164,10 +164,52 @@ class WorkerDirectoryTest {
         assertRoleEndpoint(RoleType.VIT, 8102);
     }
 
+    @Test
+    void storesSiblingEnginesUnderTheirDistinctLogicalAddresses() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 1, 2);
+
+        workerDirectory.currentOrDiscover(
+                RoleType.PREFILL, first.getLogicalIpPort(), () -> first);
+        workerDirectory.currentOrDiscover(
+                RoleType.PREFILL, second.getLogicalIpPort(), () -> second);
+
+        Map<String, WorkerStatus> statuses =
+                workerDirectory.statusSnapshot(RoleType.PREFILL);
+        assertEquals(2, statuses.size());
+        assertSame(first, statuses.get("127.0.0.1:8080@0"));
+        assertSame(second, statuses.get("127.0.0.1:8080@1"));
+    }
+
+    @Test
+    void excludesEverySiblingWhenOneLogicalEngineIsNotAlive() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 1, 2);
+        discover(first);
+        discover(second);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, first.getLogicalIpPort(), first);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, second.getLogicalIpPort(), second);
+        RunnerTestSupport.publish(second,
+                RunnerTestSupport.response(second, false, 2L));
+
+        assertTrue(workerDirectory.prefillRoutingSnapshot(RoleType.PREFILL)
+                .isEmpty());
+    }
+
     private void assertRoleEndpoint(RoleType role, int port) {
         WorkerStatus status = status(role, null, port);
         WorkerEndpoint registered = RunnerTestSupport.publishEndpoint(registry,
-                role, status.getIpPort(), status);
+                role, status.getLogicalIpPort(), status);
 
         List<WorkerEndpoint.GenerationPin> selected =
                 workerDirectory.captureEndpoints(role, null);
@@ -200,9 +242,9 @@ class WorkerDirectoryTest {
         discover(decode);
 
         assertSame(prefill, workerDirectory.statusSnapshot(RoleType.PREFILL)
-                .get(prefill.getIpPort()));
+                .get(prefill.getLogicalIpPort()));
         assertSame(decode, workerDirectory.statusSnapshot(RoleType.DECODE)
-                .get(decode.getIpPort()));
+                .get(decode.getLogicalIpPort()));
         assertEquals(2, workerDirectory.discoveredCount());
         assertEquals(1, workerDirectory.discoveredCount(RoleType.PREFILL));
     }
@@ -212,7 +254,7 @@ class WorkerDirectoryTest {
         WorkerStatus status = status(RoleType.VIT, "group", 8080);
         discover(status);
 
-        assertEquals(Map.of(status.getIpPort(), status),
+        assertEquals(Map.of(status.getLogicalIpPort(), status),
                 workerDirectory.statusSnapshot(RoleType.VIT));
         assertThrows(UnsupportedOperationException.class,
                 () -> workerDirectory.statusSnapshot(RoleType.VIT).clear());
@@ -238,6 +280,6 @@ class WorkerDirectoryTest {
 
     private void discover(WorkerStatus status) {
         assertSame(status, workerDirectory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status));
+                status.getRole(), status.getLogicalIpPort(), () -> status));
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/status/WorkerDirectoryTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/status/WorkerDirectoryTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -204,6 +205,41 @@ class WorkerDirectoryTest {
 
         assertTrue(workerDirectory.prefillRoutingSnapshot(RoleType.PREFILL)
                 .isEmpty());
+    }
+
+    @Test
+    void physicalGroupHealthUsesEndpointAndGroupOwnership() {
+        WorkerStatus completeFirst = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-a", "127.0.0.1", 8080, 8081,
+                "site", null, 0, 2, "endpoint-a|group-a|127.0.0.1:8080");
+        WorkerStatus completeSecond = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-a", "127.0.0.1", 8080, 8081,
+                "site", null, 1, 2, "endpoint-a|group-a|127.0.0.1:8080");
+        WorkerStatus incompleteSibling = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-b", "127.0.0.1", 8080, 8081,
+                "site", null, 2, 3, "endpoint-b|group-b|127.0.0.1:8080");
+        discover(completeFirst);
+        discover(completeSecond);
+        discover(incompleteSibling);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, completeFirst.getLogicalIpPort(),
+                completeFirst);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, completeSecond.getLogicalIpPort(),
+                completeSecond);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, incompleteSibling.getLogicalIpPort(),
+                incompleteSibling);
+
+        List<String> routable = workerDirectory.endpointAddresses(
+                RoleType.PREFILL, "group-a");
+
+        assertEquals(2, routable.size());
+        assertEquals(Set.of(
+                completeFirst.getLogicalIpPort(),
+                completeSecond.getLogicalIpPort()), Set.copyOf(routable));
+        assertTrue(workerDirectory.endpointAddresses(
+                RoleType.PREFILL, "group-b").isEmpty());
     }
 
     private void assertRoleEndpoint(RoleType role, int port) {


### PR DESCRIPTION
## Summary
- migrate logical multi-engine worker identity and N>1 status-port routing
- retain RTP-LLM single-engine compatibility: internal `ip:port@0`, legacy status gRPC port, no `engine_index` on the schedule wire
- report per-engine metrics with logical `ip:port@index`; keep flexlb-mock-engine physical `ip:port` fixtures unchanged

## Validation
- `./mvnw test -Pinternal -pl flexlb-sync,flexlb-cache,flexlb-api -am -Dtest=DecodeEndpointTest,PrefillEndpointTest,CostBasedPrefillSelectionMetricTest,EngineHealthReporterTest,EngineHealthReporterSelectionMetricTest,LocalSyncCacheMatchProviderTest,CacheMetricsReporterTest,WorkerStatusSyncTest,FlexlbScheduleEngineIndexTest,FileDiscoveryDynamicScaleEndToEndTest -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw spotless:check -Pspotless-check -Pinternal`

## Known unrelated test instability
- full-suite teardown can block in `TransientCapacityQueueContractTest`
- mock-engine has an existing deadline timeout / HTTP GET hang in unrelated E2E tests