### PR TITLE
feat(cp): support context parallelism for Qwen3.5 hybrid prefill

### DIFF
--- a/rtp_llm/config/quant_config.py
+++ b/rtp_llm/config/quant_config.py
@@ -229,6 +229,51 @@ class QuantizationConfig(ABC):
             weight_type = weights_config.get("type")
             weight_strategy = weights_config.get("strategy")
             weight_dynamic = weights_config.get("dynamic", False)
+            ignore_patterns = quant_config.get("ignore") or []
+            if (
+                weight_type == "float"
+                and bits == 8
+                and weight_strategy == "block"
+            ):
+                _validate_compressed_targets(group_name, group_config)
+                block_structure = weights_config.get("block_structure")
+                if block_structure != [128, 128]:
+                    raise ValueError(
+                        "compressed-tensors FP8 block weights require the backend "
+                        "supported block_structure [128, 128], "
+                        f"got {block_structure}"
+                    )
+                if weight_dynamic or not weights_config.get("symmetric", True):
+                    raise ValueError(
+                        "compressed-tensors FP8 block weights must be static and "
+                        f"symmetric, got {weights_config}"
+                    )
+                if not (
+                    isinstance(activation_config, dict)
+                    and activation_config.get("type") == "float"
+                    and activation_config.get("num_bits") == 8
+                    and activation_config.get("strategy") == "group"
+                    and activation_config.get("group_size") == 128
+                    and activation_config.get("dynamic", False)
+                    and activation_config.get("symmetric", True)
+                ):
+                    raise ValueError(
+                        "compressed-tensors FP8 block input activations require "
+                        "dynamic symmetric 8-bit float group quantization with "
+                        f"group_size 128, got {activation_config}"
+                    )
+                return Fp8BlockWiseQuantConfig.from_config(
+                    {
+                        "bits": bits,
+                        "method": Fp8BlockWiseQuantConfig.get_method(),
+                        "group_size": block_structure[0],
+                        "is_quanted": True,
+                        "weight_scale_suffix": weights_config.get(
+                            "weight_scale_suffix", ".weight_scale"
+                        ),
+                        "ignore_patterns": ignore_patterns,
+                    }
+                )
             if (
                 weight_type == "float"
                 and bits == 8
@@ -494,6 +539,8 @@ class Fp8BlockWiseQuantConfig(QuantizationConfig):
         **kwargs: Any,
     ):
         super().__init__(bits=bits, group_size=group_size, is_quanted=is_quanted)
+        self.weight_scale_suffix = kwargs.get("weight_scale_suffix", ".weight_scale_inv")
+        self.exclude_modules = set(kwargs.get("ignore_patterns", []))
 
     @classmethod
     def get_method(cls) -> str:

--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -428,6 +428,27 @@ def setup_default_args(py_env_configs):
     if py_env_configs.kv_cache_config.seq_size_per_block == 0:
         py_env_configs.kv_cache_config.seq_size_per_block = 64
 
+    if py_env_configs.prefill_cp_config.is_enabled():
+        from rtp_llm.model_factory import ModelFactory
+
+        model_cls = ModelFactory.get_model_cls(py_env_configs.model_args.model_type)
+        alignment = model_cls.prefill_cp_alignment()
+        source_config = py_env_configs.prefill_cp_config
+        target_config = py_env_configs.parallelism_config.prefill_cp_config
+        if not hasattr(source_config, "segment_size_alignment") or not hasattr(
+            target_config, "segment_size_alignment"
+        ):
+            raise RuntimeError(
+                "The ops binding must be rebuilt before context parallelism is enabled"
+            )
+        source_config.segment_size_alignment = alignment
+        target_config.segment_size_alignment = alignment
+        block_size = py_env_configs.kv_cache_config.seq_size_per_block
+        if block_size % alignment != 0:
+            raise ValueError(
+                f"KV cache block size {block_size} must be divisible by CP alignment {alignment}"
+            )
+
     # Set NCCL_P2P_DISABLE for RTX GPUs or when CUDA is not available
     # Frontend doesn't need this setting
     if py_env_configs.role_config.role_type != RoleType.FRONTEND:

--- a/rtp_llm/config/test/server_config_setup_test.py
+++ b/rtp_llm/config/test/server_config_setup_test.py
@@ -11,7 +11,9 @@ from rtp_llm.config.py_config_modules import PyEnvConfigs, ServerConfig
 from rtp_llm.config.server_config_setup import (
     set_parallelism_config,
     setup_and_configure_server,
+    setup_default_args,
 )
+from rtp_llm.models.qwen3_next.qwen3_next import Qwen3NextBase
 from rtp_llm.ops import CPRotateMethod, KvCacheDataType, NcclCommConfig, RoleType
 from rtp_llm.server.server_args.server_args import setup_args
 
@@ -318,6 +320,27 @@ class GenerateConfigTest(TestCase):
         self.assertEqual(
             py_env_configs.parallelism_config.prefill_cp_config.prefill_cp_size, 4
         )
+
+    def test_prefill_cp_alignment_setup_and_block_validation(self):
+        self.assertEqual(PyEnvConfigs().prefill_cp_config.segment_size_alignment, 1)
+        self.assertEqual(Qwen3NextBase.prefill_cp_alignment(), 64)
+
+        with patch(
+            "rtp_llm.model_factory.ModelFactory.get_model_cls",
+            return_value=Qwen3NextBase,
+        ):
+            config = PyEnvConfigs()
+            config.model_args.model_type = "aligned_model"
+            config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+            setup_default_args(config)
+            self.assertEqual(config.prefill_cp_config.segment_size_alignment, 64)
+            self.assertEqual(
+                config.parallelism_config.prefill_cp_config.segment_size_alignment, 64
+            )
+
+            config.kv_cache_config.seq_size_per_block = 96
+            with self.assertRaisesRegex(ValueError, "must be divisible"):
+                setup_default_args(config)
 
     @patch.dict(
         "os.environ",

--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -45,7 +45,8 @@ std::string PrefillCPConfig::to_string() const {
     }
     oss << "\n comm_buffer_size: " << comm_buffer_size << "\n"
         << " kv_cache_sharded: " << kv_cache_sharded << "\n"
-        << " prefill_cp_size: " << prefill_cp_size << "\n";
+        << " prefill_cp_size: " << prefill_cp_size << "\n"
+        << " segment_size_alignment: " << segment_size_alignment << "\n";
     return oss.str();
 }
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -35,7 +35,8 @@ struct PrefillCPConfig {
     bool kv_cache_sharded = false;
     // Explicit prefill CP size for decode-side fixed/SWA ring sizing; 0 = unset.
     int64_t prefill_cp_size = 0;
-    bool    is_enabled() const {
+    size_t segment_size_alignment = 1;
+    bool   is_enabled() const {
         return method != CPRotateMethod::DISABLED && method != CPRotateMethod::UNKNOWN
                && method != CPRotateMethod::PREFILL_CP;
     }

--- a/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.cc
@@ -33,7 +33,8 @@ FIFOScheduler::FIFOScheduler(const RuntimeConfig&                   runtime_conf
         std::max<int64_t>(runtime_config.fifo_scheduler_config.max_batch_tokens_without_cache, 0))),
     prefill_cp_size_(parallelism_config.prefill_cp_config.is_enabled() ?
                          static_cast<size_t>(std::max<int64_t>(parallelism_config.tp_size, 1)) :
-                         1) {
+                         1),
+    prefill_cp_segment_alignment_(parallelism_config.prefill_cp_config.segment_size_alignment) {
     RTP_LLM_LOG_INFO("max_generate_batch_size is [%zu], max_batch_tokens_size is [%zu], "
                      "max_batch_tokens_without_cache is [%zu], cp_force_single_prefill is [%d], "
                      "prefill_cp_size is [%zu], max_inited_kv_cache_streams is [%zu]",
@@ -239,7 +240,8 @@ size_t FIFOScheduler::prefillTokenCostWithoutCache(const GenerateStreamPtr& stre
     // Match the token count that CP presents to the model after per-sequence padding.
     auto token_count = static_cast<size_t>(std::max(stream->contextLength(), 0));
     if (prefill_cp_size_ > 1) {
-        token_count = makeZigzagTokenLayout(token_count, prefill_cp_size_).padded_token_count;
+        token_count =
+            makeZigzagTokenLayout(token_count, prefill_cp_size_, prefill_cp_segment_alignment_).padded_token_count;
     }
     return token_count * static_cast<size_t>(stream->currentBatchSize());
 }

--- a/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.h
+++ b/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.h
@@ -125,6 +125,7 @@ private:
     // excluded). 0 disables it.
     const size_t max_batch_tokens_without_cache_ = 0;
     const size_t prefill_cp_size_                = 1;
+    const size_t prefill_cp_segment_alignment_   = 1;
 
     // Consumed (exchanged to 0) from the const fillExtraMetrics() reporting hook.
     mutable std::atomic<int64_t> pending_group_fallback_count_ = 0;

--- a/rtp_llm/cpp/models/context_parallel/ContextParallelProcessorBase.cc
+++ b/rtp_llm/cpp/models/context_parallel/ContextParallelProcessorBase.cc
@@ -290,7 +290,8 @@ void IContextParallelProcessor::handleInputs(GptModelInputs&                    
     for (size_t p = 0; p < num_prefill_stream; ++p) {
         int num_prefill_token = input_lengths.data_ptr<int32_t>()[num_decode_stream + p];
 
-        const auto token_layout = makeZigzagTokenLayout(num_prefill_token, prefill_cp_size);
+        const auto token_layout = makeZigzagTokenLayout(
+            num_prefill_token, prefill_cp_size, parallelism_config_.prefill_cp_config.segment_size_alignment);
 
         prefill_cp_split_tokens_size += token_layout.token_count_per_rank;
         padding_lengths[p] = token_layout.padding_token_count;

--- a/rtp_llm/cpp/models/context_parallel/ZigzagTokenLayout.cc
+++ b/rtp_llm/cpp/models/context_parallel/ZigzagTokenLayout.cc
@@ -1,16 +1,24 @@
 #include "rtp_llm/cpp/models/context_parallel/ZigzagTokenLayout.h"
 
+#include <limits>
 #include <stdexcept>
 
 namespace rtp_llm {
 
-ZigzagTokenLayout makeZigzagTokenLayout(size_t token_count, size_t cp_size) {
-    if (cp_size == 0) {
-        throw std::invalid_argument("Zigzag cp_size must be positive");
+ZigzagTokenLayout makeZigzagTokenLayout(size_t token_count, size_t cp_size, size_t segment_size_alignment) {
+    if (cp_size == 0 || segment_size_alignment == 0) {
+        throw std::invalid_argument("Zigzag size and alignment must be positive");
     }
 
-    const size_t alignment          = 2 * cp_size;
-    const size_t padded_token_count = (token_count + alignment - 1) / alignment * alignment;
+    if (cp_size > std::numeric_limits<size_t>::max() / 2 / segment_size_alignment) {
+        throw std::overflow_error("Zigzag alignment exceeds size_t range");
+    }
+    const size_t alignment = 2 * cp_size * segment_size_alignment;
+    const size_t remainder = token_count % alignment;
+    if (remainder != 0 && token_count > std::numeric_limits<size_t>::max() - (alignment - remainder)) {
+        throw std::overflow_error("Zigzag padded token count exceeds size_t range");
+    }
+    const size_t padded_token_count = remainder == 0 ? token_count : token_count + alignment - remainder;
     return {
         padded_token_count,
         padded_token_count - token_count,

--- a/rtp_llm/cpp/models/context_parallel/ZigzagTokenLayout.h
+++ b/rtp_llm/cpp/models/context_parallel/ZigzagTokenLayout.h
@@ -11,7 +11,7 @@ struct ZigzagTokenLayout {
 };
 
 // Zigzag context parallelism pads every sequence independently to a multiple
-// of 2 * cp_size so each rank receives two equally sized chunks.
-ZigzagTokenLayout makeZigzagTokenLayout(size_t token_count, size_t cp_size);
+// of 2 * cp_size * segment_size_alignment.
+ZigzagTokenLayout makeZigzagTokenLayout(size_t token_count, size_t cp_size, size_t segment_size_alignment = 1);
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/models/context_parallel/test/ZigzagTokenLayoutTest.cc
+++ b/rtp_llm/cpp/models/context_parallel/test/ZigzagTokenLayoutTest.cc
@@ -1,5 +1,6 @@
 #include "rtp_llm/cpp/models/context_parallel/ZigzagTokenLayout.h"
 
+#include <limits>
 #include <stdexcept>
 
 #include "gtest/gtest.h"
@@ -27,6 +28,23 @@ TEST(ZigzagTokenLayoutTest, ComputesPaddingAndPerRankTokens) {
 
 TEST(ZigzagTokenLayoutTest, RejectsZeroCpSize) {
     EXPECT_THROW(makeZigzagTokenLayout(1, 0), std::invalid_argument);
+}
+
+TEST(ZigzagTokenLayoutTest, AlignsEverySegment) {
+    const auto layout = makeZigzagTokenLayout(257, 2, 64);
+    EXPECT_EQ(layout.padded_token_count, 512);
+    EXPECT_EQ(layout.token_count_per_rank, 256);
+    EXPECT_THROW(makeZigzagTokenLayout(1, 2, 0), std::invalid_argument);
+}
+
+TEST(ZigzagTokenLayoutTest, ChecksSizeTBoundaries) {
+    const auto max = std::numeric_limits<size_t>::max();
+    EXPECT_THROW(makeZigzagTokenLayout(1, max), std::overflow_error);
+    EXPECT_THROW(makeZigzagTokenLayout(max, 4), std::overflow_error);
+
+    const auto largest_aligned = max - max % 8;
+    EXPECT_EQ(makeZigzagTokenLayout(largest_aligned, 4).padded_token_count,
+              largest_aligned);
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -2122,23 +2122,33 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("comm_buffer_size", &PrefillCPConfig::comm_buffer_size)
         .def_readwrite("kv_cache_sharded", &PrefillCPConfig::kv_cache_sharded)
         .def_readwrite("prefill_cp_size", &PrefillCPConfig::prefill_cp_size)
+        .def_readwrite("segment_size_alignment", &PrefillCPConfig::segment_size_alignment)
         .def("to_string", &PrefillCPConfig::to_string)
         .def("is_enabled", &PrefillCPConfig::is_enabled)
         .def("is_prefill_enabled", &PrefillCPConfig::is_prefill_enabled)
         .def(py::pickle(
             [](const PrefillCPConfig& self) {
-                return py::make_tuple(self.method, self.comm_buffer_size, self.kv_cache_sharded, self.prefill_cp_size);
+                return py::make_tuple(self.method,
+                                      self.comm_buffer_size,
+                                      self.kv_cache_sharded,
+                                      self.prefill_cp_size,
+                                      self.segment_size_alignment);
             },
             [](py::tuple t) {
-                if (t.size() != 2 && t.size() != 4)
+                if (t.size() < 2 || t.size() > 5)
                     throw std::runtime_error("Invalid state!");
                 PrefillCPConfig c;
                 try {
                     c.method           = t[0].cast<CPRotateMethod>();
                     c.comm_buffer_size = t[1].cast<size_t>();
-                    if (t.size() >= 4) {
+                    if (t.size() >= 3) {
                         c.kv_cache_sharded = t[2].cast<bool>();
+                    }
+                    if (t.size() >= 4) {
                         c.prefill_cp_size  = t[3].cast<int64_t>();
+                    }
+                    if (t.size() == 5) {
+                        c.segment_size_alignment = t[4].cast<size_t>();
                     }
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("PrefillCPConfig unpickle error: ") + e.what());

--- a/rtp_llm/cpp/pybind/config_pickle_test.py
+++ b/rtp_llm/cpp/pybind/config_pickle_test.py
@@ -1,7 +1,7 @@
 import pickle
 import unittest
 
-from rtp_llm.ops import GrammarConfig
+from rtp_llm.ops import CPRotateMethod, GrammarConfig, PrefillCPConfig
 
 
 def _new_grammar_config():
@@ -82,6 +82,51 @@ class GrammarConfigPickleTest(unittest.TestCase):
             ):
                 config = _new_grammar_config()
                 config.__setstate__(state)
+
+
+class PrefillCPConfigPickleTest(unittest.TestCase):
+    def test_current_format_round_trip(self):
+        config = PrefillCPConfig()
+        expected = {
+            "method": CPRotateMethod.ALL_GATHER,
+            "comm_buffer_size": 1024,
+            "kv_cache_sharded": True,
+            "prefill_cp_size": 4,
+            "segment_size_alignment": 64,
+        }
+        for name, value in expected.items():
+            setattr(config, name, value)
+
+        restored = pickle.loads(pickle.dumps(config))
+        for name, value in expected.items():
+            self.assertEqual(getattr(restored, name), value)
+
+    def test_legacy_states_are_loaded(self):
+        for state in (
+            (CPRotateMethod.ALLTOALL, 128),
+            (CPRotateMethod.ALLTOALL, 192, True),
+            (CPRotateMethod.ALL_GATHER, 256, True, 2),
+        ):
+            with self.subTest(state=state):
+                restored = PrefillCPConfig.__new__(PrefillCPConfig)
+                restored.__setstate__(state)
+                expected = (
+                    state[0],
+                    state[1],
+                    state[2] if len(state) >= 3 else False,
+                    state[3] if len(state) >= 4 else 0,
+                    1,
+                )
+                self.assertEqual(
+                    (
+                        restored.method,
+                        restored.comm_buffer_size,
+                        restored.kv_cache_sharded,
+                        restored.prefill_cp_size,
+                        restored.segment_size_alignment,
+                    ),
+                    expected,
+                )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/model_loader/per_block_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_block_fp8_quant_weight.py
@@ -12,6 +12,9 @@ from rtp_llm.model_loader.linear_attn_weight import (
     W8A8Fp8PerBlockLinearAttnAtomicWeight,
 )
 from rtp_llm.model_loader.load_config import LoadConfig
+from rtp_llm.model_loader.per_channel_fp8_quant_weight import (
+    _ckpt_base_matches_quant_exclude,
+)
 from rtp_llm.model_loader.tensor_source import TensorSource
 from rtp_llm.model_loader.weight_module import (
     AtomicWeight,
@@ -52,6 +55,45 @@ B_SUFFIX = ".bias"
 QW_SUFFIX = ".weight"
 QS_SUFFIX = ".weight_scale_inv"
 APPEND_SUFFIX = "_scale_inv"
+
+
+def _is_whole_weight_excluded(
+    src_weight_info: WeightModule, exclude_modules: set
+) -> bool:
+    """Return true only when an exclusion safely covers the whole weight."""
+    if not exclude_modules or not src_weight_info.weights:
+        return False
+
+    matches = []
+    for ckpt_weight in src_weight_info.weights:
+        base_name = ckpt_weight.name.rsplit(".", 1)[0]
+        matched = _ckpt_base_matches_quant_exclude(base_name, exclude_modules)
+        if matched and "{i}" in base_name and base_name not in exclude_modules:
+            raise ValueError(
+                "FP8 per-block loading cannot represent a partial per-layer "
+                f"quantization exclusion for {base_name}; exclude the whole "
+                "weight template or use a uniformly quantized checkpoint"
+            )
+        matches.append(matched)
+
+    if any(matches) and not all(matches):
+        matched_names = [
+            weight.name
+            for weight, matched in zip(src_weight_info.weights, matches)
+            if matched
+        ]
+        raise ValueError(
+            "FP8 per-block loading cannot mix quantized and unquantized tensors "
+            f"inside fused weight {src_weight_info.name}; matched exclusions: "
+            f"{matched_names}"
+        )
+    return bool(matches) and all(matches)
+
+
+def _rewrite_scale_suffix(weight: WeightModule, scale_suffix: str) -> None:
+    for ckpt_weight in getattr(weight, "weights", ()):
+        if ckpt_weight.name.endswith(QS_SUFFIX):
+            ckpt_weight.name = ckpt_weight.name[: -len(QS_SUFFIX)] + scale_suffix
 
 
 def dequant_weight_split_k(
@@ -119,7 +161,9 @@ def per_block_cast_to_fp8(
     )
     x_amax = x_view.abs().float().amax(dim=(2, 4), keepdim=True).clamp(1e-4)
     x_scaled = (x_view * (FP8_E4M3_MAX / x_amax)).to(torch.float8_e4m3fn)
-    x_quantized = x_scaled.view(b, m_padded, n_padded)[:, :m, :n]
+    # x_view only partitions dimensions; reshape restores the padded row-major matrix.
+    x_quantized_padded = x_scaled.reshape(b, m_padded, n_padded)
+    x_quantized = x_quantized_padded[:, :m, :n]
     scales = (x_amax / FP8_E4M3_MAX).to(torch.float32)
     squeeze_dims = []
 
@@ -284,6 +328,8 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
         # registry's "must be exactly one match" check passes.
         if is_v4_weight(src_weight_info):
             return False
+        if _is_whole_weight_excluded(src_weight_info, quant_config.exclude_modules):
+            return False
         return True
 
     def __init__(
@@ -352,6 +398,12 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
             )
         else:
             raise ValueError(f"Unsupported weight name {src_weight_info.name}")
+
+        scale_suffix = getattr(quant_config, "weight_scale_suffix", QS_SUFFIX)
+        if scale_suffix != QS_SUFFIX:
+            _rewrite_scale_suffix(kernel, scale_suffix)
+            if scale is not None:
+                _rewrite_scale_suffix(scale, scale_suffix)
 
         sub_weights = {kernel.name: kernel}
         if scale is not None:
@@ -863,7 +915,11 @@ class LoadQuantPerBlockFp8Weight(PerBlockFp8Weight):
         ):
             return False
         name = src_weight_info.name
-        return name in cls.w8a8_weight_list and name not in [W.mla_kc, W.mla_vc]
+        if name not in cls.w8a8_weight_list or name in [W.mla_kc, W.mla_vc]:
+            return False
+        if _is_whole_weight_excluded(src_weight_info, quant_config.exclude_modules):
+            return False
+        return True
 
     def __init__(
         self,

--- a/rtp_llm/model_loader/test/BUILD
+++ b/rtp_llm/model_loader/test/BUILD
@@ -38,6 +38,12 @@ py_test(
 )
 
 py_test(
+    name = "test_per_block_fp8_weight",
+    srcs = ["test_per_block_fp8_weight.py"],
+    deps = py_test_deps,
+)
+
+py_test(
     name = "test_compressed_w8a8_int8_per_channel",
     srcs = ["test_compressed_w8a8_int8_per_channel.py"],
     deps = py_test_deps,

--- a/rtp_llm/model_loader/test/test_per_block_fp8_weight.py
+++ b/rtp_llm/model_loader/test/test_per_block_fp8_weight.py
@@ -1,0 +1,194 @@
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+from rtp_llm.config.quant_config import Fp8BlockWiseQuantConfig, QuantizationConfig
+from rtp_llm.model_loader.attn_weight import (
+    AttnAtomicWeight,
+    AttnConfig,
+    MlaAttnAtomicWeight,
+    MlaConfig,
+)
+from rtp_llm.model_loader.per_block_fp8_quant_weight import (
+    PerBlockFp8Weight,
+    per_block_cast_to_fp8,
+)
+from rtp_llm.utils.model_weight import FP8_E4M3_MAX, CkptWeightInfo, W
+
+
+def _compressed_fp8_config():
+    return {
+        "quant_method": "compressed-tensors",
+        "config_groups": {
+            "group_0": {
+                "weights": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "strategy": "block",
+                    "block_structure": [128, 128],
+                    "dynamic": False,
+                    "symmetric": True,
+                    "weight_scale_suffix": ".scale",
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "strategy": "group",
+                    "group_size": 128,
+                    "dynamic": True,
+                    "symmetric": True,
+                },
+                "targets": ["Linear"],
+            }
+        },
+        "ignore": ["lm_head"],
+    }
+
+
+class CompressedFp8BlockConfigTest(unittest.TestCase):
+    def _load(self, quantization_config):
+        with tempfile.TemporaryDirectory() as model_dir:
+            Path(model_dir, "config.json").write_text(
+                json.dumps({"quantization_config": quantization_config})
+            )
+            return QuantizationConfig.load_from_ckpt(model_dir)
+
+    def test_accepts_supported_schema(self):
+        config = self._load(_compressed_fp8_config())
+        self.assertIsInstance(config, Fp8BlockWiseQuantConfig)
+        self.assertEqual(config.group_size(), 128)
+        self.assertEqual(config.weight_scale_suffix, ".scale")
+        self.assertEqual(config.exclude_modules, {"lm_head"})
+
+    def test_rejects_unsupported_weight_schema(self):
+        cases = {
+            "small block": ("block_structure", [64, 64]),
+            "zero block": ("block_structure", [0, 0]),
+            "asymmetric block": ("block_structure", [128, 64]),
+            "dynamic weight": ("dynamic", True),
+            "asymmetric weight": ("symmetric", False),
+        }
+        for name, (field, value) in cases.items():
+            with self.subTest(name=name):
+                config = copy.deepcopy(_compressed_fp8_config())
+                config["config_groups"]["group_0"]["weights"][field] = value
+                with self.assertRaises(ValueError):
+                    self._load(config)
+
+    def test_rejects_unsupported_activation_schema(self):
+        cases = {
+            "missing activation": None,
+            "static activation": {"dynamic": False},
+            "wrong group size": {"group_size": 64},
+            "asymmetric activation": {"symmetric": False},
+        }
+        for name, override in cases.items():
+            with self.subTest(name=name):
+                config = copy.deepcopy(_compressed_fp8_config())
+                group = config["config_groups"]["group_0"]
+                if override is None:
+                    group["input_activations"] = None
+                else:
+                    group["input_activations"].update(override)
+                with self.assertRaises(ValueError):
+                    self._load(config)
+
+
+class PerBlockCastToFp8Test(unittest.TestCase):
+    def test_non_aligned_dimensions_preserve_layout(self):
+        block_size = 4
+        for shape in ((8, 7), (7, 8), (7, 6)):
+            with self.subTest(shape=shape):
+                weight = torch.arange(
+                    1, shape[0] * shape[1] + 1, dtype=torch.float32
+                ).reshape(shape)
+                actual, actual_scales = per_block_cast_to_fp8(weight, block_size)
+                for block_row, row in enumerate(range(0, shape[0], block_size)):
+                    for block_col, col in enumerate(range(0, shape[1], block_size)):
+                        tile = weight[row : row + block_size, col : col + block_size]
+                        amax = tile.abs().amax().clamp(1e-4)
+                        expected = (tile * (FP8_E4M3_MAX / amax)).to(
+                            torch.float8_e4m3fn
+                        )
+                        actual_tile = actual[
+                            row : row + block_size, col : col + block_size
+                        ]
+                        self.assertTrue(torch.equal(actual_tile, expected))
+                        self.assertEqual(
+                            actual_scales[block_row, block_col].item(),
+                            (amax / FP8_E4M3_MAX).item(),
+                        )
+
+
+class PerBlockFp8WeightDescriptorTest(unittest.TestCase):
+    @staticmethod
+    def _quant_config(**kwargs):
+        return Fp8BlockWiseQuantConfig(is_quanted=True, group_size=128, **kwargs)
+
+    @staticmethod
+    def _qkv_weight():
+        return AttnAtomicWeight(
+            name=W.attn_qkv_w,
+            weights=[
+                CkptWeightInfo("model.layers.{i}.self_attn.q_proj.weight"),
+                CkptWeightInfo("model.layers.{i}.self_attn.k_proj.weight"),
+                CkptWeightInfo("model.layers.{i}.self_attn.v_proj.weight"),
+            ],
+            config=AttnConfig(),
+        )
+
+    def test_rejects_concrete_layer_exclusion(self):
+        config = self._quant_config(ignore_patterns=["model.layers.7.self_attn.q_proj"])
+        with self.assertRaisesRegex(ValueError, "partial per-layer"):
+            PerBlockFp8Weight.support(config, self._qkv_weight())
+
+    def test_rejects_partial_fused_weight_exclusion(self):
+        config = self._quant_config(
+            ignore_patterns=["model.layers.{i}.self_attn.q_proj"]
+        )
+        with self.assertRaisesRegex(ValueError, "fused weight"):
+            PerBlockFp8Weight.support(config, self._qkv_weight())
+
+    def test_accepts_whole_fused_weight_exclusion(self):
+        config = self._quant_config(
+            ignore_patterns=[
+                "model.layers.{i}.self_attn.q_proj",
+                "model.layers.{i}.self_attn.k_proj",
+                "model.layers.{i}.self_attn.v_proj",
+            ]
+        )
+        self.assertFalse(PerBlockFp8Weight.support(config, self._qkv_weight()))
+
+    def test_rewrites_mla_embedded_scale_suffix(self):
+        source = MlaAttnAtomicWeight(
+            name=W.mla_kc,
+            weights=[CkptWeightInfo("model.layers.{i}.self_attn.kv_b_proj.weight")],
+            config=MlaConfig(
+                head_num=2,
+                nope_head_dim=64,
+                rope_head_dim=64,
+                kv_lora_rank=128,
+                v_head_dim=64,
+                use_mla=True,
+            ),
+        )
+        quantized = PerBlockFp8Weight(
+            source,
+            self._quant_config(weight_scale_suffix=".scale"),
+            name=source.name,
+        )
+        self.assertEqual(
+            [weight.name for weight in quantized.kernel.weights],
+            [
+                "model.layers.{i}.self_attn.kv_b_proj.weight",
+                "model.layers.{i}.self_attn.kv_b_proj.scale",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -203,6 +203,10 @@ class BaseModel(object):
     def support_cuda_graph(self) -> bool:
         return False
 
+    @classmethod
+    def prefill_cp_alignment(cls) -> int:
+        return 1
+
     def _load(self, device: str):
         # set empty weights for attention service
         # record device string for later use (e.g., WeightManager, python model init)

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -16,6 +16,10 @@ from rtp_llm.ops import HybridAttentionType, KVCacheSpecType
 
 
 class Qwen3NextBase(BaseModel):
+    @classmethod
+    def prefill_cp_alignment(cls) -> int:
+        return 64
+
     def _create_python_model(self):
         model_config = self.model_config
         parallelism_config = self.parallelism_config

--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -527,6 +527,12 @@ def init_user_buffers_environment(parallelism_config: ParallelismConfig):
     from rtp_llm.models_py.utils.arch import is_cuda
 
     if parallelism_config.use_ub_comm and is_cuda():
+        if parallelism_config.world_size != parallelism_config.tp_size:
+            logging.warning(
+                "User buffers do not support multiple TP groups; falling back to "
+                "the process-group communication path"
+            )
+            return
 
         from rtp_llm.models_py.distributed.user_buffers import (
             init_user_buffers_communicator,
@@ -663,6 +669,10 @@ def send(tensor: torch.Tensor, dst: int, group: Group) -> None:
     torch.distributed.send(tensor, dst, group=process_group)
 
 
+def get_global_rank_from_group_rank(rank: int, group: Group) -> int:
+    return torch.distributed.get_global_rank(_get_group(group), rank)
+
+
 def recv(tensor: torch.Tensor, src: int, group: Group) -> torch.Tensor:
     """Receive a tensor from a source rank.
 
@@ -689,6 +699,13 @@ def broadcast(tensor: torch.Tensor, src: int, group: Group) -> None:
     """
     process_group = _get_group(group)
     torch.distributed.broadcast(tensor, src, group=process_group)
+
+
+def broadcast_from_group_rank(tensor: torch.Tensor, src: int, group: Group) -> None:
+    process_group = _get_group(group)
+    torch.distributed.broadcast(
+        tensor, torch.distributed.get_global_rank(process_group, src), group=process_group
+    )
 
 
 def all_reduce(tensor: torch.Tensor, group: Group, *, inplace: bool = False) -> torch.Tensor:

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -8,7 +8,12 @@ from torch import nn
 
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.model_loader.model_weight_info import ModelWeights
-from rtp_llm.models_py.distributed.collective_torch import Group, all_gather, all_reduce
+from rtp_llm.models_py.distributed.collective_torch import (
+    Group,
+    all_gather,
+    all_reduce,
+    broadcast_from_group_rank,
+)
 from rtp_llm.models_py.model_desc.block_map import (
     get_group_tags_for_layers,
     get_primary_attention_inputs,
@@ -71,6 +76,18 @@ from rtp_llm.utils.swizzle_utils import (
 from rtp_llm.utils.util import to_torch_dtype
 
 logger = logging.getLogger(__name__)
+GDN_STATE_CHUNK_SIZE = 64
+
+
+def _cp_cache_ends(new_len: int, block_size: int, device: torch.device) -> torch.Tensor:
+    interior = torch.arange(
+        block_size,
+        max(block_size, new_len),
+        block_size,
+        dtype=torch.long,
+        device=device,
+    )
+    return torch.cat([interior, interior.new_tensor([new_len])])
 
 
 @lru_cache(maxsize=None)
@@ -104,6 +121,9 @@ class Qwen3NextMetadata(object):
         self.cp_restore_indices = cp_restore_indices
         self.cp_local_extract_indices = cp_local_extract_indices
         self.cp_local_valid_mask = cp_local_valid_mask
+        self.cp_segment_conv1d_metadata: Dict[
+            int, tuple[torch.Tensor, CausalConv1dMetadata]
+        ] = {}
 
     def get_prefill_conv1d_meta(self) -> Optional[CausalConv1dMetadata]:
         return self.prefill_conv1d_meta
@@ -761,6 +781,225 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # b,a should be contiguous for fused_gdn_gating
         return mixed_qkv, z, b, a
 
+    def _forward_cp_relay(
+        self,
+        mixed_qkv: torch.Tensor,
+        z: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        initial_states: Optional[torch.Tensor],
+        conv_states: Optional[torch.Tensor],
+        ssm_states: Optional[torch.Tensor],
+        seq_size_per_block: int,
+        attention_inputs: PyAttentionInputs,
+        attn_meta: Qwen3NextMetadata,
+    ) -> torch.Tensor:
+        """Run each contiguous GDN segment once and relay its recurrent state."""
+        cp_size = self.parallelism_config.tp_size
+        cp_rank = self.parallelism_config.tp_rank
+        local_tokens = z.shape[0]
+        segment_tokens = local_tokens // 2
+        actual_tokens = int(
+            attention_inputs.context_parallel_info.prefill_actual_input_lengths_cpu[
+                0
+            ].item()
+        )
+        valid_lengths = tuple(
+            max(0, min(segment_tokens, actual_tokens - i * segment_tokens))
+            for i in range(2 * cp_size)
+        )
+
+        g, beta = fused_gdn_gating(self.prefill_gdn.alog, a, b, self.prefill_gdn.dt_bias)
+        state = (
+            initial_states.float()
+            if initial_states is not None
+            else torch.zeros(
+                1,
+                self.local_num_v_heads,
+                self.head_v_dim,
+                self.head_k_dim,
+                dtype=torch.float32,
+                device=mixed_qkv.device,
+            )
+        )
+        conv_state_len = self.prefill_gdn.linear_conv_kernel_dim - 1
+        prefix_len = int(attention_inputs.prefix_lengths[0].item())
+        if conv_states is not None and prefix_len:
+            conv_cache_pos = (prefix_len - 1) // seq_size_per_block
+            conv_cache_id = attention_inputs.kv_cache_kernel_block_id_device[
+                0, conv_cache_pos
+            ].long()
+            conv_state = conv_states.index_select(0, conv_cache_id.view(1))[
+                0
+            ].transpose(0, 1).contiguous()
+        else:
+            conv_state = mixed_qkv.new_zeros(conv_state_len, mixed_qkv.shape[1])
+        local_output = mixed_qkv.new_zeros(
+            local_tokens, self.local_num_v_heads, self.head_v_dim
+        )
+
+        cache_ends = cache_ids = local_cache_states = local_conv_cache_states = None
+        if ssm_states is not None:
+            new_len = actual_tokens
+            cache_ends = _cp_cache_ends(
+                new_len, seq_size_per_block, mixed_qkv.device
+            )
+            cache_positions = (prefix_len + cache_ends - 1) // seq_size_per_block
+            cache_ids = attention_inputs.kv_cache_kernel_block_id_device[
+                0, cache_positions
+            ].long()
+            local_cache_states = ssm_states.new_zeros(
+                cache_ends.shape[0], *ssm_states.shape[1:]
+            )
+            local_conv_cache_states = conv_states.new_zeros(
+                cache_ends.shape[0], *conv_states.shape[1:]
+            )
+
+        steps = (
+            [(rank, rank, 0, 1) for rank in range(cp_size - 1)]
+            + [(cp_size - 1, cp_size - 1, 0, 2)]
+            + [
+                (rank, 2 * cp_size - 1 - rank, 1, 1)
+                for rank in range(cp_size - 2, -1, -1)
+            ]
+        )
+        for step_index, (owner, global_segment, local_segment, count) in enumerate(
+            steps
+        ):
+            valid_tokens = sum(valid_lengths[global_segment : global_segment + count])
+            if cp_rank == owner and valid_tokens:
+                local_start = local_segment * segment_tokens
+                local_end = local_start + valid_tokens
+                raw_qkv = mixed_qkv[local_start:local_end]
+                # A width-W causal conv only needs the preceding W-1 raw inputs.
+                conv_input = torch.cat([conv_state, raw_qkv], dim=0)
+                conv_tokens = conv_input.shape[0]
+                conv_entry = attn_meta.cp_segment_conv1d_metadata.get(conv_tokens)
+                if conv_entry is None:
+                    conv_cu = torch.tensor(
+                        [0, conv_tokens],
+                        dtype=torch.int32,
+                        device=conv_input.device,
+                    )
+                    conv_entry = (
+                        conv_cu,
+                        prepare_causal_conv1d_metadata(conv_cu, conv_input.device),
+                    )
+                    attn_meta.cp_segment_conv1d_metadata[conv_tokens] = conv_entry
+                conv_cu, conv_meta = conv_entry
+                qkv = causal_conv1d_fn(
+                    x=conv_input.transpose(0, 1),
+                    weight=self.prefill_gdn.conv_weights,
+                    bias=None,
+                    conv_states=None,
+                    query_start_loc=conv_cu,
+                    block_map=None,
+                    prefix_lengths=attention_inputs.prefix_lengths_device,
+                    seq_size_per_block=1,
+                    metadata=conv_meta,
+                ).transpose(0, 1)[conv_state_len:]
+                conv_state = conv_input[-conv_state_len:].contiguous()
+                if qkv.shape[0] >= 2048:
+                    query, key, value = scatter_qkv(
+                        qkv,
+                        self.local_num_k_heads,
+                        self.local_num_v_heads,
+                        self.head_k_dim,
+                        self.head_v_dim,
+                    )
+                else:
+                    query, key, value = torch.split(
+                        qkv,
+                        [
+                            self.local_num_k_heads * self.head_k_dim,
+                            self.local_num_k_heads * self.head_k_dim,
+                            self.local_num_v_heads * self.head_v_dim,
+                        ],
+                        dim=-1,
+                    )
+                    query = query.view(
+                        1, -1, self.local_num_k_heads, self.head_k_dim
+                    )
+                    key = key.view(1, -1, self.local_num_k_heads, self.head_k_dim)
+                    value = value.view(
+                        1, -1, self.local_num_v_heads, self.head_v_dim
+                    )
+                output, chunk_states, state = chunk_gated_delta_rule(
+                    query,
+                    key,
+                    value,
+                    g[:, local_start:local_end].contiguous(),
+                    beta[:, local_start:local_end].contiguous(),
+                    initial_state=state,
+                    output_final_state=True,
+                    use_qk_l2norm_in_kernel=True,
+                )
+                local_output[local_start:local_end] = output.squeeze_(0)
+
+                if local_cache_states is not None:
+                    global_start = global_segment * segment_tokens
+                    positions = torch.nonzero(
+                        (cache_ends > global_start)
+                        & (cache_ends <= global_start + valid_tokens),
+                        as_tuple=False,
+                    ).flatten()
+                    offsets = cache_ends[positions] - global_start
+                    selected = chunk_states[
+                        0,
+                        (offsets // GDN_STATE_CHUNK_SIZE).clamp_max(
+                            chunk_states.shape[1] - 1
+                        ),
+                    ]
+                    selected = torch.where(
+                        (offsets == valid_tokens)[:, None, None, None],
+                        state[0],
+                        selected,
+                    )
+                    local_cache_states.index_copy_(
+                        0, positions, selected.to(local_cache_states.dtype)
+                    )
+                    conv_offsets = (
+                        offsets[:, None]
+                        + torch.arange(conv_state_len, device=mixed_qkv.device)
+                    ).flatten()
+                    selected_conv_states = (
+                        conv_input.index_select(0, conv_offsets)
+                        .view(-1, conv_state_len, raw_qkv.shape[1])
+                        .transpose(1, 2)
+                        .contiguous()
+                    )
+                    local_conv_cache_states.index_copy_(
+                        0, positions, selected_conv_states
+                    )
+            if step_index + 1 < len(steps):
+                broadcast_from_group_rank(state, src=owner, group=Group.TP)
+                broadcast_from_group_rank(conv_state, src=owner, group=Group.TP)
+
+        if local_cache_states is not None:
+            local_cache_states = all_reduce(local_cache_states, group=Group.TP)
+            local_conv_cache_states = all_reduce(
+                local_conv_cache_states, group=Group.TP
+            )
+            valid_positions = torch.nonzero(cache_ids > 0, as_tuple=False).flatten()
+            ssm_states.index_copy_(
+                0, cache_ids[valid_positions], local_cache_states[valid_positions]
+            )
+            conv_states.index_copy_(
+                0,
+                cache_ids[valid_positions],
+                local_conv_cache_states[valid_positions],
+            )
+
+        local_output = self.norm(
+            local_output.reshape(-1, self.head_v_dim), z.reshape(-1, self.head_v_dim)
+        ).reshape(-1, self.local_num_v_heads * self.head_v_dim)
+        local_output = self.out_proj(local_output)
+        return torch.where(
+            attn_meta.cp_local_valid_mask[:, None],
+            local_output,
+            torch.zeros_like(local_output),
+        )
+
     # TODO: extract shared conv1d/FLA/ssm-state logic with Qwen3NextGatedDeltaNetPrefill
     # to eliminate duplication
     def _forward_cp_prefill(
@@ -773,23 +1012,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         kv_cache: Optional[LayerKVCache],
         attn_meta: Qwen3NextMetadata,
     ) -> torch.Tensor:
-        """CP prefill path: all-gather projected states, compute on full sequence,
-        extract local zigzag tokens."""
+        """Run CP prefill, relaying causal state for the common single-request case."""
         cp_info = attention_inputs.context_parallel_info
-
-        packed = torch.cat([mixed_qkv, b, a], dim=-1)
-        full_packed = all_gather(packed, group=Group.TP)
-
-        padding_mask = cp_info.prefill_qkv_padding_mask
-        restore_indices = cp_info.prefill_qkv_restore_indice
-        unpad_restore = restore_indices[padding_mask == 1]
-        full_packed = full_packed[unpad_restore]
-
-        qkv_dim = mixed_qkv.shape[-1]
-        b_dim = b.shape[-1]
-        full_mixed_qkv = full_packed[:, :qkv_dim].contiguous()
-        full_b = full_packed[:, qkv_dim : qkv_dim + b_dim].contiguous()
-        full_a = full_packed[:, qkv_dim + b_dim :].contiguous()
 
         gdn = self.prefill_gdn
         full_cu = attn_meta.full_prefill_cu_seqlens
@@ -808,19 +1032,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             if kv_cache_tensor is not None
             else None
         )
-        full_mixed_qkv = causal_conv1d_fn(
-            x=full_mixed_qkv.transpose(0, 1),
-            weight=gdn.conv_weights,
-            bias=None,
-            conv_states=conv_states,
-            query_start_loc=full_cu,
-            block_map=attention_inputs.kv_cache_kernel_block_id_device,
-            seq_size_per_block=seq_size_per_block,
-            prefix_lengths=attention_inputs.prefix_lengths_device,
-            metadata=full_conv_meta,
-        ).transpose(0, 1)
-
-        g, beta = fused_gdn_gating(gdn.alog, full_a, full_b, gdn.dt_bias)
         ssm_states = (
             gdn._get_ssm_states(kv_cache_tensor)
             if kv_cache_tensor is not None
@@ -834,7 +1045,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 gdn.local_num_v_heads,
                 gdn.head_v_dim,
                 gdn.head_k_dim,
-                device=full_mixed_qkv.device,
+                device=mixed_qkv.device,
                 dtype=gdn.ssm_state_dtype,
             )
             load_initial_state_from_block_map(
@@ -844,6 +1055,66 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 initial_states,
                 seq_size_per_block,
             )
+
+        can_relay = (
+            context_batch_size == 1
+            and self.parallelism_config.tp_size >= 2
+            and mixed_qkv.shape[0] % (2 * GDN_STATE_CHUNK_SIZE) == 0
+            and not attention_inputs.is_cuda_graph
+            and not self.parallelism_config.prefill_cp_config.kv_cache_sharded
+            and (
+                kv_cache is None
+                or (
+                    seq_size_per_block % GDN_STATE_CHUNK_SIZE == 0
+                    and int(attention_inputs.prefix_lengths[0].item())
+                    % seq_size_per_block
+                    == 0
+                )
+            )
+        )
+        if can_relay:
+            result = self._forward_cp_relay(
+                mixed_qkv,
+                z,
+                b,
+                a,
+                initial_states,
+                conv_states,
+                ssm_states,
+                seq_size_per_block,
+                attention_inputs,
+                attn_meta,
+            )
+            _maybe_write_cp_cache_store(attention_inputs, kv_cache, attn_meta)
+            return result
+
+        packed = torch.cat([mixed_qkv, b, a], dim=-1)
+        full_packed = all_gather(packed, group=Group.TP)
+
+        padding_mask = cp_info.prefill_qkv_padding_mask
+        restore_indices = cp_info.prefill_qkv_restore_indice
+        unpad_restore = restore_indices[padding_mask == 1]
+        full_packed = full_packed[unpad_restore]
+
+        qkv_dim = mixed_qkv.shape[-1]
+        b_dim = b.shape[-1]
+        full_mixed_qkv = full_packed[:, :qkv_dim].contiguous()
+        full_b = full_packed[:, qkv_dim : qkv_dim + b_dim].contiguous()
+        full_a = full_packed[:, qkv_dim + b_dim :].contiguous()
+
+        full_mixed_qkv = causal_conv1d_fn(
+            x=full_mixed_qkv.transpose(0, 1),
+            weight=gdn.conv_weights,
+            bias=None,
+            conv_states=conv_states,
+            query_start_loc=full_cu,
+            block_map=attention_inputs.kv_cache_kernel_block_id_device,
+            seq_size_per_block=seq_size_per_block,
+            prefix_lengths=attention_inputs.prefix_lengths_device,
+            metadata=full_conv_meta,
+        ).transpose(0, 1)
+
+        g, beta = fused_gdn_gating(gdn.alog, full_a, full_b, gdn.dt_bias)
 
         if full_mixed_qkv.shape[0] >= 2048 and gdn.head_k_dim == gdn.head_v_dim:
             query, key, value = scatter_qkv(

--- a/rtp_llm/models_py/modules/factory/attention/attn_factory.py
+++ b/rtp_llm/models_py/modules/factory/attention/attn_factory.py
@@ -82,6 +82,9 @@ def get_mla_impl(
     _validate_dynamic_fp8_config(attn_configs, is_cuda_graph, attn_inputs)
 
     mla_impls = PREFILL_MLA_IMPS if attn_inputs.is_prefill else DECODE_MLA_IMPS
+    uses_context_parallel = (
+        getattr(attn_inputs, "context_parallel_info", None) is not None
+    )
     for impl in mla_impls:
         # Check support before creating instance
         if not impl.support(attn_configs, attn_inputs):
@@ -93,12 +96,10 @@ def get_mla_impl(
             attn_inputs.is_prefill
             and attn_inputs.cu_kv_seqlens_device.max().item()
             <= attn_configs.indexer_topk
-            and not (
-                parallelism_config and parallelism_config.prefill_cp_config.is_enabled()
-            )
+            and not uses_context_parallel
         )
 
-        if not use_fast_path and not impl.support_parallelism_config(
+        if uses_context_parallel and not impl.support_parallelism_config(
             parallelism_config
         ):
             continue
@@ -210,6 +211,9 @@ def get_fmha_impl(
         if attn_inputs.is_prefill
         else DYNAMIC_FP8_DECODE_IMPLS
     )
+    uses_context_parallel = (
+        getattr(attn_inputs, "context_parallel_info", None) is not None
+    )
     strict_impl_selection = dynamic_fp8 or (
         VALIDATE_FMHA_CONFIG is not None
         and VALIDATE_FMHA_CONFIG(attn_configs, attn_inputs, fmha_config)
@@ -233,7 +237,9 @@ def get_fmha_impl(
             continue
 
         # Check if implementation supports parallelism config
-        if not impl.support_parallelism_config(parallelism_config):
+        if uses_context_parallel and not impl.support_parallelism_config(
+            parallelism_config
+        ):
             continue
         kwargs = {"fmha_config": fmha_config} if impl.accepts_fmha_config else {}
         try:

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_cp_impl.py
@@ -25,6 +25,7 @@ from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.cp_uti
     generate_full_causal_kv_indices,
     generate_q_indices,
     plan_prefix_paged_attention,
+    resolve_kv_cache_block_id,
 )
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     get_py_flashinfer_workspace_buffer,
@@ -68,7 +69,6 @@ class PCPAllGatherAttnOp:
 
         self.prefill_cp_rank = parallelism_config.tp_rank
         self.prefill_cp_size = parallelism_config.tp_size
-
         self.seq_size_per_block = attn_configs.tokens_per_block
 
         self.q0_idx = self.q1_idx = None
@@ -100,15 +100,21 @@ class PCPAllGatherAttnOp:
         cu_seqlens = attention_inputs.cu_seqlens_device[
             : attention_inputs.input_lengths.size(0) + 1
         ]
+        # The scheduler publishes CP chunk lengths on CUDA, while FlashInfer's
+        # plan() consumes indptr on the host. Copy the small per-request tensor
+        # once and reuse it for all host-side index construction below.
+        local_chunk_lengths = self.cp_info.prefill_cp_chunk_lengths.cpu()
+        qo_indptr = torch.zeros(
+            local_chunk_lengths.numel() + 1, dtype=torch.int32, device="cpu"
+        )
+        qo_indptr[1:] = torch.cumsum(local_chunk_lengths // 2, dim=0)
         padding_mask = self.cp_info.prefill_qkv_padding_mask
         kv_restore_indices = self.cp_info.prefill_qkv_restore_indice
         self.kv_restore_unpad_indices = kv_restore_indices[padding_mask == 1]
 
-        qo_indptr = cu_seqlens // 2
-
-        q0_idx, q1_idx = generate_q_indices(self.cp_info.prefill_cp_chunk_lengths)
+        q0_idx, q1_idx = generate_q_indices(local_chunk_lengths)
         kv0_idx, kv1_idx = generate_full_causal_kv_indices(
-            self.cp_info.prefill_cp_chunk_lengths,
+            local_chunk_lengths,
             self.prefill_cp_rank,
             self.prefill_cp_size,
         )
@@ -122,7 +128,7 @@ class PCPAllGatherAttnOp:
             self.attn_inputs.prefix_lengths,
             self.attn_inputs.sequence_lengths,
             self.cp_info.prefill_actual_input_lengths_cpu,
-            self.attn_inputs.kv_cache_kernel_block_id,
+            resolve_kv_cache_block_id(self.attn_inputs),
             self.attn_configs.kernel_tokens_per_block,
         )
 
@@ -194,20 +200,24 @@ class PCPAllGatherAttnOp:
         # TODO: make write local kvcache async
         restore_k = all_keys[self.kv_restore_unpad_indices]
         restore_v = all_values[self.kv_restore_unpad_indices]
-        kv_cache_tensor = kv_cache.kv_cache_base.view(
-            -1, 2, self.num_kv_heads, self.seq_size_per_block, self.head_dim
-        )
-        append_paged_kv_cache(
-            append_key=restore_k,
-            append_value=restore_v,
-            batch_indices=params.batch_indice_d,
-            positions=params.positions_d,
-            paged_kv_cache=kv_cache_tensor,
-            kv_indices=params.page_indice_d,
-            kv_indptr=params.decode_page_indptr_d,
-            kv_last_page_len=params.paged_kv_last_page_len_d,
-            kv_layout="HND",
-        )
+        # Warm-up runs before any KV cache is allocated. There is nothing to write
+        # to, and prefix attention cannot be active without a cache either.
+        kv_cache_tensor = None
+        if kv_cache is not None:
+            kv_cache_tensor = kv_cache.kv_cache_base.view(
+                -1, 2, self.num_kv_heads, self.seq_size_per_block, self.head_dim
+            )
+            append_paged_kv_cache(
+                append_key=restore_k,
+                append_value=restore_v,
+                batch_indices=params.batch_indice_d,
+                positions=params.positions_d,
+                paged_kv_cache=kv_cache_tensor,
+                kv_indices=params.page_indice_d,
+                kv_indptr=params.decode_page_indptr_d,
+                kv_last_page_len=params.paged_kv_last_page_len_d,
+                kv_layout="HND",
+            )
 
         q0 = torch.index_select(q_reshaped, 0, self.q0_idx).contiguous()
         q1 = torch.index_select(q_reshaped, 0, self.q1_idx).contiguous()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_overlap_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_overlap_impl.py
@@ -27,6 +27,7 @@ from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.cp_uti
     generate_nonlocal_causal_kv_indices,
     generate_q_indices,
     plan_prefix_paged_attention,
+    resolve_kv_cache_block_id,
 )
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     get_py_flashinfer_workspace_buffer,
@@ -132,7 +133,7 @@ class PCPAllGatherOverlapAttnOp:
             self.attn_inputs.prefix_lengths,
             self.attn_inputs.sequence_lengths,
             cp_info.prefill_actual_input_lengths_cpu,
-            self.attn_inputs.kv_cache_kernel_block_id,
+            resolve_kv_cache_block_id(self.attn_inputs),
             self.attn_configs.kernel_tokens_per_block,
         )
 
@@ -208,9 +209,12 @@ class PCPAllGatherOverlapAttnOp:
         self,
         all_keys: torch.Tensor,
         all_values: torch.Tensor,
-        kv_cache: KVCache,
+        kv_cache: Optional[KVCache],
         params: ParamsBase,
     ):
+        # Warm-up runs before any KV cache is allocated, so there is nothing to write to.
+        if kv_cache is None:
+            return None
         restore_k = all_keys[self.kv_restore_unpad_indices]
         restore_v = all_values[self.kv_restore_unpad_indices]
         kv_cache_tensor = kv_cache.kv_cache_base.view(

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/alltoall_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/alltoall_cp_impl.py
@@ -9,12 +9,19 @@ from flashinfer import (
 from flashinfer.cascade import merge_state
 from flashinfer.page import append_paged_kv_cache
 
-from rtp_llm.models_py.distributed.collective_torch import Group, all_gather, recv, send
+from rtp_llm.models_py.distributed.collective_torch import (
+    Group,
+    all_gather,
+    get_global_rank_from_group_rank,
+    recv,
+    send,
+)
 from rtp_llm.models_py.distributed.user_buffers import get_user_buffers_communicator
 from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.cp_utils import (
     generate_half_kv_indices,
     generate_half_q_indices,
     plan_prefix_paged_attention,
+    resolve_kv_cache_block_id,
 )
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     get_py_flashinfer_workspace_buffer,
@@ -73,7 +80,9 @@ class PCPAll2AllAttnOp:
         self.comm_events = [torch.cuda.Event() for _ in range(self.prefill_cp_size)]
         self.math_events = [torch.cuda.Event() for _ in range(self.prefill_cp_size)]
 
-        self.all_shuffle_indices = None
+        self.cache_append_indices = None
+        self.cache_append_batch_indices = None
+        self.cache_append_positions = None
         self.half_q_idx = self.half_kv_idx = None
 
         # Init flashinfer attention wrappers
@@ -104,7 +113,7 @@ class PCPAll2AllAttnOp:
         ]
         prefill_cp_chunk_lengths = self.cp_info.prefill_cp_chunk_lengths
         shuffle_indices = self.cp_info.prefill_shuffle_indices
-        self.all_shuffle_indices = all_gather(shuffle_indices, group=Group.TP).reshape(
+        all_shuffle_indices = all_gather(shuffle_indices, group=Group.TP).reshape(
             -1, shuffle_indices.shape[0]
         )
 
@@ -147,17 +156,39 @@ class PCPAll2AllAttnOp:
             self.attn_inputs.prefix_lengths,
             self.attn_inputs.sequence_lengths,
             self.cp_info.prefill_actual_input_lengths_cpu,
-            self.attn_inputs.kv_cache_kernel_block_id,
+            resolve_kv_cache_block_id(self.attn_inputs),
             self.attn_configs.kernel_tokens_per_block,
         )
 
         chunk_lens = prefill_cp_chunk_lengths.tolist()
-        self.append_batch_indice = torch.cat(
+        append_batch_indice = torch.cat(
             [
                 torch.full((cl,), i, dtype=torch.int32, device=self.device)
                 for i, cl in enumerate(chunk_lens)
             ]
         )
+        token_actual_lengths = self.cp_info.prefill_actual_input_lengths_cpu.to(
+            self.device
+        )[append_batch_indice.long()]
+        token_prefix_lengths = self.attn_inputs.prefix_lengths.to(self.device)[
+            append_batch_indice.long()
+        ]
+        self.cache_append_indices = []
+        self.cache_append_batch_indices = []
+        self.cache_append_positions = []
+        for shuffle_positions in all_shuffle_indices:
+            valid_indices = torch.nonzero(
+                (shuffle_positions >= 0) & (shuffle_positions < token_actual_lengths),
+                as_tuple=False,
+            ).flatten()
+            self.cache_append_indices.append(valid_indices)
+            self.cache_append_batch_indices.append(
+                append_batch_indice.index_select(0, valid_indices)
+            )
+            self.cache_append_positions.append(
+                shuffle_positions.index_select(0, valid_indices)
+                + token_prefix_lengths.index_select(0, valid_indices)
+            )
 
         self.has_prefix = self.attn_inputs.prefix_lengths.any().item()
         if self.has_prefix:
@@ -174,6 +205,52 @@ class PCPAll2AllAttnOp:
             )
 
         return params
+
+    def _append_kv_cache(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        source_rank: int,
+        kv_cache_tensor: Optional[torch.Tensor],
+        params: ParamsBase,
+    ) -> None:
+        if kv_cache_tensor is None:
+            return
+        valid_indices = self.cache_append_indices[source_rank]
+        if valid_indices.numel() == 0:
+            return
+        append_paged_kv_cache(
+            append_key=key.index_select(0, valid_indices),
+            append_value=value.index_select(0, valid_indices),
+            batch_indices=self.cache_append_batch_indices[source_rank],
+            positions=self.cache_append_positions[source_rank],
+            paged_kv_cache=kv_cache_tensor,
+            kv_indices=params.page_indice_d,
+            kv_indptr=params.decode_page_indptr_d,
+            kv_last_page_len=params.paged_kv_last_page_len_d,
+            kv_layout="HND",
+        )
+
+    def _exchange_kv(
+        self,
+        kv_buffer: torch.Tensor,
+        recv_buf: torch.Tensor,
+        next_rank_id: int,
+        prev_rank_id: int,
+    ) -> None:
+        if self.use_ub and self.ub_communicator.can_handle_tensor(kv_buffer):
+            self.ub_communicator.send(kv_buffer, dst=next_rank_id)
+            self.ub_communicator.recv(recv_buf, src=prev_rank_id)
+            return
+
+        next_global_rank = get_global_rank_from_group_rank(next_rank_id, Group.TP)
+        prev_global_rank = get_global_rank_from_group_rank(prev_rank_id, Group.TP)
+        if self.prefill_cp_rank < next_rank_id:
+            send(kv_buffer, dst=next_global_rank, group=Group.TP)
+            recv(recv_buf, src=prev_global_rank, group=Group.TP)
+        else:
+            recv(recv_buf, src=prev_global_rank, group=Group.TP)
+            send(kv_buffer, dst=next_global_rank, group=Group.TP)
 
     def forward(
         self,
@@ -209,9 +286,13 @@ class PCPAll2AllAttnOp:
             dtype=torch.float32,
             device=q.device,
         )
-        kv_cache_tensor = kv_cache.kv_cache_base.view(
-            -1, 2, self.num_kv_heads, self.seq_size_per_block, self.head_dim
-        )
+        # Warm-up runs before any KV cache is allocated, so there is nothing to
+        # write to; prefix attention cannot be active without a cache either.
+        kv_cache_tensor = None
+        if kv_cache is not None:
+            kv_cache_tensor = kv_cache.kv_cache_base.view(
+                -1, 2, self.num_kv_heads, self.seq_size_per_block, self.head_dim
+            )
         for round_id in range(0, self.prefill_cp_size):
             if round_id > 0:
                 out_buffer.zero_()
@@ -227,18 +308,12 @@ class PCPAll2AllAttnOp:
                         self.prefill_cp_rank + round_id + 1
                     ) % self.prefill_cp_size
 
-                    if self.use_ub and self.ub_communicator.can_handle_tensor(
-                        kv_buffer
-                    ):
-                        self.ub_communicator.send(kv_buffer, dst=next_rank_id)
-                        self.ub_communicator.recv(recv_buf, src=prev_rank_id)
-                    else:
-                        if self.prefill_cp_rank < next_rank_id:
-                            send(kv_buffer, dst=next_rank_id, group=Group.TP)
-                            recv(recv_buf, src=prev_rank_id, group=Group.TP)
-                        else:
-                            recv(recv_buf, src=prev_rank_id, group=Group.TP)
-                            send(kv_buffer, dst=next_rank_id, group=Group.TP)
+                    self._exchange_kv(
+                        kv_buffer,
+                        recv_buf,
+                        next_rank_id=next_rank_id,
+                        prev_rank_id=prev_rank_id,
+                    )
                     self.comm_events[round_id].record()
 
             if round_id == 0:  # local attention
@@ -247,16 +322,12 @@ class PCPAll2AllAttnOp:
                 k = k.reshape(-1, self.num_kv_heads, self.head_dim)
                 v = v.reshape(-1, self.num_kv_heads, self.head_dim)
 
-                append_paged_kv_cache(
-                    append_key=k,
-                    append_value=v,
-                    batch_indices=self.append_batch_indice,
-                    positions=self.all_shuffle_indices[self.prefill_cp_rank],
-                    paged_kv_cache=kv_cache_tensor,
-                    kv_indices=params.page_indice_d,
-                    kv_indptr=params.decode_page_indptr_d,
-                    kv_last_page_len=params.paged_kv_last_page_len_d,
-                    kv_layout="HND",
+                self._append_kv_cache(
+                    k,
+                    v,
+                    self.prefill_cp_rank,
+                    kv_cache_tensor,
+                    params,
                 )
 
                 q_reshaped = q.reshape(-1, self.num_qo_heads, self.head_dim)
@@ -294,16 +365,12 @@ class PCPAll2AllAttnOp:
                 )
                 # TODO: make write local kvcache async
                 src_rank = (self.prefill_cp_rank - round_id) % self.prefill_cp_size
-                append_paged_kv_cache(
-                    append_key=remote_k,
-                    append_value=remote_v,
-                    batch_indices=self.append_batch_indice,
-                    positions=self.all_shuffle_indices[src_rank],
-                    paged_kv_cache=kv_cache_tensor,
-                    kv_indices=params.page_indice_d,
-                    kv_indptr=params.decode_page_indptr_d,
-                    kv_last_page_len=params.paged_kv_last_page_len_d,
-                    kv_layout="HND",
+                self._append_kv_cache(
+                    remote_k,
+                    remote_v,
+                    src_rank,
+                    kv_cache_tensor,
+                    params,
                 )
                 if round_id > self.prefill_cp_rank:
                     q_split = (

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/cp_utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/cp_utils.py
@@ -2,6 +2,19 @@ import torch
 from flashinfer import BatchPrefillWithPagedKVCacheWrapper
 
 
+def resolve_kv_cache_block_id(attn_inputs) -> torch.Tensor:
+    """Prefill warm-up runs before any KV cache exists, but the ``fill_mla_params``
+    pybind signature requires a Tensor, so substitute an empty int32 tensor."""
+    block_id = attn_inputs.kv_cache_kernel_block_id
+    if block_id is None or block_id.numel() == 0:
+        block_id = attn_inputs.kv_cache_kernel_block_id_device
+    if block_id is None:
+        block_id = torch.empty(
+            0, dtype=torch.int32, device=attn_inputs.cu_seqlens_device.device
+        )
+    return block_id
+
+
 def plan_prefix_paged_attention(
     wrapper: BatchPrefillWithPagedKVCacheWrapper,
     qo_indptr: torch.Tensor,

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
@@ -50,7 +50,7 @@ py_test(
         "//conditions:default": []
     }),
     tags = ["H20"],
-    exec_properties = {'gpu': 'H20'},
+    exec_properties = {'gpu': 'H20', 'gpu_count': '4'},
 )
 
 py_test(
@@ -73,6 +73,7 @@ py_test(
         "@//:cuda_pre_12_9": flashinfer_deps,
         "//conditions:default": []
     }),
-    tags = ["manual"],
-    exec_properties = {'gpu': 'H20'},
+    # H20 is a scheduled CI tag; four GPUs are required by the relay regression.
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '4'},
 )

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
@@ -68,8 +68,48 @@ def build_restore_indices(cp_chunk_lengths: List[int], cp_size: int) -> torch.Te
     return torch.tensor(restore, dtype=torch.int32)
 
 
-def build_padding_mask(cp_chunk_lengths: List[int], cp_size: int) -> torch.Tensor:
-    return torch.ones(sum(cp_chunk_lengths) * cp_size, dtype=torch.int32)
+def build_padding_mask(
+    cp_chunk_lengths: List[int],
+    cp_size: int,
+    actual_lengths: List[int] | None = None,
+) -> torch.Tensor:
+    padded_lengths = [length * cp_size for length in cp_chunk_lengths]
+    if actual_lengths is None:
+        actual_lengths = padded_lengths
+    if len(actual_lengths) != len(padded_lengths):
+        raise ValueError("actual and padded length counts must match")
+    masks = []
+    for actual, padded in zip(actual_lengths, padded_lengths):
+        if actual < 0 or actual > padded:
+            raise ValueError(f"actual length {actual} exceeds padded length {padded}")
+        masks.append(
+            torch.cat(
+                [
+                    torch.ones(actual, dtype=torch.int32),
+                    torch.zeros(padded - actual, dtype=torch.int32),
+                ]
+            )
+        )
+    return torch.cat(masks)
+
+
+def build_shuffle_indices(
+    actual_lengths: List[int],
+    cp_chunk_lengths: List[int],
+    cp_size: int,
+    rank: int,
+) -> torch.Tensor:
+    if len(actual_lengths) != len(cp_chunk_lengths):
+        raise ValueError("actual and chunk length counts must match")
+    if rank < 0 or rank >= cp_size:
+        raise ValueError(f"rank {rank} is outside CP size {cp_size}")
+    indices = []
+    for actual, chunk in zip(actual_lengths, cp_chunk_lengths):
+        padded = chunk * cp_size
+        if actual > padded:
+            raise ValueError(f"actual length {actual} exceeds padded length {padded}")
+        indices.extend(zigzag_positions_for_rank(padded, cp_size, rank))
+    return torch.tensor(indices, dtype=torch.int32)
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +204,7 @@ def build_cp_attn_inputs(
     tokens_per_block: int,
     prefix_lengths: List[int] | None = None,
     device: torch.device = torch.device("cuda"),
+    block_id_start: int = 0,
 ) -> PyAttentionInputs:
     """Build ``PyAttentionInputs`` with properly populated CP info.
 
@@ -194,7 +235,11 @@ def build_cp_attn_inputs(
     offset = 0
     for i, sl in enumerate(sequence_lengths):
         nb = math.ceil(sl / tokens_per_block)
-        block_ids[i, :nb] = torch.arange(offset, offset + nb, dtype=torch.int32)
+        block_ids[i, :nb] = torch.arange(
+            block_id_start + offset,
+            block_id_start + offset + nb,
+            dtype=torch.int32,
+        )
         offset += nb
     inp.kv_cache_block_id = block_ids
     inp.kv_cache_kernel_block_id = block_ids
@@ -205,11 +250,17 @@ def build_cp_attn_inputs(
     new_lengths = [sl - pl for sl, pl in zip(sequence_lengths, prefix_lengths)]
 
     cp_info = PyContextParallelParams()
-    cp_info.prefill_cp_chunk_lengths = torch.tensor(cp_chunk_lengths, dtype=torch.int32)
-    cp_info.prefill_cp_padding_lengths = torch.zeros(batch_size, dtype=torch.int32)
-    cp_info.prefill_qkv_padding_mask = build_padding_mask(cp_chunk_lengths, cp_size).to(
-        device
+    cp_info.prefill_cp_chunk_lengths = torch.tensor(
+        cp_chunk_lengths, dtype=torch.int32, device=device
     )
+    padded_lengths = [length * cp_size for length in cp_chunk_lengths]
+    cp_info.prefill_cp_padding_lengths = torch.tensor(
+        [padded - actual for padded, actual in zip(padded_lengths, new_lengths)],
+        dtype=torch.int32,
+    )
+    cp_info.prefill_qkv_padding_mask = build_padding_mask(
+        cp_chunk_lengths, cp_size, new_lengths
+    ).to(device)
     cp_info.prefill_qkv_restore_indice = build_restore_indices(
         cp_chunk_lengths, cp_size
     ).to(device)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_alltoall_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_alltoall_cp_impl.py
@@ -14,12 +14,14 @@ from typing import List
 from unittest.mock import patch
 
 import torch
+import torch.multiprocessing as mp
 
 from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.alltoall_cp_impl import (
     PCPAll2AllAttnOp,
 )
 from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils import (
     build_cp_attn_inputs,
+    build_shuffle_indices,
     compute_rank_positions,
     extract_kv_from_paged_cache,
     fill_prefix_into_kv_cache,
@@ -29,6 +31,7 @@ from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils
     reference_prefill_with_prefix,
     zigzag_positions_for_rank,
 )
+from rtp_llm.test.utils.port_util import PortManager
 
 _A2A_MODULE = (
     "rtp_llm.models_py.modules.factory.attention."
@@ -43,6 +46,52 @@ def _sleep_us(us: int = _COMM_DELAY_US) -> None:
     end = time.perf_counter() + us * 1e-6
     while time.perf_counter() < end:
         pass
+
+
+def _group_rank_send_recv_worker(world_rank, master_port):
+    from rtp_llm.models_py.distributed.collective_torch import (
+        destroy_distributed_environment,
+        init_distributed_environment,
+    )
+    from rtp_llm.models_py.distributed.user_buffers import (
+        get_user_buffers_communicator,
+    )
+    from rtp_llm.ops import NcclCommConfig, ParallelismConfig
+
+    torch.cuda.set_device(world_rank)
+    config = ParallelismConfig()
+    config.tp_size = 2
+    config.tp_rank = world_rank % 2
+    config.dp_size = 2
+    config.dp_rank = world_rank // 2
+    config.world_size = 4
+    config.world_rank = world_rank
+    config.local_world_size = 4
+    config.local_rank = world_rank
+    config.use_ub_comm = True
+    init_distributed_environment(
+        config,
+        NcclCommConfig(nccl_ip="127.0.0.1"),
+        master_port,
+        timeout=60,
+    )
+    try:
+        device = torch.device(f"cuda:{world_rank}")
+        group_base_rank = config.dp_rank * config.tp_size
+        peer_rank = 1 - config.tp_rank
+        op = PCPAll2AllAttnOp.__new__(PCPAll2AllAttnOp)
+        op.ub_communicator = get_user_buffers_communicator()
+        assert op.ub_communicator is None
+        op.use_ub = op.ub_communicator is not None
+        op.prefill_cp_rank = config.tp_rank
+        sent = torch.tensor([world_rank], dtype=torch.int32, device=device)
+        received = torch.empty_like(sent)
+        op._exchange_kv(sent, received, peer_rank, peer_rank)
+        torch.testing.assert_close(
+            received.cpu(), torch.tensor([group_base_rank + peer_rank], dtype=torch.int32)
+        )
+    finally:
+        destroy_distributed_environment()
 
 
 class TestPCPAll2AllAttnOp(unittest.TestCase):
@@ -69,15 +118,12 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
         new_lengths: List[int],
         cp_size: int,
         rank: int,
-        prefix_lengths: List[int] | None = None,
         device: torch.device = torch.device("cuda"),
     ) -> torch.Tensor:
-        if prefix_lengths is None:
-            prefix_lengths = [0] * len(new_lengths)
         indices: List[int] = []
-        for new_len, pl in zip(new_lengths, prefix_lengths):
+        for new_len in new_lengths:
             positions = zigzag_positions_for_rank(new_len, cp_size, rank)
-            indices.extend(p + pl for p in positions)
+            indices.extend(positions)
         return torch.tensor(indices, dtype=torch.int32, device=device)
 
     # ---- mock builders ----
@@ -108,6 +154,12 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
         )
         with contextlib.ExitStack() as stack:
             stack.enter_context(patch(f"{_A2A_MODULE}.all_gather", side_effect=mock_ag))
+            stack.enter_context(
+                patch(
+                    f"{_A2A_MODULE}.get_global_rank_from_group_rank",
+                    side_effect=lambda rank, group: rank,
+                )
+            )
             stack.enter_context(patch(f"{_A2A_MODULE}.send", side_effect=mock_send))
             stack.enter_context(patch(f"{_A2A_MODULE}.recv", side_effect=mock_recv))
             stack.enter_context(
@@ -119,6 +171,209 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
             op = PCPAll2AllAttnOp(attn_cfg, attn_inputs, par_cfg)
             params = op.prepare(attn_inputs)
             return op.forward(qkv, kv_cache, params)
+
+    def run_padded(
+        self,
+        new_lengths: List[int],
+        prefix_lengths: List[int],
+        with_kv_cache: bool,
+    ):
+        assert with_kv_cache or not any(prefix_lengths)
+        cp_size = 4
+        cp_rank = 1
+        segment_alignment = 64
+        cp_chunk_lengths = [
+            math.ceil(length / (2 * cp_size * segment_alignment))
+            * (2 * segment_alignment)
+            for length in new_lengths
+        ]
+        head_num, kv_head_num, head_dim = 8, 2, 64
+        tokens_per_block = 16
+
+        attn_cfg, par_cfg = make_configs(
+            head_num=head_num,
+            kv_head_num=kv_head_num,
+            head_dim=head_dim,
+            tokens_per_block=tokens_per_block,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+        )
+        total_new = sum(new_lengths)
+        q_full = torch.randn(
+            total_new,
+            head_num,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        k_full = torch.randn(
+            total_new,
+            kv_head_num,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        v_full = torch.randn_like(k_full)
+        prefix_k = torch.randn(
+            sum(prefix_lengths),
+            kv_head_num,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        prefix_v = torch.randn_like(prefix_k)
+        ref_output = reference_prefill_with_prefix(
+            q_full,
+            prefix_k,
+            prefix_v,
+            k_full,
+            v_full,
+            new_lengths,
+            prefix_lengths,
+        )
+
+        all_shuffle = [
+            build_shuffle_indices(new_lengths, cp_chunk_lengths, cp_size, rank).to(
+                self.device
+            )
+            for rank in range(cp_size)
+        ]
+
+        def padded_rank_tensor(tensor, positions):
+            parts = []
+            token_offset = position_offset = 0
+            for actual, chunk in zip(new_lengths, cp_chunk_lengths):
+                seq_positions = positions[position_offset : position_offset + chunk]
+                valid = seq_positions < actual
+                output = tensor.new_full((chunk, *tensor.shape[1:]), 123)
+                output[valid] = tensor.index_select(
+                    0, seq_positions[valid].long() + token_offset
+                )
+                parts.append(output)
+                token_offset += actual
+                position_offset += chunk
+            return torch.cat(parts)
+
+        all_q = [padded_rank_tensor(q_full, positions) for positions in all_shuffle]
+        all_k = [padded_rank_tensor(k_full, positions) for positions in all_shuffle]
+        all_v = [padded_rank_tensor(v_full, positions) for positions in all_shuffle]
+        all_kv_buffers = {
+            rank: torch.cat(
+                [
+                    all_k[rank].reshape(-1, kv_head_num * head_dim),
+                    all_v[rank].reshape(-1, kv_head_num * head_dim),
+                ],
+                dim=0,
+            )
+            for rank in range(cp_size)
+        }
+        qkv = torch.cat(
+            [
+                all_q[cp_rank].reshape(-1, head_num * head_dim),
+                all_k[cp_rank].reshape(-1, kv_head_num * head_dim),
+                all_v[cp_rank].reshape(-1, kv_head_num * head_dim),
+            ],
+            dim=-1,
+        )
+        attn_inputs = build_cp_attn_inputs(
+            [new + prefix for new, prefix in zip(new_lengths, prefix_lengths)],
+            cp_chunk_lengths,
+            cp_size,
+            tokens_per_block,
+            prefix_lengths=prefix_lengths,
+            device=self.device,
+        )
+        attn_inputs.context_parallel_info.prefill_shuffle_indices = all_shuffle[
+            cp_rank
+        ].cpu()
+        padding_mask = attn_inputs.context_parallel_info.prefill_qkv_padding_mask
+        self.assertGreater((padding_mask == 0).sum().item(), 0)
+
+        kv_cache = None
+        if with_kv_cache:
+            sequence_lengths = [
+                new + prefix for new, prefix in zip(new_lengths, prefix_lengths)
+            ]
+            kv_cache = make_kv_cache(
+                sum(
+                    math.ceil(length / tokens_per_block) for length in sequence_lengths
+                ),
+                kv_head_num,
+                tokens_per_block,
+                head_dim,
+                device=self.device,
+            )
+            fill_prefix_into_kv_cache(
+                kv_cache,
+                prefix_k,
+                prefix_v,
+                prefix_lengths,
+                sequence_lengths,
+                tokens_per_block,
+            )
+        else:
+            empty_ids = torch.empty(0, dtype=torch.int32)
+            attn_inputs.kv_cache_kernel_block_id = empty_ids
+            attn_inputs.kv_cache_kernel_block_id_device = empty_ids.to(self.device)
+
+        output = self._run_with_mocks(
+            attn_cfg,
+            par_cfg,
+            attn_inputs,
+            qkv,
+            kv_cache,
+            all_shuffle,
+            all_kv_buffers,
+        )
+        positions = all_shuffle[cp_rank]
+        batch_indices = torch.cat(
+            [
+                torch.full((chunk,), batch, device=self.device)
+                for batch, chunk in enumerate(cp_chunk_lengths)
+            ]
+        )
+        actual_by_position = torch.tensor(new_lengths, device=self.device)[
+            batch_indices.long()
+        ]
+        valid = positions < actual_by_position
+        expected_parts = []
+        token_offset = position_offset = 0
+        for actual, chunk in zip(new_lengths, cp_chunk_lengths):
+            seq_positions = positions[position_offset : position_offset + chunk]
+            seq_valid = seq_positions < actual
+            expected_parts.append(
+                ref_output.index_select(
+                    0, seq_positions[seq_valid].long() + token_offset
+                )
+            )
+            token_offset += actual
+            position_offset += chunk
+        self._assert_close(output[valid], torch.cat(expected_parts))
+
+        if kv_cache is not None:
+            cache_k, cache_v = extract_kv_from_paged_cache(
+                kv_cache, sequence_lengths, tokens_per_block
+            )
+            expected_k = []
+            expected_v = []
+            prefix_offset = new_offset = 0
+            for prefix, new in zip(prefix_lengths, new_lengths):
+                expected_k.extend(
+                    [
+                        prefix_k[prefix_offset : prefix_offset + prefix],
+                        k_full[new_offset : new_offset + new],
+                    ]
+                )
+                expected_v.extend(
+                    [
+                        prefix_v[prefix_offset : prefix_offset + prefix],
+                        v_full[new_offset : new_offset + new],
+                    ]
+                )
+                prefix_offset += prefix
+                new_offset += new
+            self.assertTrue(torch.equal(cache_k, torch.cat(expected_k)))
+            self.assertTrue(torch.equal(cache_v, torch.cat(expected_v)))
 
     # ---- no-prefix driver ----
 
@@ -345,7 +600,6 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
                 new_lengths,
                 cp_size,
                 r,
-                prefix_lengths=prefix_lengths,
                 device=self.device,
             )
             for r in range(cp_size)
@@ -506,6 +760,26 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
             cp_rank=2,
             tokens_per_block=16,
         )
+
+    def test_padding_filters_cache_sentinels(self):
+        self.run_padded([65, 130], [64, 32], with_kv_cache=True)
+
+    def test_warmup_without_cache_or_block_ids(self):
+        self.run_padded([65], [0], with_kv_cache=False)
+
+    @unittest.skipUnless(torch.cuda.device_count() >= 4, "four CUDA devices required")
+    def test_nonzero_tp_subgroup_falls_back_from_user_buffers(self):
+        ports, locks = PortManager().get_consecutive_ports(1)
+        try:
+            mp.spawn(
+                _group_rank_send_recv_worker,
+                args=(ports[0],),
+                nprocs=4,
+                join=True,
+            )
+        finally:
+            for lock in locks:
+                lock.__exit__(None, None, None)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
@@ -2,8 +2,8 @@
 Unit tests for CP linear attention (GatedDeltaNet) per-layer all-gather path.
 
 Tests:
-  1. Index math: cp_local_extract_indices correctly maps zigzag positions
-  2. Full forward: single-rank mock verifies CP output matches non-CP reference
+  1. Metadata and forward: production CP metadata maps local zigzag tokens correctly
+  2. Relay: real TP subgroups match non-CP output and cache states
 """
 
 import contextlib
@@ -14,17 +14,18 @@ from typing import List
 from unittest.mock import patch
 
 import torch
+import torch.multiprocessing as mp
 
 from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils import (
     build_cp_attn_inputs,
-    build_padding_mask,
-    build_restore_indices,
+    build_shuffle_indices,
     compute_rank_positions,
-    zigzag_positions_for_rank,
 )
 from rtp_llm.models_py.triton_kernels.causal_conv1d import (
+    causal_conv1d_fn,
     prepare_causal_conv1d_metadata,
 )
+from rtp_llm.test.utils.port_util import PortManager
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
@@ -56,90 +57,273 @@ def _add_device_tensors(inputs, device: torch.device):
         {
             "prefix_lengths_device": inputs.prefix_lengths.to(device),
             "input_lengths_device": inputs.input_lengths.to(device),
+            "kv_cache_kernel_block_id_device": (
+                inputs.kv_cache_kernel_block_id.to(device)
+                if inputs.kv_cache_kernel_block_id is not None
+                else None
+            ),
         },
     )
 
 
-class TestCPLinearAttnIndexMath(unittest.TestCase):
-    """Verify that _build_cp_linear_attn_metadata produces correct extract indices."""
+def _make_linear_module(device, parallelism_config):
+    from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+    from rtp_llm.ops import DataType, LinearAttentionConfig
+    from rtp_llm.utils.model_weight import W
 
-    def _build_indices(
-        self,
-        sequence_lengths: List[int],
-        cp_size: int,
-        cp_rank: int,
-        device: torch.device,
-    ):
-        """Reproduce the index construction from Qwen3NextModel._build_cp_linear_attn_metadata."""
-        cp_chunk_lengths = [sl // cp_size for sl in sequence_lengths]
-        restore_indices = build_restore_indices(cp_chunk_lengths, cp_size).to(device)
-        padding_mask = build_padding_mask(cp_chunk_lengths, cp_size).to(device)
-        unpad_restore = restore_indices[padding_mask == 1]
+    num_heads, head_dim, hidden_size, conv_width = 2, 64, 128, 4
+    config = LinearAttentionConfig()
+    config.linear_num_key_heads = num_heads
+    config.linear_num_value_heads = num_heads
+    config.linear_key_head_dim = head_dim
+    config.linear_value_head_dim = head_dim
+    config.linear_conv_kernel_dim = conv_width
+    config.ssm_state_dtype = DataType.TYPE_BF16
+    config.conv_state_dtype = DataType.TYPE_BF16
 
-        total_ag = padding_mask.shape[0]
-        local_chunk_total = total_ag // cp_size
-        local_start = cp_rank * local_chunk_total
-        local_end = local_start + local_chunk_total
+    qkv_dim = head_dim * num_heads * 3
+    torch.manual_seed(123)
+    weights = {
+        W.linear_attn_conv1d_w: torch.randn(
+            qkv_dim, 1, conv_width, device=device, dtype=torch.bfloat16
+        ),
+        W.linear_attn_dt_b: torch.randn(num_heads, device=device, dtype=torch.bfloat16),
+        W.linear_attn_alog: torch.randn(num_heads, device=device, dtype=torch.bfloat16),
+        W.linear_attn_norm_w: torch.randn(
+            head_dim, device=device, dtype=torch.bfloat16
+        ),
+        W.linear_attn_qkvz_w: torch.randn(
+            hidden_size,
+            qkv_dim + head_dim * num_heads,
+            device=device,
+            dtype=torch.bfloat16,
+        ),
+        W.linear_attn_qkvz_s: None,
+        W.linear_attn_ba_w: torch.randn(
+            hidden_size, num_heads * 2, device=device, dtype=torch.bfloat16
+        ),
+        W.linear_attn_out_w: torch.randn(
+            head_dim * num_heads,
+            hidden_size,
+            device=device,
+            dtype=torch.bfloat16,
+        ),
+        W.linear_attn_out_s: None,
+    }
+    return Qwen3NextGatedDeltaNet(
+        config, parallelism_config, weights, layernorm_eps=1e-6
+    ).to(device)
 
-        inv_restore = torch.empty(total_ag, dtype=torch.long, device=device)
-        inv_restore.fill_(-1)
-        inv_restore[unpad_restore.long()] = torch.arange(
-            unpad_restore.shape[0], device=device
+
+def _make_nocp_inputs(new_length, prefix_length, device):
+    from rtp_llm.ops.compute_ops import PyAttentionInputs
+
+    total_length = prefix_length + new_length
+    block_count = math.ceil(total_length / 64)
+    block_ids = torch.arange(1, block_count + 1, dtype=torch.int32).view(1, -1)
+    inputs = PyAttentionInputs()
+    inputs.is_prefill = True
+    inputs.cu_seqlens_device = torch.tensor(
+        [0, new_length], dtype=torch.int32, device=device
+    )
+    inputs.input_lengths = torch.tensor([new_length], dtype=torch.int32)
+    inputs.sequence_lengths = torch.tensor([total_length], dtype=torch.int32)
+    inputs.prefix_lengths = torch.tensor([prefix_length], dtype=torch.int32)
+    inputs.kv_cache_kernel_block_id = block_ids
+    inputs.context_parallel_info = None
+    return _add_device_tensors(inputs, device)
+
+
+def _make_cp_metadata(inputs, cp_size, cp_rank, device):
+    from types import SimpleNamespace
+
+    from rtp_llm.models_py.model_desc.qwen3_next import (
+        Qwen3NextMetadata,
+        Qwen3NextModel,
+    )
+
+    metadata_builder = SimpleNamespace(
+        parallelism_config=SimpleNamespace(tp_size=cp_size, tp_rank=cp_rank)
+    )
+    metadata = Qwen3NextModel._build_cp_linear_attn_metadata(
+        metadata_builder, inputs, device
+    )
+    return Qwen3NextMetadata(
+        full_prefill_conv1d_meta=metadata[0],
+        full_prefill_cu_seqlens=metadata[1],
+        cp_restore_indices=metadata[2],
+        cp_local_extract_indices=metadata[3],
+        cp_local_valid_mask=metadata[4],
+    )
+
+
+def _new_linear_cache(module, total_length, device):
+    from rtp_llm.ops.compute_ops import LayerKVCache
+
+    converter = module.prefill_gdn.linear_cache_converter
+    row_elements = math.ceil(converter.block_size_bytes / 2)
+    block_count = math.ceil(total_length / 64)
+    base = torch.zeros(
+        block_count + 1,
+        row_elements,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    return LayerKVCache(base, 64)
+
+
+def _run_cp_relay_case(module, device, cp_rank, new_length, prefix_length, with_cache):
+    from rtp_llm.models_py.distributed.collective_torch import Group
+    from rtp_llm.models_py.distributed.collective_torch import (
+        all_reduce as distributed_all_reduce,
+    )
+    from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextMetadata
+
+    total_length = prefix_length + new_length
+    reference_cache = cp_cache = None
+    if with_cache:
+        initial_cache = _new_linear_cache(module, total_length, device)
+        if prefix_length:
+            prefix_hidden = torch.randn(
+                prefix_length, 128, device=device, dtype=torch.bfloat16
+            )
+            prefix_inputs = _make_nocp_inputs(prefix_length, 0, device)
+            prefix_cu = prefix_inputs.cu_seqlens_device
+            prefix_meta = Qwen3NextMetadata(
+                prefill_conv1d_meta=prepare_causal_conv1d_metadata(prefix_cu, device)
+            )
+            module(prefix_hidden, None, initial_cache, prefix_inputs, prefix_meta)
+        reference_cache = _new_linear_cache(module, total_length, device)
+        reference_cache.kv_cache_base.copy_(initial_cache.kv_cache_base)
+        cp_cache = _new_linear_cache(module, total_length, device)
+        cp_cache.kv_cache_base.copy_(initial_cache.kv_cache_base)
+
+    full_hidden = torch.randn(new_length, 128, device=device, dtype=torch.bfloat16)
+    reference_inputs = _make_nocp_inputs(new_length, prefix_length, device)
+    reference_cu = reference_inputs.cu_seqlens_device
+    reference_meta = Qwen3NextMetadata(
+        prefill_conv1d_meta=prepare_causal_conv1d_metadata(reference_cu, device)
+    )
+    with torch.no_grad():
+        reference_output = module(
+            full_hidden, None, reference_cache, reference_inputs, reference_meta
         )
 
-        local_mask = padding_mask[local_start:local_end]
-        local_ag_positions = torch.arange(local_start, local_end, device=device)[
-            local_mask == 1
-        ]
-        return inv_restore[local_ag_positions]
+    cp_size = 2
+    segment_alignment = 64
+    padded_length = math.ceil(new_length / (2 * cp_size * segment_alignment)) * (
+        2 * cp_size * segment_alignment
+    )
+    cp_chunk_length = padded_length // cp_size
+    positions = build_shuffle_indices(
+        [new_length], [cp_chunk_length], cp_size, cp_rank
+    ).to(device)
+    valid = positions < new_length
+    local_hidden = full_hidden.new_zeros(cp_chunk_length, full_hidden.shape[1])
+    local_hidden[valid] = full_hidden.index_select(0, positions[valid].long())
+    cp_inputs = build_cp_attn_inputs(
+        [total_length],
+        [cp_chunk_length],
+        cp_size,
+        64,
+        prefix_lengths=[prefix_length],
+        block_id_start=1,
+        device=device,
+    )
+    cp_inputs.context_parallel_info.prefill_shuffle_indices = positions.cpu()
+    cp_inputs = _add_device_tensors(cp_inputs, device)
+    assert (cp_inputs.context_parallel_info.prefill_qkv_padding_mask == 0).any()
+    cp_meta = _make_cp_metadata(cp_inputs, cp_size, cp_rank, device)
 
-    def test_single_seq_cp2_rank0(self):
-        device = torch.device("cpu")
-        seq_lengths = [16]
-        cp_size, cp_rank = 2, 0
-        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
-        expected = zigzag_positions_for_rank(16, cp_size, cp_rank)
-        self.assertEqual(idx.tolist(), expected)
+    def out_of_place_all_reduce(tensor, group):
+        assert group == Group.TP
+        result = tensor.clone()
+        return distributed_all_reduce(result, group=group, inplace=True)
 
-    def test_single_seq_cp2_rank1(self):
-        device = torch.device("cpu")
-        seq_lengths = [16]
-        cp_size, cp_rank = 2, 1
-        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
-        expected = zigzag_positions_for_rank(16, cp_size, cp_rank)
-        self.assertEqual(idx.tolist(), expected)
+    patch_target = "rtp_llm.models_py.model_desc.qwen3_next.all_reduce"
+    reduce_context = (
+        patch(patch_target, side_effect=out_of_place_all_reduce)
+        if with_cache
+        else contextlib.nullcontext()
+    )
+    with reduce_context, torch.no_grad():
+        cp_output = module(local_hidden, None, cp_cache, cp_inputs, cp_meta)
 
-    def test_single_seq_cp4(self):
-        device = torch.device("cpu")
-        for rank in range(4):
-            idx = self._build_indices([32], 4, rank, device)
-            expected = zigzag_positions_for_rank(32, 4, rank)
-            self.assertEqual(idx.tolist(), expected, f"rank={rank}")
+    torch.testing.assert_close(
+        cp_output[valid].float(),
+        reference_output.index_select(0, positions[valid].long()).float(),
+        rtol=1e-2,
+        atol=1e-2,
+    )
+    if cp_cache is not None:
+        reference_ssm = module.prefill_gdn._get_ssm_states(
+            reference_cache.kv_cache_base
+        )
+        cp_ssm = module.prefill_gdn._get_ssm_states(cp_cache.kv_cache_base)
+        torch.testing.assert_close(
+            cp_ssm.float(), reference_ssm.float(), rtol=2e-2, atol=2e-2
+        )
+        reference_conv = module.prefill_gdn._get_conv_states(
+            reference_cache.kv_cache_base
+        )
+        cp_conv = module.prefill_gdn._get_conv_states(cp_cache.kv_cache_base)
+        torch.testing.assert_close(cp_conv, reference_conv, rtol=0, atol=0)
 
-    def test_multi_batch_cp2(self):
-        device = torch.device("cpu")
-        seq_lengths = [8, 16]
-        cp_size, cp_rank = 2, 0
-        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
-        expected = []
-        offset = 0
-        for sl in seq_lengths:
-            positions = zigzag_positions_for_rank(sl, cp_size, cp_rank)
-            expected.extend([p + offset for p in positions])
-            offset += sl
-        self.assertEqual(idx.tolist(), expected)
 
-    def test_roundtrip_all_ranks_cover_all_tokens(self):
-        """All ranks together should cover every token exactly once."""
-        device = torch.device("cpu")
-        seq_lengths = [16, 32]
-        cp_size = 2
-        all_indices = []
-        for rank in range(cp_size):
-            idx = self._build_indices(seq_lengths, cp_size, rank, device)
-            all_indices.extend(idx.tolist())
-        total = sum(seq_lengths)
-        self.assertEqual(sorted(all_indices), list(range(total)))
+def _cp_relay_worker(world_rank, master_port):
+    from rtp_llm.models_py.distributed.collective_torch import (
+        destroy_distributed_environment,
+        init_distributed_environment,
+    )
+    from rtp_llm.ops import CPRotateMethod, NcclCommConfig, ParallelismConfig
+
+    device = torch.device(f"cuda:{world_rank}")
+    torch.cuda.set_device(device)
+    cp_rank = world_rank % 2
+    parallelism_config = ParallelismConfig()
+    parallelism_config.tp_size = 2
+    parallelism_config.tp_rank = cp_rank
+    parallelism_config.dp_size = 2
+    parallelism_config.dp_rank = world_rank // 2
+    parallelism_config.world_size = 4
+    parallelism_config.world_rank = world_rank
+    parallelism_config.local_world_size = 4
+    parallelism_config.local_rank = world_rank
+    parallelism_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+    init_distributed_environment(
+        parallelism_config,
+        NcclCommConfig(nccl_ip="127.0.0.1"),
+        master_port,
+        timeout=60,
+    )
+    try:
+        module = _make_linear_module(device, parallelism_config)
+        for new_length, prefix_length, with_cache in (
+            (1, 0, False),
+            (2, 0, False),
+            (65, 0, True),
+            (65, 64, True),
+        ):
+            _run_cp_relay_case(
+                module,
+                device,
+                cp_rank,
+                new_length,
+                prefix_length,
+                with_cache,
+            )
+    finally:
+        destroy_distributed_environment()
+
+
+class TestCPLinearAttnMetadata(unittest.TestCase):
+    def test_cache_ends_support_short_and_aligned_sequences(self):
+        from rtp_llm.models_py.model_desc.qwen3_next import _cp_cache_ends
+
+        self.assertEqual(_cp_cache_ends(128, 2048, torch.device("cpu")).tolist(), [128])
+        self.assertEqual(
+            _cp_cache_ends(4096, 2048, torch.device("cpu")).tolist(), [2048, 4096]
+        )
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
@@ -150,6 +334,55 @@ class TestCPLinearAttnForward(unittest.TestCase):
         self.device = torch.device("cuda")
         torch.manual_seed(42)
         torch.cuda.manual_seed(42)
+
+    def test_segmented_conv_matches_full_sequence(self):
+        """Carrying the last width-1 inputs preserves causal-conv results."""
+        width = 4
+        dim = 256
+        lengths = [64, 1, 2, 65]
+        total = sum(lengths)
+        x = torch.randn(total, dim, device=self.device, dtype=torch.bfloat16)
+        weight = torch.randn(dim, width, device=self.device, dtype=torch.bfloat16)
+        prefix_lengths = torch.zeros(1, dtype=torch.int32, device=self.device)
+
+        full_cu = torch.tensor([0, total], dtype=torch.int32, device=self.device)
+        full = causal_conv1d_fn(
+            x=x.transpose(0, 1),
+            weight=weight,
+            bias=None,
+            conv_states=None,
+            query_start_loc=full_cu,
+            block_map=None,
+            prefix_lengths=prefix_lengths,
+            seq_size_per_block=1,
+            metadata=prepare_causal_conv1d_metadata(full_cu, self.device),
+        ).transpose(0, 1)
+
+        carry = x.new_zeros(width - 1, dim)
+        outputs = []
+        start = 0
+        for length in lengths:
+            raw_segment = x[start : start + length]
+            segment_input = torch.cat([carry, raw_segment])
+            segment_cu = torch.tensor(
+                [0, segment_input.shape[0]], dtype=torch.int32, device=self.device
+            )
+            segment_output = causal_conv1d_fn(
+                x=segment_input.transpose(0, 1),
+                weight=weight,
+                bias=None,
+                conv_states=None,
+                query_start_loc=segment_cu,
+                block_map=None,
+                prefix_lengths=prefix_lengths,
+                seq_size_per_block=1,
+                metadata=prepare_causal_conv1d_metadata(segment_cu, self.device),
+            ).transpose(0, 1)
+            outputs.append(segment_output[width - 1 :])
+            carry = segment_input[-(width - 1) :].contiguous()
+            start += length
+
+        torch.testing.assert_close(torch.cat(outputs), full, rtol=0, atol=0)
 
     def _run_cp_vs_nocp(
         self,
@@ -172,7 +405,7 @@ class TestCPLinearAttnForward(unittest.TestCase):
             prepare_causal_conv1d_metadata,
         )
         from rtp_llm.ops import DataType, LinearAttentionConfig, ParallelismConfig
-        from rtp_llm.ops.compute_ops import PyAttentionInputs, PyContextParallelParams
+        from rtp_llm.ops.compute_ops import PyAttentionInputs
 
         assert all(sl % (cp_size * 2) == 0 for sl in sequence_lengths)
         cp_chunk_lengths = [sl // cp_size for sl in sequence_lengths]
@@ -293,43 +526,8 @@ class TestCPLinearAttnForward(unittest.TestCase):
                 )
                 all_rank_packed.append(torch.cat([r_mixed_qkv, r_b, r_a], dim=-1))
 
-        cp_info = cp_attn_inputs.context_parallel_info
-        restore_indices = cp_info.prefill_qkv_restore_indice
-        padding_mask = cp_info.prefill_qkv_padding_mask
-        unpad_restore = restore_indices[padding_mask == 1]
-
-        total_ag = padding_mask.shape[0]
-        local_chunk_total = total_ag // cp_size
-        local_start = cp_rank * local_chunk_total
-        local_end = local_start + local_chunk_total
-
-        inv_restore = torch.empty(total_ag, dtype=torch.long, device=self.device)
-        inv_restore.fill_(-1)
-        inv_restore[unpad_restore.long()] = torch.arange(
-            unpad_restore.shape[0], device=self.device
-        )
-        local_inv = inv_restore[local_start:local_end]
-        cp_local_valid_mask = local_inv >= 0
-        cp_local_extract_idx = local_inv[cp_local_valid_mask]
-
-        actual_lengths = torch.tensor(sequence_lengths, dtype=torch.int32)
-        full_cu_from_actual = torch.zeros(
-            batch_size + 1, dtype=torch.int32, device=self.device
-        )
-        full_cu_from_actual[1:] = torch.tensor(
-            sequence_lengths, device=self.device
-        ).cumsum(0)
-
-        full_conv_meta = prepare_causal_conv1d_metadata(
-            query_start_loc=full_cu_from_actual, device=self.device
-        )
-
-        cp_meta = Qwen3NextMetadata(
-            full_prefill_conv1d_meta=full_conv_meta,
-            full_prefill_cu_seqlens=full_cu_from_actual,
-            cp_restore_indices=restore_indices,
-            cp_local_extract_indices=cp_local_extract_idx,
-            cp_local_valid_mask=cp_local_valid_mask,
+        cp_meta = _make_cp_metadata(
+            cp_attn_inputs, cp_size, cp_rank, self.device
         )
 
         def mock_ag(tensor, group=None):
@@ -358,6 +556,15 @@ class TestCPLinearAttnForward(unittest.TestCase):
 
     def test_multi_batch_cp2(self):
         self._run_cp_vs_nocp(sequence_lengths=[16, 32], cp_size=2, cp_rank=0)
+
+    @unittest.skipUnless(torch.cuda.device_count() >= 4, "four CUDA devices required")
+    def test_cp2_relay_short_tail_prefix_and_cache(self):
+        ports, locks = PortManager().get_consecutive_ports(1)
+        try:
+            mp.spawn(_cp_relay_worker, args=(ports[0],), nprocs=4, join=True)
+        finally:
+            for lock in locks:
+                lock.__exit__(None, None, None)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -412,26 +412,6 @@ class FIFOSchedulerConfig:
         ...
 
 
-class GrammarConfig:
-    constrained_json_disable_any_whitespace: bool
-    grammar_backend: str
-    num_workers: int
-    override_stop_tokens: list[int]
-    tokenizer_info_json: str
-
-    def __getstate__(self) -> tuple:
-        ...
-
-    def __init__(self) -> None:
-        ...
-
-    def __setstate__(self, arg0: tuple) -> None:
-        ...
-
-    def to_string(self) -> str:
-        ...
-
-
 class FMHAConfig:
     absorb_opt_len: int
     disable_flashinfer_hybrid_prefill: bool
@@ -572,6 +552,7 @@ class GrammarConfig:
     compiler_cache_bytes: int
     constrained_json_disable_any_whitespace: bool
     num_workers: int
+    terminate_without_stop_token: bool
     tokenizer_info_json: str
     def __getstate__(self) -> tuple:
         ...
@@ -1305,6 +1286,7 @@ class PrefillCPConfig:
     kv_cache_sharded: bool
     method: CPRotateMethod
     prefill_cp_size: int
+    segment_size_alignment: int
     def __getstate__(self) -> tuple:
         ...
     def __init__(self) -> None:


### PR DESCRIPTION
# Qwen3.5 混合注意力 Context Parallelism 开发与验证

## PR 概要

Qwen3.5 同时包含 full attention 和 Gated DeltaNet（GDN）linear attention。原有 Context Parallelism 可以并行 full attention，但 GDN 具有沿 token 方向传递的 recurrent state，原路径需要在各 rank 聚合后重复计算完整序列，linear attention 层无法获得实际 CP 加速。

本 PR 为 Qwen3.5 prefill 增加了 GDN CP relay 路径：输入仍使用与 full attention 一致的 zigzag CP 布局，每个连续 GDN segment 只在所属 rank 计算一次，并按照全局因果顺序将 recurrent state 传给下一 segment；causal-conv 同步传递最后 3 个未卷积 QKV，因此无需在每个 GDN 层 all-gather 完整投影序列。实现同时补充了 Qwen3.5 所需的 CP 分段对齐、SSM/conv cache 状态处理、非对齐长度与 attention 元数据兼容，以及 compressed-tensors FP8 block checkpoint 加载支持。不满足 relay 快路径条件时仍保留原有完整序列回退。

下文使用三个 FP8 checkpoint 验证现有 full-attention CP 路径和新增混合注意力 CP 路径。Qwen3.5 测试模型已由 9B 统一替换为官方 Qwen3.5-27B-FP8；该模型包含 64 层，其中每 4 层有 1 层 full attention，其余为 GDN，更能体现 linear-attention CP 的收益。

## 测试口径

- 代码：`a938f21c16fb382dafbcc112eb2be79a14cd7a88`。
- 硬件：NVIDIA RTX PRO 5000 72GB Blackwell（SM120）。
- 模型权重：三个 checkpoint 均为 FP8；activation 和 KV cache 为 BF16。
- 容器：`hub.docker.alibaba-inc.com/isearch/rtp_llm_base_gpu_cuda13:2026_07_21_15_21_171a25a`。
- 并行配置：`CP_METHOD=ALL_GATHER`、`EP_SIZE=1`、`DP_SIZE=1`；关闭 layer micro-batch、User Buffer、CUDA Graph 和 cache reuse。
- Cache block：QwQ-32B 和 Qwen3-32B 使用 64 token；Qwen3.5-27B 使用 2048 token。
- TTFT 为 `first_token_cost_time - wait_time`。batch size=1，1 次预热、5 次测量，去掉最大值和最小值后取平均。
- 括号内加速比以同一输入长度的单卡为 1.00x；两个 full-attention 32B 模型以单卡 ragged 为基准，Qwen3.5-27B 以单卡 fmha_v2 为基准。
- 通用精度探针在输入长度 128、1024、4096 下贪心生成 8 个 token 并返回完整 logits；Qwen3-32B 另使用 20 条真实中英文 prompt（34~206 token）与官方 16 位模型比较同一上下文的首步完整 logits。

## FMHA v2 与 ragged

| 项目 | fmha_v2 | ragged |
|---|---|---|
| 当前 RTP-LLM 接口 | FlashInfer 暴露的 `trtllm_fmha_v2_prefill` | FlashInfer `BatchPrefillWithRaggedKVCacheWrapper` |
| 输入组织 | MHA 使用 packed QKV，GQA 使用连续 Q/KV，并传入累计序列长度 | 按有效 token 紧凑排列 Q/K/V，以 `cu_seqlens` 描述各变长序列 |
| 当前调用返回值 | attention output | attention output，可同时返回 LSE（log-sum-exp） |
| 本报告用途 | 非 CP 的生产默认路径 | 单卡/TP 对照，以及 CP 的局部 attention |

CP 将 context 的 KV 分布到多个 rank；每个 rank 先计算局部 attention，随后必须用各分片的 LSE 作为全局 softmax 权重合并局部输出。当前 fmha_v2 调用路径不返回该 LSE，而 ragged 接口支持 `return_lse=True` 和 `merge_state`，因此 CP2 必须启用 ragged。这是 CP 正确归并的接口要求。为避免 kernel 口径造成虚高，两个 full-attention 32B 模型同时报告单卡/TP2 的 fmha_v2 与 ragged，并统一以单卡 ragged 计算加速比。

Qwen3.5-27B 的普通单卡/TP2 ragged 均在首个 forward 由 attention factory 报 `can not find mha type`，因此该模型按既定口径只比较三条可用路径，并以单卡 fmha_v2 为基准；CP2 使用能返回 LSE 的 CP ragged 路径。

## Qwen3.5-27B

模型：`Qwen/Qwen3.5-27B-FP8`（official FP8 block）。TTFT 单位：ms。

| 输入长度 | 单卡 fmha_v2 | TP2 fmha_v2 | CP2 ragged |
|---:|---:|---:|---:|
| 1024 | 142.20 (1.00x) | 125.67 (1.13x) | 152.07 (0.94x) |
| 4096 | 645.60 (1.00x) | 484.98 (1.33x) | 387.51 (1.67x) |
| 8192 | 1389.78 (1.00x) | 1030.73 (1.35x) | 777.74 (1.79x) |
| 16384 | 3055.87 (1.00x) | 2206.41 (1.38x) | 1659.55 (1.84x) |
| 32768 | 7136.08 (1.00x) | 4955.88 (1.44x) | 3631.74 (1.96x) |

在主要长上下文场景下，新增 linear-attention CP 已产生明显收益：32K 时 CP2 为 1.96x，TP2 为 1.44x，CP2 相对 TP2 的 TTFT 再降低 26.7%，相对优化前 CP2 的 4406.90 ms 降低 17.6%；16K 时分别为 1.84x 和 1.38x，CP2 相对 TP2 再降低 24.8%。1K 下 CP 通信和 relay 固定开销仍占主导，暂不具备收益。

执行路径也已通过日志与 timeline 交叉确认：两个 rank 均以 `prefill_cp_size=2` 初始化 ZIG_ZAG CP；32K timeline 中 rank0/rank1 分别执行 96/48 次 `ChunkGatedDeltaRuleFunction`，数量与 48 个 GDN 层的 CP2 relay 调度完全一致。优化后每个 rank 的 all-gather 从 81 次降至 33 次，消除的 48 次正好对应全部 GDN 层；新增的 96 次卷积状态广播每次仅 30,720 个 BF16 元素，合计约 0.7 ms/rank。新旧 CP2 在 128/1024/4096 三组探针上的最终 logits 逐元素一致。

## QwQ-32B

模型：`qingcheng-ai/QWQ-32B-FP8`（community FP8 block）。TTFT 单位：ms。

| 输入长度 | 单卡 ragged | 单卡 fmha_v2 | TP2 ragged | TP2 fmha_v2 | CP2 ragged |
|---:|---:|---:|---:|---:|---:|
| 1024 | 166.17 (1.00x) | 168.83 (0.98x) | 132.23 (1.26x) | 134.23 (1.24x) | 106.01 (1.57x) |
| 4096 | 745.96 (1.00x) | 775.38 (0.96x) | 535.15 (1.39x) | 549.23 (1.36x) | 397.41 (1.88x) |
| 8192 | 1628.41 (1.00x) | 1742.65 (0.93x) | 1139.11 (1.43x) | 1193.94 (1.36x) | 858.47 (1.90x) |
| 16384 | 3687.86 (1.00x) | 4120.46 (0.90x) | 2466.56 (1.50x) | 2685.04 (1.37x) | 1959.28 (1.88x) |
| 32768 | 9032.31 (1.00x) | 10727.20 (0.84x) | 5649.50 (1.60x) | 6480.47 (1.39x) | 4741.55 (1.90x) |

## Qwen3-32B

模型：`Qwen/Qwen3-32B-FP8`（official FP8 block）。TTFT 单位：ms。

| 输入长度 | 单卡 ragged | 单卡 fmha_v2 | TP2 ragged | TP2 fmha_v2 | CP2 ragged |
|---:|---:|---:|---:|---:|---:|
| 1024 | 167.99 (1.00x) | 171.54 (0.98x) | 134.09 (1.25x) | 136.62 (1.23x) | 105.95 (1.59x) |
| 4096 | 777.67 (1.00x) | 828.68 (0.94x) | 550.69 (1.41x) | 571.93 (1.36x) | 427.96 (1.82x) |
| 8192 | 1753.17 (1.00x) | 1936.94 (0.91x) | 1196.91 (1.46x) | 1290.81 (1.36x) | 955.26 (1.84x) |
| 16384 | 4155.38 (1.00x) | 4851.92 (0.86x) | 2703.70 (1.54x) | 3074.18 (1.35x) | 2282.73 (1.82x) |
| 32768 | 10905.57 (1.00x) | 13642.88 (0.80x) | 6637.48 (1.64x) | 7992.48 (1.36x) | 5867.52 (1.86x) |

### FP8 精度问题

官方 `Qwen/Qwen3-32B` checkpoint 实际为 BF16，因此以它作为官方 16 位参考。比较使用 20 条真实 prompt 的同一首步上下文；最后一层 lm_head 统一采用 FP32 accumulation，并只统计 151669 个有效 tokenizer token。表格单元格依次给出“top-1 一致数；centered 相对 L2 中位数 / P95”，其中 centered 指先去除不影响 softmax 的 logits 整体平移。

| RTP FP8 配置 | 相对单卡 fmha_v2 | 相对官方 16 位 BF16 |
|---|---:|---:|
| 单卡 fmha_v2 | 20/20；0 / 0 | 19/20；9.01% / 12.80% |
| 单卡 ragged | 17/20；6.20% / 11.46% | 18/20；7.89% / 13.40% |
| TP2 fmha_v2 | 18/20；6.43% / 11.41% | 19/20；7.98% / 13.31% |
| TP2 ragged | 18/20；6.54% / 11.48% | 19/20；8.24% / 13.45% |
| CP2 ragged | 17/20；6.61% / 12.28% | 18/20；7.97% / 13.38% |

- 这不是单条构造 prompt 的偶发现象：20 条真实 prompt 中，五种配置有 4 条在首 token 分叉、13 条在前 8 token 内分叉；但所有官方 BF16 top-1 在五条 RTP 路径中都仍位于 top-5，首次共同分叉处的 top1/top2 margin 中位数仅为 0.122。
- 五条 RTP 路径没有一致的精度赢家。TP2 ragged 对 BF16 的平均 centered L2 最低（8.92%），但相对其他四路的配对 95% 置信区间全部跨过 0，不能据此判定某一路实现错误。
- 官方 Transformers FP8 相对官方 BF16 的 centered L2 中位数已经达到 6.21%~6.50%，且有 2/20 条首 token 改变；同一权重仅切换 eager/SDPA，BF16 的路径差异中位数为 1.69%，FP8 会放大到 4.57%。主要问题是 Qwen3-32B 动态激活 FP8 对计算路径敏感，而不是 CP 独有误差。
- 在本 PR 的纯基线提交 `19dc18f50` 上可复现同一分歧；两条 RTP 路径进入 attention 前的 QKV 完全一致，64 层逐层 kernel 对 FP32 参考也未出现异常突增。CP2 对 BF16 的平均 L2 为 9.12%，仅比最低的 TP2 ragged 高 0.20 个百分点（95% CI `[-0.28, +0.67]`），当前没有证据表明本 PR 或 CP 的 LSE 归并是根因。

## 说明

- CP 仅用于纯初始 prompt 的 prefill，本次未测试 decode。
- CP 在每个 rank 复制完整 FP8 模型，不改变模型权重容量限制；KV cache 容量上限也可能低于 TP。
- Qwen3.5-27B 的普通单卡/TP2 ragged 配置已实际运行并确认不支持，未用空白或旧 9B 数据补表。
- 本轮 Qwen3.5-27B 和 QwQ-32B 的所有可用配置均未出现 token 级差异，因此按报告约定不增加精度问题小节。
- 本报告的精度探针用于发现不同执行路径间的数值分歧，不替代完整任务精度评测。
