### PR TITLE
docs(flexlb): align architecture docs with current design

### DIFF
--- a/rtp_llm/cpp/model_rpc/proto/flexlb_schedule_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/flexlb_schedule_service.proto
@@ -75,6 +75,8 @@ message FlexlbServerStatusPB {
     int32 http_port = 3;
     int32 grpc_port = 4;
     reserved 5;
+    // Present only for a multi-engine frontend; zero is a valid selected index.
+    optional int32 engine_index = 6;
 }
 
 // Why an incoming request was rejected by the admission decision.  This is

--- a/rtp_llm/flexlb/README.md
+++ b/rtp_llm/flexlb/README.md
@@ -370,9 +370,21 @@ Each endpoint must contain exactly one `discovery` object. Supported types are:
 - `dashscope`: Uses `address` as the virtual service ID (internal builds). `base_url` defaults to
   `http://127.0.0.1:8880` when omitted.
 
-`worker_status_port` is optional and controls the gRPC port used only for `GetWorkerStatus`.
+`worker_status_port` is optional and controls the per-engine gRPC port used for `GetWorkerStatus`
+and `GetCacheStatus`.
+When configured, it must be in the TCP port range `[1, 65535]`, including single-engine endpoints.
 When omitted, FlexLB uses the endpoint gRPC port (`http` discovery port + 1, or the discovered
-port itself when `protocol` is `grpc`).
+port itself when `protocol` is `grpc`). `multi_engine_num` defaults to `1`. When it is greater
+than `1`, `worker_status_port` is required and logical engine index `i` is polled at
+`worker_status_port + i`; the endpoint protocol does not change this status-port range.
+
+Each discovered frontend expands to `multi_engine_num` logical workers identified as
+`ip:http_port@index` (including `@0` when the value is `1`). The frontend HTTP/gRPC address stays
+physical and shared. If any index in a physical frontend is unhealthy, FlexLB removes all of its
+logical siblings from routing; resource capacity, queue state, and cache ownership remain
+independent per index. The schedule response omits `engine_index` when `multi_engine_num` is `1`
+and returns the selected index when it is greater than `1`; internal cache and rollback identities
+remain index-qualified in both cases.
 
 Discovery runtime policy belongs to `FLEXLB_CONFIG`, not to each topology endpoint:
 

--- a/rtp_llm/flexlb/docs/architecture/00-overview.md
+++ b/rtp_llm/flexlb/docs/architecture/00-overview.md
@@ -89,8 +89,12 @@ LoadBalancer 策略选 worker（读 EngineWorkerStatus 共享状态 + CacheAware
 ## 核心不变量
 
 - **路由读、同步写**：`EngineWorkerStatus.MODEL_ROLE_WORKER_STATUS`（静态单例，四个角色各一个
-  `ConcurrentHashMap<ip:port, WorkerStatus>`）由后台同步线程写、路由线程读；`WorkerStatus`
-  内所有计数为 Atomic 字段，原子性是**字段级**而非快照级。
+  `ConcurrentHashMap<ip:httpPort@index, WorkerStatus>`）由后台同步线程写、路由线程读；
+  `WorkerStatus` 内所有计数为 Atomic 字段，原子性是**字段级**而非快照级。
+- **内部逻辑地址、外部物理地址**：worker 身份内部一律用逻辑 `ip:httpPort@index`
+  （map key、cache 匹配、回滚、feedback，N=1 也是 `@0`）；对外（schedule 响应、gRPC 拨号）
+  一律用物理地址，线上协议不出现 `@index`，仅 N>1 时 schedule 响应附加 wire
+  `engine_index`。
 - **选中即记账，失败必回滚**：策略 `select()` 成功即 `putLocalTask()` 预扣队列时间与 KV
   token；多阶段路由部分失败必须经 `rollBackRoutingFailure()` → `removeLocalTask()` 撤销。
 - **本地预测 + 引擎对账**：`localTaskMap` 记录 IN_TRANSIT 任务；引擎状态返回后

--- a/rtp_llm/flexlb/docs/architecture/00-overview.md
+++ b/rtp_llm/flexlb/docs/architecture/00-overview.md
@@ -1,110 +1,86 @@
 # Overview
 
-FlexLB 是面向 AI 模型推理负载（RTP-LLM）的高性能智能负载均衡器：提供多种负载均衡策略、
-请求排队调度、KV cache 感知路由与主从高可用。基于 Spring Boot 2.7.18 响应式架构（WebFlux），
-运行于 Java 21。
+FlexLB 是 RTP-LLM 模型推理的负载均衡器。它在 Java 21 / Spring Boot 2.7 WebFlux
+进程中提供 FlexLB 自己的 gRPC 调度服务、worker 状态同步、cache 感知选址、队列调度与
+可选的 ZooKeeper 主选举。
 
-本目录是**稳态架构文档**（描述当前代码长什么样）。架构变了要回来更新本目录。
-流程约束（构建、测试、提交规范）见根目录 [AGENTS.md](../../AGENTS.md)。
+本目录描述当前代码的稳态设计，而不是部署方案或演进计划。代码结构或运行时所有权发生
+变化时，应同步更新本目录。
 
 ## 文档索引
 
 | 文档 | 内容 |
 |---|---|
-| [01-routing-and-balancing](01-routing-and-balancing.md) | Router / LoadBalancer 模式、角色多阶段路由与 group 链、回滚机制、四种策略算法 |
-| [02-queue-scheduling](02-queue-scheduling.md) | PriorityScheduler / WorkerBatcher / RouteService、请求生命周期与取消 |
-| [03-resource-management](03-resource-management.md) | EndpointRegistry、worker 可用性与本地资源预留 |
-| [04-worker-sync-and-cache](04-worker-sync-and-cache.md) | Worker 状态 gRPC 同步、本地乐观预测、KV cache 三种匹配源（LOCAL_SYNC / KVCM / LOCAL_STANDBY） |
-| [05-lifecycle-and-consistency](05-lifecycle-and-consistency.md) | 生命周期 Hook 与 /hook/* 端点、ZooKeeper LeaderSelector 主选举、slave 转发 |
-| [06-configuration-and-observability](06-configuration-and-observability.md) | 全量配置字段与默认值、HTTP 端点、日志架构、指标体系 |
-
-## 技术栈
-
-| 类别 | 技术 |
-|---|---|
-| 语言 | Java 21 |
-| 框架 | Spring Boot 2.7.18（WebFlux 响应式，HTTP 端点返回 `Mono`/`Flux`） |
-| 响应式 | Project Reactor 2024.0.10 |
-| RPC | gRPC 1.65.0（worker 状态同步 + KVCM meta service） |
-| 协调 | Apache Curator 5.4.0（ZooKeeper LeaderSelector 主选举） |
-| 本地缓存 | Caffeine |
-| 网络 | Netty 4.1.127.Final |
-| 观测 | FlexMonitor 抽象（默认 NoOp，internal profile 下 KMonitor）、OpenTelemetry W3C 传播 |
-| 测试 | JUnit 5 + Mockito 5.20.0 |
+| [01-routing-and-balancing](01-routing-and-balancing.md) | 角色选址、候选策略、DIRECT 和 QUEUE 的提交边界 |
+| [02-queue-scheduling](02-queue-scheduling.md) | 全局队列、endpoint batcher、交付与请求生命周期 |
+| [03-resource-management](03-resource-management.md) | worker generation、endpoint 账本与容量事件 |
+| [04-worker-sync-and-cache](04-worker-sync-and-cache.md) | worker 状态提交、cache matching 与 block hash |
+| [05-lifecycle-and-consistency](05-lifecycle-and-consistency.md) | hook 生命周期、主选举和 gRPC follower 转发 |
+| [06-configuration-and-observability](06-configuration-and-observability.md) | 配置边界、配置来源、端口与观测入口 |
 
 ## 模块划分
 
-多模块 Maven 工程：
-
 | 模块 | 职责 |
 |---|---|
-| **flexlb-api** | Web 层：`HttpLoadBalanceServer`（调度）、`FlexlbControlServer`（控制）、`HealthCheckServer`、`AppStateHookServer`（生命周期 hook）；主端口 7001 |
-| **flexlb-common** | 共享模型（`WorkerStatus`、`Request`/`Response`、`RoleType`、`BalanceContext`）、`FlexlbConfig`/`ConfigService`、`FlexMonitor` 指标抽象、`BlockCacheKeyCalculator` |
-| **flexlb-grpc** | 引擎 gRPC 客户端（worker status / cache status）+ KVCM meta-service 客户端（`KvcmGrpcClient`、leader 解析、健康探测） |
-| **flexlb-sync** | 核心：路由与策略、排队调度、动态资源管理、worker 状态同步、主选举、生命周期 Hook、监控上报 |
-| **flexlb-cache** | KV cache 匹配：LOCAL_SYNC 两级索引（`KvCacheManager`/`GlobalCacheIndex`/`EngineLocalView`）、KVCM provider、Local Standby 兜底索引、failover 编排、block hash 计算 |
+| `flexlb-api` | WebFlux 控制与 hook 端点；`FlexlbGrpcServer`、`FlexlbServiceImpl` 和 follower gRPC forwarder |
+| `flexlb-common` | 配置契约、请求/worker 数据模型、服务发现拓扑、指标抽象和公共工具 |
+| `flexlb-grpc` | 引擎 worker/cache 状态客户端、KVCM 客户端、channel 和 name resolver |
+| `flexlb-sync` | `DefaultRouter`、`RequestScheduler`、endpoint 账本、worker 同步、主选举、生命周期与调度观测 |
+| `flexlb-cache` | block hash、LOCAL_SYNC 索引、KVCM/Local Standby 匹配与 cache 遥测 |
 
-flexlb-sync 内部包结构（`org.flexlb`）：
+`flexlb-sync` 的核心包如下：
 
 ```
 balance/
-├── scheduler/      DefaultRouter / PriorityScheduler / WorkerBatcher / Dispatcher
-├── endpoint/       EndpointRegistry / PrefillEndpoint / DecodeEndpoint / 本地预留账本
-├── strategy/       LoadBalanceStrategy + Prefill / Decode / Random 策略
-└── resource/       PrefillResourceMeasure / DecodeResourceMeasure / ResourceMeasureFactory
-consistency/        LBStatusConsistencyService / ZookeeperMasterElectService
-sync/
-├── synchronizer/   MasterEngineSynchronizer（20ms 定时）/ AbstractEngineStatusSynchronizer（线程池）
-├── runner/         EngineSyncRunner / GrpcWorkerStatusRunner / GrpcCacheStatusCheckRunner
-├── schedule/       ExpirationCleaner（worker/任务过期清理）
-└── status/         EngineWorkerStatus / ModelWorkerStatus / WorkerBlockHashConfigResolver
-service/
-├── grace/          GracefulOnlineService / GracefulShutdownService / ActiveRequestCounter / strategy/ 各 Hooker
-├── grpc/           EngineGrpcService
-├── monitor/        EngineHealthReporter / BatchSchedulerReporter / PrioritySchedulerReporter / FlexlbLogManager
-└── RouteService
+├── scheduler/    RequestScheduler / GlobalQueueCoordinator / WorkerBatcher /
+│                 RequestRegistry / DefaultRouter
+├── endpoint/     EndpointRegistry / PrefillEndpoint / DecodeEndpoint /
+│                 generation lifecycle
+├── delivery/     batch 与 route-decision 的交付边界
+├── strategy/     CostBasedPrefillStrategy / CostBasedDecodeStrategy / RandomStrategy
+└── eviction/     priority preemption 与引擎取消协调
+sync/             MasterEngineSynchronizer / runners / WorkerDirectory
+consistency/      LBStatusConsistencyService / ZookeeperMasterElectService
+service/          RouteService、grace、monitor、grpc 与 optimizer
 ```
 
 ## 请求主链路
 
 ```
-gRPC FlexlbService.Schedule (FlexlbGrpcServer, HTTP 端口 + 100)
-    ↓ ActiveRequestCounter.acquire()（在途请求计数）
-    ↓ 若启用一致性且本机非 master → 转发给 master（master 不可达则降级本地路由）
-    ↓ RequestBlockHashService.prepareBlockCacheKeys()（block hash 计算，独立线程池）
-RouteService.route()
-    ├─ scheduler.type=DIRECT：当前调用链执行 DefaultRouter.route()
-    └─ scheduler.type=QUEUE：PriorityScheduler.submit()
-           ├─ ordering.type=FIFO：普通路由后提交到 Prefill WorkerBatcher
-           └─ ordering.type=PRIORITY：PriorityAdmissionScheduler 做优先级准入/抢占
-    ↓
-DefaultRouter：按非空角色 map 固定顺序路由 PDFUSION → DECODE → PREFILL → VIT，
-               首个成功角色的 worker group 约束后续角色的候选（group 亲和链）
-    ↓
-LoadBalancer 策略选 worker（读 EngineWorkerStatus 共享状态 + CacheAwareService 匹配）
-    ↓ 选中即 WorkerStatus.putLocalTask()：本地乐观记账（队列时间 / KV token 预扣）
-后阶段失败 → DefaultRouter.rollBackRoutingFailure() 逐个 LoadBalancer.rollBack() 撤销记账
+gRPC FlexlbService.Schedule（HTTP server.port + 2）
+    ↓ 解析请求、计入 ActiveRequestCounter、校验 cache identity
+    ↓ 若启用一致性且本机是 follower：单跳 gRPC 转发到 master
+    ↓ 本地路由时准备 block cache keys，并由 RouteService 绑定 FlexlbConfig 快照
+    ├─ DIRECT: DefaultRouter 选址并在同一提交事务中获取 endpoint 所有权
+    └─ QUEUE: RequestScheduler 注册 RequestSlot 后写入 GlobalQueueCoordinator
+            ↓ 决策线程从全局有序队列规划，DefaultRouter 为完整角色集生成选址
+            ↓ 在精确 Prefill/Decode generation 上提交预留
+            ↓ Prefill WorkerBatcher 按 SINGLE 或 FIXED_WINDOW 组织交付
+            ↓ DeliveryStrategy: EnqueueBatch，或返回 route decision
+    ↓ RequestRegistry 处理 ACK、接受确认、取消、deadline 和终态，完成原始 future
 ```
+
+`MODEL_SERVICE_CONFIG` 中的拓扑决定必须路由的角色；`ModelMetaConfig` 将已配置角色按
+`PDFUSION → DECODE → PREFILL → VIT` 的固定顺序保存。运行时某个 worker map 是否为空不会
+改变这份请求角色集。
 
 ## 核心不变量
 
-- **路由读、同步写**：`EngineWorkerStatus.MODEL_ROLE_WORKER_STATUS`（静态单例，四个角色各一个
-  `ConcurrentHashMap<ip:httpPort@index, WorkerStatus>`）由后台同步线程写、路由线程读；
-  `WorkerStatus` 内所有计数为 Atomic 字段，原子性是**字段级**而非快照级。
-- **内部逻辑地址、外部物理地址**：worker 身份内部一律用逻辑 `ip:httpPort@index`
-  （map key、cache 匹配、回滚、feedback，N=1 也是 `@0`）；对外（schedule 响应、gRPC 拨号）
-  一律用物理地址，线上协议不出现 `@index`，仅 N>1 时 schedule 响应附加 wire
-  `engine_index`。
-- **选中即记账，失败必回滚**：策略 `select()` 成功即 `putLocalTask()` 预扣队列时间与 KV
-  token；多阶段路由部分失败必须经 `rollBackRoutingFailure()` → `removeLocalTask()` 撤销。
-- **本地预测 + 引擎对账**：`localTaskMap` 记录 IN_TRANSIT 任务；引擎状态返回后
-  `updateTaskStates()` 对账（IN_TRANSIT→CONFIRMED→RUNNING→FINISHED / LOST），
-  `updateKvCacheTokens()` 回填在途任务的 KV 修正。
-- **策略必须注册**：4 个策略 bean 在构造函数中自注册进 `LoadBalanceStrategyFactory`；
-  `DefaultRouter` 用 `@DependsOn` 保证注册先于路由器构造。
-- **并发抢占用 CAS**：ShortestTTFT 系策略通过 `lastSelectedTime` 的 `compareAndSet`
-  防止多个调度线程基于同一快照选中同一 worker。
-- **master 优先，可降级**：启用一致性时 slave 把请求转发给 master；master 未知或不可达时
-  **降级为本地路由**（不是拒绝）。
-- **KVCM 与 LOCAL_SYNC 互斥**：`kvcmEnabled` 时不再调度本地 cache 状态轮询，cache 匹配走
-  KVCM，Local Standby 作为兜底（自动/手动 failover）。
+- **逻辑身份贯穿内部状态**：一个物理 frontend 的每个 engine 都是
+  `ip:httpPort@engineIndex`；N=1 仍为 `@0`。对外 `ServerStatus` 使用物理地址，只有多
+  engine 响应显式携带 `engine_index`。
+- **发现、状态与路由 generation 分离**：`WorkerDirectory` 持有已发现的
+  `WorkerStatus` generation；`EndpointRegistry` 只公开已提交有效状态的 endpoint generation。
+  路由必须取得 `GenerationPin`，同地址替换或退役不能让旧选择获得新资源。
+- **QUEUE 只有一个生命周期所有者**：`RequestRegistry` 拥有 request id 去重、全局准入、
+  deadline、delivery claim、取消与终态。全局队列负责顺序和选址；每个 `WorkerBatcher`
+  只负责已选定 Prefill endpoint 的分组及交付。
+- **资源以精确 endpoint 账本提交**：Prefill 的活动请求与 Decode 的 shadow reservation/
+  engine fence 都绑定 request generation；失败、取消和退役经相应 reducer 释放，不能由
+  选择阶段的临时快照直接释放。
+- **物理组健康是逻辑 worker 的共同门槛**：共享 frontend 的所有期望 engine sibling
+  均已发布且健康时，该物理组中的逻辑 worker 才可路由。
+- **cache 匹配源由配置决定**：`LOCAL_SYNC` 使用 worker cache 状态更新的本地索引；
+  `KVCM` 使用外部查询并维护 Local Standby 作为故障转移源。两种主索引不会同时写入。
+- **一致性优先单一所有者**：follower 仅在尚未得到 master 地址时可本地路由；已向 master
+  发起的调用发生超时或失败时结果属于不确定交付，不再本地重试，必要时发送取消协调。

--- a/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
+++ b/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
@@ -32,7 +32,9 @@ worker 选择契约，两者组合完成多角色多阶段路由。
    worker group 约束后续所有角色的候选集**（group 亲和链，如 DECODE 选中的 group 决定
    PREFILL 只能在同 group 中选）。任一角色失败立即返回
    `RoutingResult.failure(已成功列表, 失败角色, 错误信息)`。
-4. **响应**：全部成功 → success 响应（携带 `List<ServerStatus>`）；失败 → 先
+4. **响应**：全部成功 → success 响应（携带 `List<ServerStatus>`；物理
+   `server_ip/http_port/grpc_port` 保持不变，N>1 时每个成功项带逻辑 `engine_index`，
+   N=1 时省略该字段）；失败 → 先
    `rollBackRoutingFailure()` 再构造错误响应，错误码取
    `failedRoleType.getErrorType().getErrorCode()`。
 
@@ -49,10 +51,20 @@ worker 选择契约，两者组合完成多角色多阶段路由。
 | DECODE | `decodeLoadBalanceStrategy` | `WEIGHTED_CACHE` | `REMAINING_KV_CACHE` |
 | VIT | `vitLoadBalanceStrategy` | `RANDOM` | `WAIT_TIME` |
 
+### gRPC Schedule 响应
+
+`FlexlbService.Schedule` 的 `FlexlbServerStatusPB` 使用 `optional int32 engine_index = 6`。
+字段号 5 保持 reserved。N=1 不设置字段；N>1 设置所选 index，包含显式 0，调用方应通过
+字段 presence 区分这两种情况。`FlexlbServiceImpl` 从内部 `ServerStatus` 转换时保留该语义；
+master forwarding 透传 protobuf 响应。物理地址字段与既有 service path 不变，旧客户端可忽略
+新增字段。此字段不改变 `EnqueueBatch` 的派发协议。
+
 ## 回滚机制
 
 `DefaultRouter.rollBackRoutingFailure()`：对 `RoutingResult` 中已成功的每个 `ServerStatus`，
-以 `serverIp:httpPort` 调用对应策略的 `rollBack(ipPort, requestId)`。
+以内部 `serverIp:httpPort@routingEngineIndex` 调用对应策略的 `rollBack(ipPort, requestId)`。
+`routingEngineIndex` 不序列化且始终存在，因此 N=1 对外省略 `engine_index` 时仍精确回滚
+`@0`；N>1 的 wire `engine_index` 只负责把选择结果传给共享 frontend。
 
 回滚的实体是**选中时的本地记账**——`WorkerStatus.removeLocalTask(requestId)` 逆转
 `putLocalTask()`：从 `runningQueueTime` 扣回估算 prefill 时间（下限 0）、把
@@ -68,16 +80,24 @@ worker 选择契约，两者组合完成多角色多阶段路由。
 均实现 `LoadBalancer.select(ctx, roleType, group)`，注册名见 `LoadBalanceStrategyEnum`
 （RANDOM / SHORTEST_TTFT / CACHE_AFFINITY_FIRST / WEIGHTED_CACHE）。
 
+所有策略先通过 `EngineWorkerStatus.selectRoutableModelWorkerStatus()` 的公共健康门控：同一
+endpoint/group/物理 frontend 展开的 `multiEngineNum` 个逻辑 worker 必须齐全、index 唯一且
+全部 `alive`，否则整组从候选集中移除。该 AND 只约束健康；门控后的资源、队列、cache 命中、
+outstanding tokens 和 score 仍读取当前 `ip:httpPort@index` 自己的状态。
+候选筛选按物理组一次计算健康状态；最终路由选择及 admission 提交（含 prefill queue
+抢占）重新检查当前组健康，失效时释放 incoming 的预留并拒绝提交，保留已有 victim。
+
 ### RandomStrategy
 
-随机起点环形扫描，取第一个 `isAlive()` 的 worker。不看资源水位、不做 cache 匹配、
+公共物理健康门控后随机起点环形扫描，取第一个 `isAlive()` 的逻辑 worker。不看资源水位、不做 cache 匹配、
 **不 `putLocalTask()`**（因此 rollBack 为空实现）。
 
 ### ShortestTTFTStrategy（PREFILL/PDFUSION 默认）
 
 1. **候选过滤**：`isAlive()` 且 `ResourceMeasure.isResourceAvailable()`（PREFILL 用等待队列
    长度 + 滞回，见 [03-resource-management](03-resource-management.md)）。
-2. **cache 匹配**：`CacheAwareService.findMatchingEngines()`（见
+2. **cache 匹配**：`CacheAwareService.findMatchingEngines()`，用逻辑
+   `ip:httpPort@index` exact-match cache ownership（见
    [04-worker-sync-and-cache](04-worker-sync-and-cache.md)）。
 3. **打分**：每个 worker 计算
    `hitCacheTokens = blockSize × 匹配块数`，

--- a/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
+++ b/rtp_llm/flexlb/docs/architecture/01-routing-and-balancing.md
@@ -1,171 +1,92 @@
 # Routing and Balancing
 
-路由与负载均衡是 flexlb-sync 的核心。`Router` 定义路由契约，`LoadBalancer` 定义单一角色内的
-worker 选择契约，两者组合完成多角色多阶段路由。
+路由实现的入口是 DefaultRouter。它不再通过可配置的 Router / LoadBalancer 工厂注册策略；
+角色选择器是构造函数注入的三个明确实现：
 
-主要代码：`flexlb-sync/src/main/java/org/flexlb/balance/scheduler/`、`balance/strategy/`。
+| 角色 | 选择器 | 说明 |
+|---|---|---|
+| PREFILL、PDFUSION | CostBasedPrefillStrategy | cache 感知的 TTFT 投影与候选选择 |
+| DECODE | CostBasedDecodeStrategy | Decode 容量过滤与 KV/load 加权随机选择 |
+| VIT | RandomStrategy | 物理组健康、group 过滤后的随机选择 |
 
-## Router / DefaultRouter
+## 角色集与 group
 
-`Router` 接口只有一个方法：`Response route(BalanceContext balanceContext)`。
+DefaultRouter 在构造时从 ModelMetaConfig.requiredRoles() 取得请求所需角色。该列表来自
+MODEL_SERVICE_CONFIG.role_endpoints，按 PDFUSION → DECODE → PREFILL → VIT 排序；不会因
+某个角色当前没有 worker 而静默跳过。
 
-`DefaultRouter`（`balance/scheduler/DefaultRouter.java`）：
+路由先尝试 router.groupSelector 为请求解析目标 group。若规则返回 group，所有角色均在该
+group 内选址；若没有规则，首个成功角色的 group 约束后续角色。任何角色无可用候选时，
+本次选中的 SelectedRole 会关闭 generation pin，且不会留下已提交的 endpoint 账本。
 
-- 类上标注 `@DependsOn({"randomStrategy", "weightedCacheStrategy", "shortestTTFTStrategy",
-  "cacheAffinityFirstStrategy"})`——4 个策略 bean 都在**各自构造函数里**调用
-  `LoadBalanceStrategyFactory.register()` 自注册，`@DependsOn` 保证注册先于 DefaultRouter 构造。
-- 每次路由时按 `FlexlbConfig.getStrategyForRoleType(roleType)` 从当前配置快照解析角色策略，
-  再经 `LoadBalanceStrategyFactory` 取对应 `LoadBalancer`——策略配置支持 Nacos 运行时热更新；
-  策略未注册则在路由时抛异常。
+WorkerDirectory 在所有选择器之前执行 physical-group health 门控：共享同一 frontend 的每个
+预期 logical engine 必须已经发布为存活 endpoint。随后选择器仍按各逻辑 engine 自己的状态、
+cache 与账本投影计算候选。
 
-### route() 流程
+## Prefill / PDFusion 选择
 
-1. **校验**：`request == null` → `INVALID_REQUEST`；全局 worker 状态未初始化 →
-   `NO_AVAILABLE_WORKER`。
-2. **角色列表**：读静态单例 `EngineWorkerStatus.MODEL_ROLE_WORKER_STATUS` 的
-   `getRoleTypeList()`——按**固定顺序 PDFUSION → DECODE → PREFILL → VIT**，只加入
-   worker map 非空的角色。没有请求级角色过滤：所有非空角色都会被路由。
-   - 因此 PD 分离部署下实际顺序是 **DECODE 先于 PREFILL**；融合部署只有 PDFUSION；
-     有 VIT worker 时 VIT 追加在最后。
-3. **`routeByRoleType()`**：逐角色调用 `loadBalancer.select(ctx, roleType, group)`。
-   `group` 初始为 null；每个角色选中后 `group = serverStatus.getGroup()`——**首个成功角色的
-   worker group 约束后续所有角色的候选集**（group 亲和链，如 DECODE 选中的 group 决定
-   PREFILL 只能在同 group 中选）。任一角色失败立即返回
-   `RoutingResult.failure(已成功列表, 失败角色, 错误信息)`。
-4. **响应**：全部成功 → success 响应（携带 `List<ServerStatus>`；物理
-   `server_ip/http_port/grpc_port` 保持不变，N>1 时每个成功项带逻辑 `engine_index`，
-   N=1 时省略该字段）；失败 → 先
-   `rollBackRoutingFailure()` 再构造错误响应，错误码取
-   `failedRoleType.getErrorType().getErrorCode()`。
+CostBasedPrefillStrategy 的一次选择按如下步骤进行：
 
-`RoleType.getErrorType()` 映射：PREFILL→`NO_PREFILL_WORKER`(8402)、DECODE→`NO_DECODE_WORKER`
-(8403)、PDFUSION→`NO_PDFUSION_WORKER`(8404)、VIT→`NO_VIT_WORKER`(8405)，全部 `canRetry=true`。
+1. 从 WorkerDirectory.prefillRoutingSnapshot() 取得非拥有的候选 generation 快照，并查询
+   CacheAwareService.findMatchingEngines()；匹配结果会记录在 BalanceContext。
+2. 对每个候选读取 PrefillEndpoint 的 route projection。投影结合 endpoint 已拥有工作、
+   请求未命中 token、cache 命中和 PrefillTimePredictor，形成预测 TTFT / drain time。
+3. 过滤不适合的候选。候选可因 pending 或 drain outlier、未建模的 engine 工作、以及 cache
+   affinity 的 outstanding-uncached-token guard 被排除或降级。
+4. 依据 router.roles.prefill.candidateChoice 选择：BEST_ONLY、在相对/最小容忍窗口内
+   随机选择，或在最短 TTFT pool 内按 least-recently-used 选择。
+5. 若配置 cacheAffinity，只有 cache 命中率达到最小阈值，且相对最短 TTFT 的额外代价不超过
+   maxExtraTtftMs 时，才优先 cache leader。
+6. 最终按地址重新取得精确 GenerationPin。快照过期、generation 更替或物理组变为不健康时，
+   本轮选择失败并交由调用方重新规划。
 
-### 角色与策略 / 资源指标映射
+这条路径将 cache 命中换算为 token；KVCM 的 P2P 命中折扣由
+router.roles.prefill.cacheAffinity.p2pHitDiscount 控制。选择器不在此阶段向引擎发送请求。
 
-映射不在 `RoleType` 上，而在 `FlexlbConfig`（`flexlb-common/.../config/FlexlbConfig.java`）：
+## Decode 与 VIT 选择
 
-| RoleType | 策略（可配） | 默认策略 | 资源指标（硬编码） |
-|---|---|---|---|
-| PDFUSION / PREFILL | `loadBalanceStrategy` | `SHORTEST_TTFT` | `WAIT_TIME` |
-| DECODE | `decodeLoadBalanceStrategy` | `WEIGHTED_CACHE` | `REMAINING_KV_CACHE` |
-| VIT | `vitLoadBalanceStrategy` | `RANDOM` | `WAIT_TIME` |
+CostBasedDecodeStrategy 从 EndpointRegistry 的 Decode routing view 捕获整批候选，然后：
 
-### gRPC Schedule 响应
+- 依据 router.roles.decode.availability 的 KV 使用率、可选的 maxEngineRequests 和 endpoint
+  账本过滤候选；QUEUE 是否在选址阶段检查 transient Decode 容量取决于
+  defersDecodeCapacityUntilDispatch() 与 preemption 配置。
+- 排除 engine load 或 KV 已明显偏离群体的 outlier；对其余候选按 decayPerToken 与
+  loadDecayPerRequest 形成稳定的加权随机分布。
+- 在选中 routing view 后重新取得同一 Decode generation 的 pin。精确 reservation 只在
+  DIRECT 提交或 QUEUE admission 提交时创建，选择快照本身不改变容量。
 
-`FlexlbService.Schedule` 的 `FlexlbServerStatusPB` 使用 `optional int32 engine_index = 6`。
-字段号 5 保持 reserved。N=1 不设置字段；N>1 设置所选 index，包含显式 0，调用方应通过
-字段 presence 区分这两种情况。`FlexlbServiceImpl` 从内部 `ServerStatus` 转换时保留该语义；
-master forwarding 透传 protobuf 响应。物理地址字段与既有 service path 不变，旧客户端可忽略
-新增字段。此字段不改变 `EnqueueBatch` 的派发协议。
+RandomStrategy 仅服务 VIT，随机循环扫描已发布且健康的 endpoint，按 group 过滤后返回一个
+带 pin 的无状态 SelectedRole。
 
-## 回滚机制
+## DIRECT 与 QUEUE 的提交边界
 
-`DefaultRouter.rollBackRoutingFailure()`：对 `RoutingResult` 中已成功的每个 `ServerStatus`，
-以内部 `serverIp:httpPort@routingEngineIndex` 调用对应策略的 `rollBack(ipPort, requestId)`。
-`routingEngineIndex` 不序列化且始终存在，因此 N=1 对外省略 `engine_index` 时仍精确回滚
-`@0`；N>1 的 wire `engine_index` 只负责把选择结果传给共享 frontend。
+RouteService 为每个 BalanceContext 绑定当前 FlexlbConfig 快照，然后按 scheduler.type 调用
+不同入口。
 
-回滚的实体是**选中时的本地记账**——`WorkerStatus.removeLocalTask(requestId)` 逆转
-`putLocalTask()`：从 `runningQueueTime` 扣回估算 prefill 时间（下限 0）、把
-`inputLength - prefixLength` 的 KV token 从 used 还给 free、从 `localTaskMap` 移除。
-`lastSelectedTime` 不回滚。
+### DIRECT
 
-各策略实现：`RandomStrategy` 为 no-op（它 select 时不记账）；`ShortestTTFTStrategy`（及其
-子类 CacheAffinityFirst）回滚时**硬编码查 PREFILL** 的 worker map；`WeightedCacheLoadBalancer`
-**硬编码查 DECODE**——回滚正确性耦合于默认的策略↔角色配对，改配对时须注意。
+DefaultRouter.routeDirect() 选齐全部所需角色后，在一个本地提交事务中转移它们的 generation pin：
 
-## 四种策略
+- Prefill/PDFusion 通过 PrefillEndpoint.registerDirectRequest() 取得精确活动请求所有权；
+- Decode 通过 DecodeEndpoint.reservePinned() 建立 shadow reservation；
+- VIT 只保留 endpoint generation 所有权。
 
-均实现 `LoadBalancer.select(ctx, roleType, group)`，注册名见 `LoadBalanceStrategyEnum`
-（RANDOM / SHORTEST_TTFT / CACHE_AFFINITY_FIRST / WEIGHTED_CACHE）。
+任何提交叶子失败时，已取得的 registration/reservation 按逆序回滚并关闭 pin；成功后构造
+Response 并提交所有权。因此 DIRECT 没有 WorkerBatcher 队列，也不支持 BATCH dispatcher。
 
-所有策略先通过 `EngineWorkerStatus.selectRoutableModelWorkerStatus()` 的公共健康门控：同一
-endpoint/group/物理 frontend 展开的 `multiEngineNum` 个逻辑 worker 必须齐全、index 唯一且
-全部 `alive`，否则整组从候选集中移除。该 AND 只约束健康；门控后的资源、队列、cache 命中、
-outstanding tokens 和 score 仍读取当前 `ip:httpPort@index` 自己的状态。
-候选筛选按物理组一次计算健康状态；最终路由选择及 admission 提交（含 prefill queue
-抢占）重新检查当前组健康，失效时释放 incoming 的预留并拒绝提交，保留已有 victim。
+### QUEUE
 
-### RandomStrategy
+DefaultRouter.routeForQueue() 只返回 QueueRouteAdmission：其中包含已 pin 的角色选择、成功响应
+和将来提交所需的精确 endpoint 信息。GlobalQueueCoordinator 在其有序决策点将该 admission
+提交给 endpoint；若 endpoint 状态或容量已变化，admission 会关闭并重规划。
 
-公共物理健康门控后随机起点环形扫描，取第一个 `isAlive()` 的逻辑 worker。不看资源水位、不做 cache 匹配、
-**不 `putLocalTask()`**（因此 rollBack 为空实现）。
+路由响应中的地址始终是物理 frontend 地址。ServerStatus 内部保留 selected engine index；
+多 engine 的 protobuf 响应才设置 engine_index（含显式的 0），单 engine 保持字段未设置。
 
-### ShortestTTFTStrategy（PREFILL/PDFUSION 默认）
+## 选择与资源的分工
 
-1. **候选过滤**：`isAlive()` 且 `ResourceMeasure.isResourceAvailable()`（PREFILL 用等待队列
-   长度 + 滞回，见 [03-resource-management](03-resource-management.md)）。
-2. **cache 匹配**：`CacheAwareService.findMatchingEngines()`，用逻辑
-   `ip:httpPort@index` exact-match cache ownership（见
-   [04-worker-sync-and-cache](04-worker-sync-and-cache.md)）。
-3. **打分**：每个 worker 计算
-   `hitCacheTokens = blockSize × 匹配块数`，
-   `prefillTime = seqLen − hitCacheTokens`，
-   `ttft = prefillTime + runningQueueTime`（本地维护的队列时间估计）。
-4. **选择**：
-   - 按 ttft 升序排（并列时 `lastSelectedTime` 早者优先）；
-   - 仅 PREFILL/PDFUSION 且配置了正的 `outstandingUncachedTokensThreshold` 时，过滤
-     `outstandingUncachedTokens + max(0, seqLen − hitCacheTokens)` 超阈值的 worker；若仍有
-     eligible worker，后续选择只在其中进行；若全部超阈值，恢复完整候选集并重跑后续
-     Top 候选/相似/cache 偏好流程（仍可能选中超阈值的 cache-preferred worker），决策 reason
-     记录 `SHORTEST_TTFT_OUTSTANDING_GUARD_FALLBACK`；
-   - 取 Top 候选：≤3 个全取，否则 `max(2, ⌈数量×0.3⌉)`；
-   - 相似阈值 `max(minTTFT × shortestTtftSimilarityThresholdRatio(0.2), 标准差 × 0.5)`，
-     筛出与最短 ttft 相近的 worker；
-   - 相似集合内做 **cache 偏好**：cache 命中高于最短 ttft worker 时改选 cache leader；
-   - **CAS 抢占**：按偏好序对 `lastSelectedTime` 做 `compareAndSet(快照值, now)`，第一个
-     成功者当选——防止并发调度线程用同一快照选中同一 worker。
-5. **提交**：`putLocalTask()` 记账（预扣队列时间与 KV token）、上报 cache 命中指标、
-   `ctx.recordCacheMatch()`。
-
-### CacheAffinityFirstStrategy（继承 ShortestTTFT，只重写选择步骤）
-
-- **终态 prefill 工作守卫**：每个 worker 的 `ttft` 已包含当前请求的未命中 Prefill token 和已有队列
-  未命中 token。计算 cache leader 相对最短 ttft worker 的额外工作；只有该差异不大于
-  `cacheAffinityFirstMaxExtraWorkTokens`，且缓存命中更多时，才选 leader（`CACHE_LEADER`），否则选最短
-  ttft（`SHORTEST_TTFT`）。在选 cache leader 前也复用同一 outstanding-threshold guard；低于
-  `cacheAffinityFirstMinHitRate` 的 cache leader 不参与 cache affinity
-  （`SHORTEST_TTFT_LOW_CACHE_HIT`）；超阈值的 cache leader 直接回退到最短 eligible worker
-  （`SHORTEST_TTFT_OUTSTANDING_GUARD`）。与 ShortestTTFT 不同，全部 worker 超阈值时**不做
-  cache 取舍，直接按最短 ttft 选择**（同样记录 `SHORTEST_TTFT_OUTSTANDING_GUARD_FALLBACK`）。
-- CAS 抢占失败时按剩余 eligible worker 继续选择；决策 reason 为
-  `CACHE_AFFINITY_FALLBACK` 或 `SHORTEST_TTFT_FALLBACK`。决策快照（debug 级）写入
-  `BalanceContext.shortestTtftDecisionByRole`。
-
-### CostBasedPrefillStrategy
-
-按候选的资源、排队和预测执行时间做成本筛选与打分。它与 ShortestTTFT 一样通过统一的
-`CacheAwareService.findMatchingEngines(CacheMatchQuery)` 取得 cache 匹配，因此 PREFILL 和
-PDFUSION 的 cost-based 路径也遵循 [04-worker-sync-and-cache](04-worker-sync-and-cache.md) 的
-源选择：`LOCAL_SYNC`、`KVCM` 或 KVCM 不可用时的 `LOCAL_STANDBY`。本地命中按全量折算；KVCM
-返回的 P2P 增量命中按 `cacheAffinity.p2pHitDiscount` 折算（默认 `0.2`），再进入原有的成本估算。
-这只改变 cache 命中的输入来源，不改变 cost-based 的候选过滤、成本公式和提交/回滚语义。
-
-### WeightedCacheLoadBalancer（DECODE 默认）
-
-1. 候选过滤：`isAlive()` + `isResourceAvailable()`（DECODE 用 KV 使用率 + 滞回）。
-2. **加权随机**（权重基于 KV cache 使用量，与 cache 匹配无关）：
-   `weight = exp(−weightedCacheDecayFactor(0.001) × (cacheUsed − 平均值))`——用得越少权重越高；
-   总权重非正或全相等时退化为均匀随机；轮盘赌选择。
-3. **cache 匹配只做记账**：选中后再查 `findMatchingEngines()`，得到
-   `prefixLength = blockSize × 匹配块数`，用于 TaskInfo 的 KV 预扣精度（`inputLength −
-   prefixLength`），不影响选谁。
-4. `putLocalTask()` 记账。
-
-## BalanceContext 路由相关字段
-
-`flexlb-common/.../dao/BalanceContext.java`：输入 `config`/`request`（`seqLen`、`blockSize`、
-`blockCacheKeys`、Local Standby keys 等）；输出 `response`；per-role 记录
-`cacheMatchSelectionByRole`（角色→选中 ip + 命中 token 数，`recordCacheMatch()` 同时累计
-查询耗时/次数与 `cacheMatchSource`）和 `shortestTtftDecisionByRole`（debug 决策快照）。
-队列字段见 [02-queue-scheduling](02-queue-scheduling.md)。
-
-## 并发要点
-
-- worker map 是 `ConcurrentHashMap`，`WorkerStatus` 计数全部 Atomic；选择路径不加锁
-  （`WorkerStatus.lock` 存在但选择路径不使用）。
-- 选择的互斥靠 `lastSelectedTime` CAS；记账/回滚靠 Atomic 加减。
-- worker 是否可选由 `PrefillResourceMeasure` / `DecodeResourceMeasure` 基于活性、
-  待处理请求、KV 使用率和可选并发上限判定（见
-  [03-resource-management](03-resource-management.md)）。
+选择器的职责是产生可验证的候选与 generation pin；EndpointRegistry、PrefillEndpoint、
+DecodeEndpoint 和 RequestRegistry 才拥有资源、交付和终态。不要在策略中加入临时
+WorkerStatus 记账或回滚逻辑：该状态无法覆盖队列、delivery ACK、取消和 generation 退役。
+详见 [02-queue-scheduling](02-queue-scheduling.md) 与
+[03-resource-management](03-resource-management.md)。

--- a/rtp_llm/flexlb/docs/architecture/02-queue-scheduling.md
+++ b/rtp_llm/flexlb/docs/architecture/02-queue-scheduling.md
@@ -1,66 +1,83 @@
 # Scheduling and Request Lifecycle
 
-`FLEXLB_CONFIG.scheduler` 是带 `type` 的联合配置：
+FLEXLB_CONFIG.scheduler 是带 type 的配置：
 
-- `DIRECT`：`RouteService` 在调用链中执行 `DefaultRouter.route()`，返回已完成的
-  `CompletableFuture<Response>`。
-- `QUEUE`（默认）：请求交给 `PriorityScheduler`，由调度器持有请求生命周期、
-  endpoint 预留和对外发布权。
+- DIRECT：RouteService 在调用线程执行 DefaultRouter.routeDirect()；没有队列和 endpoint
+  batcher 工作线程。
+- QUEUE（默认）：RequestScheduler 是唯一公共入口，RequestRegistry 拥有请求生命周期，
+  GlobalQueueCoordinator 决定全局顺序与选址，WorkerBatcher 只处理已经选定 endpoint 的
+  分组及交付。
 
-QUEUE 模式下，`ordering.type` 和 `dispatcher.type` 是两个正交维度：
+QUEUE 下有三个彼此独立的配置维度：
 
-- ordering：`FIFO`（默认）或 `PRIORITY`；PRIORITY 由 `PriorityAdmissionScheduler`
-  进行优先级准入、状态快照和可选抢占。
-- dispatcher：`BATCH`（默认）或 `NON_BATCH`；前者通过引擎 enqueue RPC
-  发布 batch，后者将路由决策返回调用方，由调用方向引擎发请求。
+| 维度 | 配置 | 责任 |
+|---|---|---|
+| 排序 | scheduler.ordering：FIFO 或 PRIORITY | GlobalQueueCoordinator 的全局队列顺序；PRIORITY 可配置 preemption |
+| 决策分组 | scheduler.decision：SINGLE 或 FIXED_WINDOW | 每个 Prefill WorkerBatcher 如何形成一份交付决策 |
+| 交付 | dispatcher：BATCH 或 NON_BATCH | EnqueueBatch，或向调用方交付单个 route decision |
 
-主要代码：`RouteService`、`PriorityScheduler`、`PriorityAdmissionScheduler`、
-`WorkerBatcher`、`DefaultBatchDispatcher` 和 `RouteDecisionDelivery`。
+## 准入与全局决策
 
-## 提交与准入
+RequestScheduler.submit() 在 ingress 线程只做同步注册和入队，不在此处扫描 worker：
 
-`RouteService.route()` 先将当前不可变的 `FlexlbConfig` 快照绑定到
-`BalanceContext`，再按 scheduler 类型分流。QUEUE 路径的关键边界是：
+1. 读取当前配置，拒绝非 QUEUE 配置或在启动后才切换到 QUEUE 的实例。
+2. RequestRegistry.register() 以 request_id 建立唯一 RequestSlot，检查重复 id 和绝对 deadline，
+   并取得 maxOutstandingRequestsGlobal 限制的全局准入 permit。容量满时，PRIORITY 可以用
+   符合配置的可逆 victim 转移 permit；否则返回 QUEUE_FULL。
+3. 将同一个 future 和 context 写入 GlobalQueueCoordinator。future 被取消或完成会 O(1) 移除
+   对应队列节点，不能留下阻塞后缀的历史节点。
 
-1. `request_id` 是请求代际标识；活跃或已终态的重复 ID 会被拒绝。
-2. `QueueCapacityConfig.maxOutstandingRequestsGlobal`（默认 100000）精确限制
-   Master 当前持有的请求数，包括还未注册进 inflight map 的准入中请求。
-3. 调度器在可能向引擎或调用方发布前装配唯一的绝对过期事件。
-4. PRIORITY ordering 进入优先级 plan/commit；FIFO ordering 先调用
-   `DefaultRouter`，提交 endpoint 预留后才把请求放入目标 Prefill 的
-   `WorkerBatcher`。
+GlobalQueueCoordinator 使用一个决策线程和受 internalRuntime.queuePlannerThreads 限制的规划池：
 
-路由、预留、inflight 注册和发布都属于同一 request generation。失败或
-取消只能通过调度器的单一 reducer 收敛，避免重复回滚和重复完成 future。
+- FIFO 以入队序列排序；PRIORITY 以 priority 降序、入队序列升序、request id 为最终稳定 tie-break。
+- 决策线程从全局队列提取有限 planning frontier，在锁外调用 DefaultRouter.routeForQueue()。
+  路由和 RPC 不在队列锁内执行。
+- 计划必须按队列顺序提交。若高优先级请求在计划期间抵达，当前 frontier 会丢弃并重新捕获。
+- 无法提交的请求按精确 PlacementKey 停放；仅当对应 endpoint 容量事件变化时才重新参与决策。
+  不重试不相关的 blocked request，且不同 endpoint/group 可以独立前进。
+- 计划在 endpoint 提交时再次验证 generation、容量和 deadline。陈旧计划关闭自己的 pins 并重规划，
+  不会把旧快照发布到 endpoint。
 
-## WorkerBatcher 与发布
+## Endpoint 运行时与交付
 
-`WorkerBatcher` 是每个 Prefill endpoint 的决策组组织者。BATCH dispatcher 使用
-`FixedWindowBatcherAlgorithm`，按 `maxRequests`、`maxCollectionWaitMs`、预测执行时间
-与 endpoint 容量触发发送；NON_BATCH dispatcher 使用
-`ImmediateNonBatchAlgorithm`，一个决策组只包含一个请求。
+每个已发布 Prefill generation 有一个 WorkerBatcher。它不是 route selector，而是该 endpoint 的
+活动请求索引、分组和交付所有者：
 
-在任何模式下，调度器都在对外可见前提交 endpoint 账本和
-`RequestLifecycle`。BATCH 路径记录引擎 ACK/执行状态；NON_BATCH 路径记录
-路由决策的交付与调用方确认。
+- SINGLE 每份决策只包含一个请求；FIXED_WINDOW 在 maxRequests、maxCollectionWaitMs 或可选
+  maxPredictedExecutionMs 条件满足时形成决策组。
+- BATCH 由 BatchDeliveryStrategy 和 DefaultBatchDispatcher 准备 EnqueueBatch，并在引擎 ACK
+  后把 batch delivery 状态交给 RequestRegistry。
+- NON_BATCH 由 RouteDeliveryStrategy 交付 route decision；调用方确认或 lifecycle 超时决定后续
+  资源归属。
+- dispatcher 的 per-Prefill in-flight 限制区分 batch 和 request；队列长度硬上限位于
+  scheduler.capacity.maxWaitingRequestsPerPrefillWorker。
 
-## 取消、过期与状态查询
+在 QUEUE 路径中，Prefill/Decode 的 reservation、delivery claim 与完成 future 都由
+RequestRegistry 的精确 RequestSlot reducer 连接。batcher 不拥有全局 admission、request id
+去重、取消或终态回收。
 
-- `cancelRequest(requestId, expectedBatchId, reason)` 由 scheduler 作为生命周期和资源的
-  唯一拥有者执行；`expectedBatchId` 防止旧取消请求命中重用 ID 的新代际。
-- 若请求可能已到达引擎，本地资源在引擎终态或取消 fence 收敛前不会被
-  乐观释放。
-- `getRequestState()` 同时查询活跃 inflight 和最近终态快照；gRPC 转发也带
-  单跳 fence，避免跟随者间循环代理。
-- `queueTimeoutMs`（默认 3600000）给 QUEUE 所有权提供上界；
-  `RequestLifecycleConfig` 另外约束 stale inflight 和已交付未确认请求。
+## 取消、过期和状态查询
+
+RequestRegistry 是以下状态变化的唯一 reducer：
+
+- client cancel、deadline、排队超时、delivery ACK/拒绝、引擎接受/运行/终态；
+- priority preemption 与可能的引擎取消 fence；
+- stale inflight 和已交付未确认请求的清理；
+- 关闭时停止新准入、等待已跨过 admission 边界的 mutation，然后终止剩余 request generation。
+
+每个 request generation 都有绝对 deadline；队列决策点与 endpoint 发布点都会再次检查，防止
+延迟定时器将已过期请求交付给引擎。取消携带 expectedBatchId 作为 generation fence，避免旧
+取消命中复用 request id 的新请求。
+
+FlexLB gRPC 还提供 GetRequestState 和 Cancel。启用一致性时，follower 对这两个调用同样尝试
+单跳转发到 master；没有 master 地址时才本地处理。见
+[05-lifecycle-and-consistency](05-lifecycle-and-consistency.md)。
 
 ## 默认配置
 
-- scheduler：`QUEUE` + `FIFO`，`queueTimeoutMs=3600000`，
-  `maxOutstandingRequestsGlobal=100000`。
-- dispatcher：`BATCH`，`maxRequests=8`，`maxCollectionWaitMs=300`，
-  `maxWaitingRequestsPerPrefillWorker=1024`，`enqueueRpcTimeoutMs=5000`。
-- lifecycle：`staleInflightTimeoutMs=300000`，
-  `deliveredNotAcceptedTimeoutMs=30000`，
-  `maxDeliveredNotAcceptedRequestsGlobal=200`。
+- scheduler：QUEUE、FIFO、queueTimeoutMs=3,600,000；全局准入为 100,000。
+- decision：FIXED_WINDOW，maxRequests=8，maxCollectionWaitMs=300。
+- dispatcher：BATCH，enqueueRpcTimeoutMs=5,000；未设置时 per-Prefill in-flight 限制不额外收紧。
+- lifecycle：staleInflightTimeoutMs=300,000，deliveredNotAcceptedTimeoutMs=30,000，
+  maxDeliveredNotAcceptedRequestsGlobal=200。
+- 每个 Prefill endpoint 等待队列上限：1,024。

--- a/rtp_llm/flexlb/docs/architecture/03-resource-management.md
+++ b/rtp_llm/flexlb/docs/architecture/03-resource-management.md
@@ -1,58 +1,64 @@
 # Resource Management
 
-当前实现没有全局的动态许可信号量。容量约束分为三层：
+FlexLB 的容量由三类所有者共同表达：RequestRegistry 的全局准入、EndpointRegistry 的
+generation 生命周期，以及 Prefill / Decode endpoint 的精确本地账本。
 
-1. `PriorityScheduler` 用 `maxOutstandingRequestsGlobal` 限制 Master 拥有的 QUEUE 请求总数。
-2. `ResourceMeasure` 在路由时判断单个 worker 是否可选。
-3. `PrefillEndpoint` / `DecodeEndpoint` 用本地预留账本保护尚未反映到引擎
-   `WorkerStatus` 中的调度决策。
+## Worker generation 与 EndpointRegistry
 
-主要代码：`balance/resource/`、`balance/endpoint/`、`DefaultRouter` 和
-`PriorityScheduler`。
+WorkerDirectory 将服务发现到的逻辑 worker 保存为每角色的 WorkerStatus generation。首次获得
+可提交的 worker status 前，该 generation 不可路由。EndpointRegistry 随后创建对应的
+PrefillEndpoint、DecodeEndpoint 或通用 WorkerEndpoint，并只公开这一份已初始化的 endpoint
+generation。
 
-## EndpointRegistry
+逻辑地址是 ip:httpPort@engineIndex，N=1 也使用 @0。Registry 按角色和逻辑地址维护 endpoint；
+状态失效或连续 transport failure 会先从路由目录 detach 旧 generation，再等待
+所有已取得的 GenerationPin 完成，然后清理 endpoint 与 LOCAL_SYNC cache 元数据。
 
-`EndpointRegistry` 按角色和 `ip:port` 维护 Prefill、Decode、P/D Fusion 与 VIT endpoint。
-同一地址的 `WorkerStatus` 代际变化时，registry 原子替换 endpoint 并关闭旧实例；
-过期 worker 只能用当时观察到的 `WorkerStatus` 对象条件删除，避免删掉同地址的
-新代际。
+选择器看到的 routing directory 只是非拥有快照。真正提交前必须 capture 精确 pin；因此地址相同
+的 replacement 无法继承旧 request 的 reservation，退役也不会打断已线性化的 handoff。
 
-## Prefill 可用性与队列
+## Prefill 容量
 
-`PrefillResourceMeasure` 要求 endpoint 存活，且引擎观测到的有效待处理请求低于
-`router.roles.prefill.availability.maxPendingRequests`（默认 64）。上下线切换使用
-`router.availabilityHysteresisPercent`（默认 15）做滞回，避免在阈值附近抖动。
+PrefillEndpoint 通过 PrefillState 管理本 generation 的活动请求与 route projection：
 
-QUEUE scheduler 选中 Prefill 后，请求进入该 endpoint 的 `WorkerBatcher`。
-`BatchDispatcherConfig.maxWaitingRequestsPerPrefillWorker`（默认 1024）是 batcher 等待队列的
-硬上限，与路由层的 worker 可用性阈值是不同责任。
+- DIRECT 路径用 registerDirectRequest() 建立精确 direct registration。
+- QUEUE 路径由 WorkerBatcher 将已提交的 request 放入 active index，并按 decision policy 形成
+  delivery group。
+- projection 将已拥有工作、引擎观测、cache 命中和本请求预估 prefill 工作组合为候选的 TTFT /
+  drain time；这是 CostBasedPrefillStrategy 的输入。
+- scheduler.capacity.maxWaitingRequestsPerPrefillWorker 是每个 batcher active queue 的硬界限。
+  dispatcher 的 in-flight delivery 限制是独立边界，不应混作 worker 状态中的 pending 值。
 
-## Decode 容量与本地预留
+Prefill 容量变化通过 EndpointEventProjector / PlacementAvailability 发布给全局队列。被某一
+endpoint 精确容量阻塞的请求仅在该事件出现时重新规划。
 
-`DecodeResourceMeasure` 要求 endpoint 存活，并同时检查：
+## Decode 容量与防重分配
 
-- 引擎可见负载未超过可选的
-  `router.roles.decode.availability.maxEngineRequests`。
-- 真实 KV 使用率未超过 `maxKvUsagePercent`（默认 90）；同样使用
-  `availabilityHysteresisPercent` 做滞回。
+DecodeEndpoint 的 admission lock 管理以 request id、endpoint generation 和 reservation token
+三元组标识的 shadow reservation。其 layered admission view 同时保留：
 
-`DecodeEndpoint.reserve()` 在对外发布前建立 shadow 预留，记录并发槽位、硬 KV
-和预期 KV。已在 Prefill 队列中的预留继续保护 KV，但不计入引擎面的
-concurrency，避免引擎空闲时被本地排队预留假性压满。
+- 引擎已观测的 KV、并发和任务状态；
+- master 已排队但引擎未必见到的 request；
+- 已发往引擎、等待接受证明的 request；
+- 已确认接受或运行的 request，以及因取消/超时仍受 engine fence 保护的 request。
 
-WorkerStatus 到达后，`DecodeEndpoint.calibrate()` 用引擎已确认状态对账。对于取消或
-发布结果不确定的请求，Engine fence 在权威终态到达前持有相应账本，防止
-KV 或并发容量被提前释放并二次分配。
+选址时 CostBasedDecodeStrategy 读取 immutable routing view；提交时 reservePinned() 重新在
+admission lock 下确认 capacity。reservation 估算 KV 为请求输入 token 加有效输出 token，并受
+endpoint 总 KV 容量限制。maxKvUsagePercent 和可选 maxEngineRequests 是引擎面的 admission
+边界；QUEUE 若没有能够替换 Decode victim 的 preemption policy，可将 transient Decode capacity
+检查推迟到交付前。
 
-## 策略层使用
+取消或交付结果不确定时，不会乐观释放 Decode KV/并发。RequestRegistry 和 DecodeEndpoint
+保留 fence，直到引擎接受、取消或终态证据使该精确 reservation 可结算，避免同一容量被二次分配。
 
-`ResourceMeasureFactory` 按指标注册 Prefill / Decode measure。`DefaultRouter` 及其策略先
-排除不可用 endpoint，再根据等待时间、KV 负载、cache 亲和性和配置的候选集
-选择 worker。QUEUE 路径成功后，endpoint 账本由 `PriorityScheduler` 负责提交、
-回滚和终态释放。
+## Preemption 与观测
 
-## 观测
+只有 PRIORITY ordering 可配置 preemption。EvictionManager 和 DecodePreemptionCoordinator 基于
+RequestRegistry 的 exact ownership 计划 victim；若允许取消引擎已拥有的 Decode 请求，还必须配置
+engine cancellation ACK 与 completion timeout。FIFO 或未配置 preemption 的队列不会把临时
+Decode 满载解释为可抢占事件。
 
-`BatchSchedulerReporter` 上报 endpoint 队列深度、等待时间、batch 大小、inflight、
-Decode 负载和本地 KV 预留。`PrioritySchedulerReporter` 上报优先级准入、抢占、
-取消和分层 Decode 负载。观测失败不得改变调度结果或资源所有权。
+HttpLoadBalanceServer 的 GET /rtp_llm/inflight_status 输出 Prefill 活动请求、Decode layered
+admission view、KV reservation 和 dispatch permit 的诊断快照。BatchSchedulerReporter 和
+RequestSchedulerReporter 上报队列、交付、准入、preemption 与 endpoint 账本指标；观测异常不得
+改变资源所有权。

--- a/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
+++ b/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
@@ -22,6 +22,26 @@ KVCM（外部 KV Cache Manager）、LOCAL_STANDBY（KVCM 的本地兜底）。
     一个在途状态检查**；
   - **仅当 `!kvcmEnabled`** 时提交 `GrpcCacheStatusCheckRunner`（`cacheCheckInProgress` CAS）。
 
+一个服务发现 frontend 会按 Endpoint `multi_engine_num` 展开为 N 个逻辑 worker，map key
+统一为 `ip:httpPort@index`（N=1 也是 `@0`）。frontend HTTP/gRPC 地址保持共享；第 i 个
+`GrpcWorkerStatusRunner` 在 N>1 时独立连接 `worker_status_port + i`；N=1 使用发现到的
+legacy gRPC port。N>1 必须显式配置 status base，配置加载时同时校验 count、base 和
+`base + N - 1 <= 65535`。
+
+worker 地址表示由不可变 `WorkerIdentity` 一次性预计算并保存，调用方不再解析或临时拼接：
+
+| 表示 | 格式 | 用途 |
+|---|---|---|
+| raw IP | `ip` | 网络连接与服务发现 |
+| raw port | `port` | 共享 frontend 端口 |
+| raw engine index | `engineIndex` | 逻辑引擎序号 |
+| physical IP-port | `ip:port` | 共享 frontend 身份、物理健康分组 |
+| logical IP-port | `ip:port@index` | 路由、rollback、KVCM 与 cache key |
+| metrics logical IP-port | `ip:port@index` | 所有可归属具体引擎的 `engineIp` 指标标签 |
+
+`WorkerHost` 在服务发现展开时持有该 identity；`WorkerStatus` 更新任一 raw 字段时原子替换
+整份 identity，保证三种派生表示来自同一个快照。N=1 也保留 `@0`。
+
 ### GrpcWorkerStatusRunner
 
 gRPC `getWorkerStatus`（VIT 走 multimodal 变体）携带 `latest_finished_version` 做增量拉取。
@@ -34,6 +54,10 @@ dp/tp size、内嵌 `cache_status`、`block_hash_lookahead_tokens`、`cache_matc
 处理逻辑：版本号新才全量更新（并发/任务表/队列时间）；版本号旧也更新 alive、时间戳并做任务
 对账；`cache_status` 总量恒更新（used = total − available）。带 `CacheHitFeedback` 的完成
 任务会异步送 `CacheAwareService.buildCacheHitComparison`（预测 vs 实际命中对比，出指标 + pv 日志）。
+连续 3 次 RPC 失败会把该逻辑 worker 标为不健康并移除其 endpoint；公共 physical AND
+gate 同时将所有 siblings 排除出路由候选，成功状态恢复且整组健康后才重新可路由。
+新发现的 worker 在首次接受有效状态前不可路由。空响应标为不健康；未初始化状态
+（`status_version=0`）与响应处理异常跳过本轮更新。
 
 ### WorkerStatus 的本地预测与对账
 
@@ -77,6 +101,10 @@ cache 版本做增量；响应恒更新 KV token 总量，版本更新时把 `ca
   `calculateDiff` 在专用 ForkJoinPool 上并行算 added/removed，diff 大小回馈动态间隔服务。
 - `KvCacheManager`：门面——`findMatchingEngines`（候选来自 `WorkerStatusProvider`）、
   `updateEngineCache`（diff 后双表应用）、`removeStaleEngineCaches`、`clear`。
+
+上述 LOCAL_SYNC key、KVCM `host_ip_port`、LOCAL_STANDBY 映射与 cache-hit comparison 均使用
+逻辑 `ip:httpPort@index`。KVCM 对 N=1 worker 兼容旧 physical `ip:httpPort` key：logical key
+未命中时才回退查询 physical key；N>1 或非 KVCM source 仍要求 exact match，无法匹配时按零命中忽略。
 
 ### KVCM（外部 KV Cache Manager）
 

--- a/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
+++ b/rtp_llm/flexlb/docs/architecture/04-worker-sync-and-cache.md
@@ -1,186 +1,93 @@
 # Worker Sync and KV Cache
 
-worker 健康与容量信息由后台线程高频异步同步；KV cache 元数据用于 cache 感知路由。
-本分支（feature/flexlb-kvcm）支持三种 cache 匹配源：LOCAL_SYNC（本地全量索引）、
-KVCM（外部 KV Cache Manager）、LOCAL_STANDBY（KVCM 的本地兜底）。
-
-主要代码：`flexlb-sync/src/main/java/org/flexlb/sync/`、`service/grpc/`，
-`flexlb-cache/src/main/java/org/flexlb/cache/`，`flexlb-grpc/.../KvcmGrpcClient.java`。
+worker 状态同步与 cache 元数据采用不同的提交边界：WorkerDirectory / EndpointRegistry 负责
+可路由的 worker generation；CacheAwareService 编排 cache 查询和元数据更新。两者都使用
+logical worker identity ip:httpPort@engineIndex。
 
 ## Worker 状态同步
 
-### 调度拓扑
+MasterEngineSynchronizer 在进程启动时读取 workerRegistry 配置，并以
+statusPollIntervalMs（默认 20ms）启动定时轮询。它为模型拓扑中的每个 required role 提交
+EngineSyncRunner；同步和 status-check executor 的线程数来自 internalRuntime（默认各 32），
+队列容量为 15,000。status RPC timeout 默认 5,000ms，worker status 超过默认 10,000ms 未更新
+会被视为陈旧。
 
-- `MasterEngineSynchronizer`：`ScheduledThreadPoolExecutor(5)` 每 **20ms**
-  （`SYNC_STATUS_INTERVAL`）触发一轮，单次 gRPC 超时 200ms。每轮按 模型×角色 提交
-  `EngineSyncRunner` 到共享线程池。
-- `AbstractEngineStatusSynchronizer`：两个静态线程池（core 500 / max 1000 / 队列 15000 /
-  AbortPolicy）——`engine-sync-executor`（状态同步）与 `status-checker-executor`。
-- `EngineSyncRunner`：从服务发现拉 worker 列表（陈旧条目要过 `max(3×同步间隔, 1s)` 宽限期
-  才移除），然后对每个 worker：
-  - 提交 `GrpcWorkerStatusRunner`，用 `statusCheckInProgress` CAS 保证**每 worker 同时至多
-    一个在途状态检查**；
-  - **仅当 `!kvcmEnabled`** 时提交 `GrpcCacheStatusCheckRunner`（`cacheCheckInProgress` CAS）。
+EngineSyncRunner 每轮执行以下工作：
 
-一个服务发现 frontend 会按 Endpoint `multi_engine_num` 展开为 N 个逻辑 worker，map key
-统一为 `ip:httpPort@index`（N=1 也是 `@0`）。frontend HTTP/gRPC 地址保持共享；第 i 个
-`GrpcWorkerStatusRunner` 在 N>1 时独立连接 `worker_status_port + i`；N=1 使用发现到的
-legacy gRPC port。N>1 必须显式配置 status base，配置加载时同时校验 count、base 和
-`base + N - 1 <= 65535`。
+1. 通过 WorkerAddressService 获取 role 的发现结果。一个 frontend 按 endpoint 的
+   multi_engine_num 展开为 N 个 logical worker；N>1 使用 worker_status_port + index，
+   N=1 未配置该端口时使用发现到的引擎 gRPC port。
+2. 对每个逻辑地址在 WorkerDirectory 中取得或创建 WorkerStatus generation。发现本身不创建
+   可路由 endpoint。
+3. 以 WorkerStatus.PollLease 的 CAS gate 确保同一 worker 同时至多一个 status poll；KVCM
+   未启用时，cache poll 另有独立 gate。
+4. 对消失的发现条目保留一个与轮询间隔相关的宽限期；宽限期后启动该 generation 的 retirement。
 
-worker 地址表示由不可变 `WorkerIdentity` 一次性预计算并保存，调用方不再解析或临时拼接：
+GrpcWorkerStatusRunner 将响应先冻结为 WorkerStatus.StatusObservation。严格更大的
+statusVersion 才会生成 PreparedStatus；endpoint reducer 用该不可变 observation 更新自己的
+账本，全部 reducer 成功后才通过 publishPreparedStatus() 原子提交新的 EngineObservation 和
+cursor。相同版本的 heartbeat 只投影活跃任务事实，不重放版本化的 mutation。
 
-| 表示 | 格式 | 用途 |
-|---|---|---|
-| raw IP | `ip` | 网络连接与服务发现 |
-| raw port | `port` | 共享 frontend 端口 |
-| raw engine index | `engineIndex` | 逻辑引擎序号 |
-| physical IP-port | `ip:port` | 共享 frontend 身份、物理健康分组 |
-| logical IP-port | `ip:port@index` | 路由、rollback、KVCM 与 cache key |
-| metrics logical IP-port | `ip:port@index` | 所有可归属具体引擎的 `engineIp` 指标标签 |
+连续三次 status RPC transport failure、空/非法状态或 reducer 失败都会使该 generation 退役。
+retirement 先从 EndpointRegistry 移除路由入口，等待已发出的 GenerationPin，再清理目录和本地
+cache。状态同步成功后，physical-group health 要求一个共享 frontend 的所有 engine sibling
+都已发布且 reportedAlive，才能被路由器使用。
 
-`WorkerHost` 在服务发现展开时持有该 identity；`WorkerStatus` 更新任一 raw 字段时原子替换
-整份 identity，保证三种派生表示来自同一个快照。N=1 也保留 `@0`。
+WorkerStatus 公开的并不是可变的 localTaskMap。它分别发布 topology、不可变
+CommittedWorkerStatus（引擎容量、KV、运行任务和 cursor）与 PollHealth。调度的本地请求、
+Prefill 队列和 Decode fence 由 endpoint / RequestRegistry 持有，详见
+[03-resource-management](03-resource-management.md)。
 
-### GrpcWorkerStatusRunner
+## LOCAL_SYNC cache 元数据
 
-gRPC `getWorkerStatus`（VIT 走 multimodal 变体）携带 `latest_finished_version` 做增量拉取。
-响应字段（`WorkerStatusResponse`）：`alive`、`available_concurrency`、running/waiting/finished
-任务表（Map<requestId, TaskInfo>）、`status_version`、`step_latency_ms`、`iterate_count`、
-dp/tp size、内嵌 `cache_status`、`block_hash_lookahead_tokens`、`cache_match_rollback_blocks`、
-`kv_cache_group_mode` 等。没有显式 TTFT 字段——负载估计由 `stepLatencyMs` 与本地
-`runningQueueTime` 组成。
+当 cacheMatching.type=LOCAL_SYNC 时，GrpcCacheStatusCheckRunner 按动态间隔获取
+PREFILL/PDFUSION 的 cache status。它仍受独立 poll lease 保护，且只将版本变化的 cached keys
+交给 CacheAwareService.updateFromWorkerStatus()。
 
-处理逻辑：版本号新才全量更新（并发/任务表/队列时间）；版本号旧也更新 alive、时间戳并做任务
-对账；`cache_status` 总量恒更新（used = total − available）。带 `CacheHitFeedback` 的完成
-任务会异步送 `CacheAwareService.buildCacheHitComparison`（预测 vs 实际命中对比，出指标 + pv 日志）。
-连续 3 次 RPC 失败会把该逻辑 worker 标为不健康并移除其 endpoint；公共 physical AND
-gate 同时将所有 siblings 排除出路由候选，成功状态恢复且整组健康后才重新可路由。
-新发现的 worker 在首次接受有效状态前不可路由。空响应标为不健康；未初始化状态
-（`status_version=0`）与响应处理异常跳过本轮更新。
+LocalSyncCacheMatchProvider 的实现由以下两级索引组成：
 
-### WorkerStatus 的本地预测与对账
+- GlobalCacheIndex：block hash 到 logical worker 集合的倒排索引；
+- EngineLocalView：logical worker 到 block hash 集合的正排索引；
+- KvCacheManager：对两级索引执行 diff、更新、移除与前缀匹配。
 
-`WorkerStatus`（flexlb-common）的原子性是**字段级**（AtomicLong/AtomicBoolean +
-ConcurrentHashMap），不是快照级：
+匹配依请求 block 链顺序进行：候选 worker 在第一个 miss 后被淘汰，结果是连续前缀长度。动态
+间隔服务根据 cache diff 大小调整下一次轮询，默认目标 diff 为 30，间隔范围 50ms 到 3,000ms。
+KVCM 启用时 LOCAL_SYNC 元数据轮询和更新关闭。
 
-- 路由选中 → `putLocalTask()`：任务记为 IN_TRANSIT，`runningQueueTime` 加上估算 prefill
-  时间，`availableKvCacheTokens`/`usedKvCacheTokens` 预扣 `inputLength − prefixLength`；
-- 引擎状态到达 → `updateTaskStates()` 状态机对账：IN_TRANSIT→CONFIRMED→RUNNING→FINISHED，
-  超时未确认判 LOST；`updateKvCacheTokens()` 在 `getAndSet` 引擎值前**加回在途任务的
-  cache-miss 部分**，避免双重计数。
-- 状态转变耗时：`updateTaskStates()` 顺带产出 `TaskStateUpdateResult` 里的延迟列表——
-  FlexLB 观测值（dispatch→waiting confirm、waiting confirm→running）与引擎侧真实值
-  （received→waiting、waiting→running，取自 TaskInfoPB 的 `request_received_time_ms`/
-  `waiting_entered_time_ms`/`running_entered_time_ms`，`0` 视为未知跳过），由
-  `GrpcWorkerStatusRunner` 分别上报供对账。
-- `ExpirationCleaner`（`@Scheduled(fixedRate=3000)`）：移除 `statusLastUpdateTime` 超过
-  3s 的 worker；按 `taskConfirmTimeoutMs`（默认 300,000ms）清理确认超时/LOST 任务并出
-  pv 日志。
+## KVCM 与 Local Standby
 
-## Cache 状态同步（LOCAL_SYNC 路径，仅 KVCM 关闭时）
+cacheMatching.type=KVCM 时，KvcmCacheMatchProvider 使用 KvcmGrpcClient 访问当前 KVCM leader，
+按 role、group、block size 和 worker kvCacheGroupMode 查询 host 前缀命中。leader 刷新、请求
+timeout、重试、心跳和恢复阈值都由 KVCM 配置控制；默认请求 timeout 为 500ms，leader 刷新为
+10 秒。
 
-`GrpcCacheStatusCheckRunner`：挂在 20ms 同步 tick 上，但 PREFILL/PDFUSION 按
-`DynamicCacheIntervalService.getCurrentIntervalMs()` 降频（跳 tick 实现）。请求携带当前
-cache 版本做增量；响应恒更新 KV token 总量，版本更新时把 `cached_keys`（block hash 集合）
-经 `CacheAwareService.updateFromWorkerStatus()` 喂给本地索引（仅 PREFILL/PDFUSION）。
+KVCM 模式仍维护 Local Standby，但它不是 worker cache status 的副本：
 
-**动态间隔**：`DefaultDynamicCacheIntervalService` 维护 30 样本滚动平均 diff 大小，目标
-`CACHE_STATUS_DIFF_SIZE(30)`；偏差 >10% 时按 ±30% 调整间隔，钳制在
-[`CACHE_STATUS_MIN_INTERVAL_MS(50)`, `CACHE_STATUS_MAX_INTERVAL_MS(3000)`]——diff 大则加快
-同步，diff 小则放慢。
+- LocalStandbyCacheMatchProvider 只从已经成功路由的 PREFILL/PDFUSION 请求异步写入映射；
+- 映射有容量上限和 TTL，接近容量时缩短 TTL；可按 Local Standby 的 block size 异步补算 hash；
+- LocalStandbyComparisonService 把 standby 预测和之后的 engine feedback 对比，用于在切换前
+  评估质量。
 
-## flexlb-cache：三种匹配源
+CacheMatchQueryOrchestrator 的查询顺序是：
 
-### LOCAL_SYNC 两级索引
+1. LOCAL_SYNC 模式直接查本地全量索引。
+2. KVCM 模式且 active source 为 LOCAL_STANDBY 时，直接查 standby。
+3. 否则查 KVCM；若查询异常，本次请求同步降级查 standby，但 active source 仍保持 KVCM。
+4. CacheMatchFailoverManager 依据 KVCM 健康自动切换，或响应 ACTIVATE_FALLBACK /
+   RECOVER_PRIMARY 手动操作。控制入口是 GET /flexlb/cache_match/status 和
+   POST /flexlb/cache_match/failover。
 
-- **大表** `GlobalCacheIndex`：`ConcurrentHashMap<Long blockHash, Set<String engineIpPort>>`，
-  变更加单把 `ReentrantLock`。`batchCalculatePrefixMatchLength`：按序遍历请求 block 链，
-  用候选集过滤 + 首个未命中即淘汰该引擎（早停），返回每引擎的前缀匹配块数。
-- **小表** `EngineLocalView`：`ConcurrentHashMap<String engineIpPort, Set<Long>>`。
-  `calculateDiff` 在专用 ForkJoinPool 上并行算 added/removed，diff 大小回馈动态间隔服务。
-- `KvCacheManager`：门面——`findMatchingEngines`（候选来自 `WorkerStatusProvider`）、
-  `updateEngineCache`（diff 后双表应用）、`removeStaleEngineCaches`、`clear`。
+CacheMatchResult 携带产生该结果的 block size；路由器用 block size × 连续命中块数换算 token，
+并限制在请求 token 数内。KVCM 对 N=1 仅在 logical key 不命中时兼容查询旧 physical key；其余
+路径要求 exact logical identity。
 
-上述 LOCAL_SYNC key、KVCM `host_ip_port`、LOCAL_STANDBY 映射与 cache-hit comparison 均使用
-逻辑 `ip:httpPort@index`。KVCM 对 N=1 worker 兼容旧 physical `ip:httpPort` key：logical key
-未命中时才回退查询 physical key；N>1 或非 KVCM source 仍要求 exact match，无法匹配时按零命中忽略。
+## Block hash
 
-### KVCM（外部 KV Cache Manager）
+RequestBlockHashService 在 schedule 的路由前准备 block_cache_keys。请求已携带 keys 时直接使用；
+否则必须提供 input_ids，服务根据当前存活 PREFILL（没有时 PDFUSION）worker 的
+BlockHashConfig 计算。没有任一种输入时，调度请求无效。
 
-- 开关：`FLEXLB_CONFIG.cacheMatching.type=KVCM`；`MODEL_SERVICE_CONFIG.kvcm` 只提供
-  KVCM address/namespace/port/discovery 定位信息；
-  `CacheMatchConfiguration` 推导不变量 **`localSyncEnabled = !kvcmEnabled`、
-  `localStandbyEnabled = kvcmEnabled`**。
-- `KvcmGrpcClient`（flexlb-grpc）：向 KVCM **leader** 发 `GetHostCacheState`
-  （namespace = `deploymentName_blockSize`，QueryType 按 worker `kvCacheGroupMode` 映射
-  QT_PREFIX_MATCH / QT_PREFIX_MATCH_WITH_MAMBA），响应 `HostCacheMatch{host_ip_port,
-  prefix_match_blocks}`；`p2pHostCount` 默认 0，只对 local 命中最长的前 N 个 host 计算
-  P2P，配置为 0 时跳过 P2P；查询失败重试至 `maxQueryRetryCount`。
-- 健康管理：daemon 线程每 `leaderRefreshIntervalMs(10s)` 刷 leader（`GetClusterInfo`）与
-  worker 元数据；心跳/查询失败计数对 `heartbeatFailureThreshold(3)` /
-  `queryFailureThreshold(10)` 判不健康，连续 `recoverySuccessThreshold(3)` 次心跳成功恢复；
-  预热期（warmup）失败忽略。健康变化通知监听者。
-
-### LOCAL_STANDBY（兜底索引）
-
-- 近似索引，**只由已路由请求写入**（write-on-route）：PREFILL/PDFUSION 路由成功后
-  `HttpLoadBalanceServer` 调 `updateFromRoutedRequest` 异步落库。master/follower 之间不复制。
-- `LocalStandbyCacheIndex`：`ConcurrentHashMap<Long blockHash, ConcurrentHashMap<worker,
-  lastUpdatedNanos>>`，TTL 过期（用量超 `ttlReductionStartRatio(0.8)` 后 TTL 从
-  `ttlMs(300s)` 线性降至 `minimumTtlMs(100s)`），容量上限
-  `min(存活 worker HBM 估算块数 × capacityMultiplier(10), maximumEntries(200万))`，
-  达到上限拒绝新映射；daemon 清理线程每 10s 增量扫描。
-- 匹配时对每个 worker 的命中块数**减去其 `cacheMatchRollbackBlocks`**（下限 0）。
-- `LocalStandbyComparisonService`：KVCM 为主时持续影子预测，与引擎实际命中
-  （`CacheHitFeedback`）对比出 delta 指标——failover 前即可评估兜底质量。
-
-### 查询编排与 failover
-
-`CacheMatchQueryOrchestrator.findMatchingEngines()`：
-
-1. KVCM 关闭 → LOCAL_SYNC。
-2. KVCM 开启：`CacheMatchFailoverManager.activeSource()` 为 LOCAL_STANDBY → 查兜底
-   （指标 `standby_fallback{active_source}`）。
-3. 否则查 KVCM；成功时同步做一次 standby 影子预测记录；**内部重试耗尽后查询抛异常时当前请求同步降级
-   查 standby，但 active source 保持 KVCM**（`standby_fallback{kvcm_query_failure}`）。KVCM gRPC client 同时报告
-   `app.cache.kvcm.query.failure.qps`。
-   每个实际走 Local Standby 的结果都会登记 resolved standby prediction，以便后续 engine feedback 产出
-   同一 `cacheMatchSource=LOCAL_STANDBY` 标签下的 cache-hit comparison 指标和 PV。Standby prediction
-   登记的异常只影响 comparison，不触发 KVCM 降级或 Local Standby 路由失败。
-
-`CacheMatchFailoverManager`：监听 KVCM 健康——不健康且 `autoSwitch` 开 → 切 LOCAL_STANDBY；恢复健康 →
-切回 KVCM；手动 `ACTIVATE_FALLBACK` 覆盖一切，
-`RECOVER_PRIMARY` 要求 KVCM 已健康
-（HTTP 入口 `POST /flexlb/cache_match/failover`，非 master 会转发给 master；状态查询
-`GET /flexlb/cache_match/status`）。
-
-`CacheMatchResult` 恒携带**应答源自己的 blockSize**（KVCM/standby 的块大小可能与请求主
-hash 不同），路由侧统一用 `blockSize × 匹配块数` 折算 token，并以请求 token 数作为上限。
-
-## Block hash 计算
-
-- 策略：`BlockHashStrategy`（flexlb-cache）由 `FlexlbConfig.blockHashStrategy` 选择，默认
-  `VLLM`；只能通过 `FLEXLB_CONFIG` 切换为 `SGLANG`。
-- `VllmBlockHashStrategy` 委托 `BlockCacheKeyCalculator`（flexlb-common）计算 vLLM 兼容的
-  `sha256_cbor` 链式块哈希（`PYTHONHASHSEED=0` 语义）：每满块 CBOR 编码
-  `[parentHash, tokens, null]` → SHA-256 → 取低 64 位为 Long key；末尾不满块丢弃。
-- `SglangBlockHashStrategy`：每页计算
-  `SHA256(parentFullDigest || tokenIdsAsUint32LittleEndian)`，用完整 32-byte digest 串联下一页，
-  取 digest 高 64 位作为有符号 Long key；与 SGLang page_size 对齐，末尾不满页不计算。
-  `block_hash_lookahead_tokens=0`
-  时每个逻辑单元是单 token；值为 1 时匹配 SGLang EAGLE，把 N 个 raw tokens 表示为 N-1 个
-  overlapping `(t_i, t_{i+1})`，每个 pair 的两个 token 都写入 hash。其他 lookahead 值请求失败。
-  可缓存前缀同样按完整页截取：普通模式按 `floor(N/blockSize)`、EAGLE 按
-  `floor((N-1)/blockSize)`。
-- 配置解析：`WorkerBlockHashConfigResolver` 每 1 分钟从存活 PREFILL（退化 PDFUSION）worker
-  的 `blockSize` + `blockHashLookaheadTokens` 刷新，不可用时保留上次有效值。
-- 执行：`BlockHashExecutor` 专用线程池（默认 core 8 / max 32 / 队列 16384，
-  `flexlb.block-hash.*` 可调），出队等待/执行耗时指标，完成后 `publishOn(parallel)` 不占
-  hash 线程。调度请求必须提供 `block_cache_keys` 或 `input_ids` 至少一种；前者直接采用不再
-  计算，后者由 Master 按当前 worker hash 配置生成，两者都为空时返回 `INVALID_REQUEST`。
-- Local Standby 块大小与主请求不同时，由 `LocalStandbyHashService`（低优先级独立线程池 +
-  Caffeine 60s 结果缓存）异步补算，路由只等主 hash；主 hash 与 standby 共用同一个
-  `BlockHashStrategy` bean。
-- LOCAL_SYNC、Local Standby 与 KVCM 查询都消费有序 block key 链，按请求顺序连续匹配并在
-  首个 miss 停止；这与 SGLang HashTree 的前缀匹配语义一致，不按算法拆分 matcher。
+BlockHashExecutor 在专用线程池执行计算，默认 core=8、max=32、队列=16,384。VLLM 策略使用
+链式 sha256_cbor block hash；SGLANG 策略使用 parent digest 与 little-endian token 页哈希，
+支持 lookahead 为 0 或 1。三种 cache matcher 都消费有序 hash 链并在首个 miss 截断，不因 hash
+算法改变前缀匹配语义。

--- a/rtp_llm/flexlb/docs/architecture/05-lifecycle-and-consistency.md
+++ b/rtp_llm/flexlb/docs/architecture/05-lifecycle-and-consistency.md
@@ -1,119 +1,67 @@
 # Lifecycle and Consistency
 
-FlexLB 的优雅上下线不靠 Spring 生命周期或 JVM 信号，而由**同机 sidecar 通过本机 HTTP hook
-端点驱动**；高可用由 ZooKeeper LeaderSelector 主选举 + slave 请求转发实现。
+FlexLB 的上线和下线由本机 sidecar 调用 HTTP hook 驱动；高可用是可选的 ZooKeeper
+LeaderSelector 选举，并通过 FlexLB 自己的 gRPC 服务把 follower 请求交给 master。
 
-主要代码：`flexlb-sync/src/main/java/org/flexlb/service/grace/`、`consistency/`，
-`flexlb-api/.../AppStateHookServer.java`、`HealthCheckServer.java`。
+## 生命周期 hook
 
-## 生命周期 Hook
-
-### 接口（flexlb-common `listener/`）
-
-| 接口 | 方法 | 备注 |
-|---|---|---|
-| `AppOnlineHooker` | `afterStartUp()` + `priority()` | `priority()` 已声明但**无调用方**——实际执行顺序硬编码在编排服务里 |
-| `AppShutDownHooker` | `beforeShutdown()` | 无优先级方法 |
-| `ApplicationWarmupState` | `isWarmupFinished()` | 供健康检查与 gRPC 客户端预热判断 |
-
-失败语义：各 Hook 内部自行 catch（`LbConsistencyHooker` 上线 catch Exception、下线 catch
-Throwable；`ActiveRequestShutdownHooker` catch InterruptedException），实践中单个 Hook 失败
-不会中断链；若真有未捕获异常，`AppStateHookServer` 返回 HTTP 500。
-
-### 编排与触发
-
-**触发点是三个仅限本机调用的 HTTP 端点**（`AppStateHookServer`，非 loopback/本机地址一律 403）：
+AppStateHookServer 只接受 loopback 或与本机地址相同的调用方，其他远端地址返回 403。
 
 | 端点 | 行为 |
 |---|---|
-| `GET /hook/process_ok` | `ApplicationReadyEvent` 后返回 200，否则 503 |
-| `GET /hook/after_start` | 同步执行 `GracefulOnlineService.online()`（故意阻塞事件循环），上报 `online_complete` |
-| `GET /hook/pre_stop` | 在 boundedElastic 上执行 `GracefulShutdownService.offline()`；活跃请求排干成功返回 200，否则 503 |
+| GET /hook/process_ok | ApplicationReadyEvent 后返回 200；此前返回 503 |
+| GET /hook/after_start | 同步执行 ApplicationLifecycle.online()，完成后才返回 200 |
+| GET /hook/pre_stop | 在 boundedElastic 执行 ApplicationLifecycle.offline()；排干成功返回 200，否则 503 或 500 |
 
-**上线顺序**（`GracefulOnlineService.online()`，`test` profile 下整体跳过）：
-1. `LbConsistencyHooker.afterStartUp()`——`LBStatusConsistencyService.start()` → ZK
-   LeaderSelector 启动（`zk_node_online`）；
-2. `QueryWarmerHooker.afterStartUp()`——**固定 sleep 10 秒**等依赖就绪（并有 10s 兜底
-   Timer 强制置位），完成后 `warmupFinished=true`（`warmer_complete`）。名字里的
-   "warm" 目前不预热任何查询路径。
+ApplicationLifecycle 是固定编排器，不再遍历 AppOnlineHooker/AppShutDownHooker 列表：
 
-**下线顺序**（`GracefulShutdownService.offline()`）：
-1. `HealthCheckHooker`——置静态 volatile `isShutDownSignalReceived=true`，`/health` 立即
-   开始返回 404，摘除流量（`health_check_offline`）；
-2. `LbConsistencyHooker`——ZK 下线/让主（`zk_node_offline`）；
-3. `ActiveRequestShutdownHooker`——排干在途请求：每 500ms 轮询
-   `ActiveRequestCounter.getCount()`，需要**连续 5s 静默**（quietPeriodMs，期间任何活跃请求
-   重置窗口）才算成功；硬超时 300s（`shutdown_timeout`）。计数来源：每个
-   `/rtp_llm/schedule` 请求通过 `Mono.using(activeRequestCounter::acquire, ...,
-   RequestToken::close)` 包裹（token 幂等关闭）。
+1. online：test profile 整体跳过；其他 profile 启动 LBStatusConsistencyService，随后等待
+   固定 3 秒初始 worker 同步并设置 warmUpFinished。
+2. health：GET /health 只有 warmUpFinished 且尚未收到 shutdown 时返回 200；其他情况返回 404。
+3. offline：先设置 shutdownReceived 并立即让 health 失败，再执行一致性 offline；然后每
+   500ms 观察 ActiveRequestCounter，要求连续 5 秒没有活跃请求。硬超时为 300 秒。
 
-### 健康检查
+ActiveRequestCounter 的 token 在每个 gRPC Schedule 调用完成、取消或出错时幂等关闭。它衡量的是
+FlexLB 接收中的 gRPC 请求，不是 endpoint 队列深度或引擎运行请求数。GracefulLifecycleReporter
+记录 process_ok、zk_node_online/offline、warmer_complete、online_complete、health_check_offline、
+shutdown_complete 和 shutdown_timeout 事件。
 
-`GET /health`（`HealthCheckServer`）：`isShutDownSignalReceived` → 404 "shutdown received"；
-warmup 未完成 → 404 "warm not finish"；否则 200 "success"。
+## 一致性配置与主选举
 
-### 指标
+FLEXLB_CONFIG.consistency 是 tagged union：
 
-`GracefulLifecycleReporter`：gauge `graceful.lifecycle.event`，tag `type`
-（`process_ok`/`zk_node_online`/`warmer_complete`/`online_complete`/`health_check_offline`/
-`zk_node_offline`/`shutdown_complete`/`shutdown_timeout`）+ `duration_ms`，值为时间戳。
+- NONE（默认）：LBStatusConsistencyService 的 start/offline 为 no-op，isMaster() 返回 false。
+- ZOOKEEPER：ZookeeperConsistencyConfig 保存连接、session/connection timeout 和
+  masterRefreshIntervalMs；该对象在 Bean 创建时读取，切换类型或连接参数需要重启。当前
+  ZookeeperMasterElectService 的实际缓存刷新任务固定为 5 秒。
 
-## 主选举与一致性
+ZookeeperMasterElectService 使用 Curator LeaderSelector，namespace 为 whale-master，路径为
+/master_lb_leader/{deploymentId}，selector id 是本机 IP，retry policy 是
+ExponentialBackoffRetry(1000, 3)，并启用 autoRequeue。
 
-### 配置
+获得领导权后服务将 isMaster 置为 true，异步 HTTP 通知其他 participant 的
+/rtp_llm/notify_master，然后阻塞在 latch 上保持领导权。SUSPENDED 或 LOST 会抛
+CancelLeadershipException；LOST 同时清空缓存 master。缓存 leader 每 5 秒刷新，master 节点
+指标每 2 秒上报。
 
-一致性行为已收拢到 `FLEXLB_CONFIG.consistency` tagged union。默认
-`{"type":"NONE"}`，相关 start/offline/destroy 都是 no-op、`isMaster()` 恒 false；启用时使用：
+offline 会禁止 rejoin 并释放 leader latch。多节点时最多等待约 30 秒确认本机不再是 leader；
+单节点或查询 participant 失败时不等待转移。GET /rtp_llm/schedule_snapshot 返回当前的领导权
+诊断快照（是否启用、是否 master、本机与缓存 master），不是调度队列的状态复制。
 
-```json
-{
-  "consistency": {
-    "type": "ZOOKEEPER",
-    "connectString": "zk-1:2181,zk-2:2181",
-    "sessionTimeoutMs": 30000,
-    "connectionTimeoutMs": 30000,
-    "masterRefreshIntervalMs": 5000
-  }
-}
-```
+## follower gRPC 转发
 
-一致性组件在 Bean 初始化时取得配置，因此 Nacos 可以保存和替换这部分字段，但当前进程
-是否启用一致性及 ZooKeeper 客户端参数在重启后生效。选举路径使用 `HIPPO_ROLE`；端口取
-Spring `server.port`，再回退 JVM `-Dserver.port` 和默认 7001（假定所有副本同端口）。
+Schedule、GetRequestState 和 Cancel 的权威生命周期在 master。启用一致性且本机不是 master 时：
 
-### ZookeeperMasterElectService
+1. FlexlbServiceImpl 通过 FlexlbGrpcForwarder 读取 cached master，并在 gRPC 端口
+   server.port + 2 上转发调用。
+2. 请求携带 forward_hop，最大只允许一次转发；self-target 或 hop limit 会拒绝再次转发。
+3. 没有 master 地址且尚未尝试 RPC 时，Schedule、状态查询和取消可本地处理。
+4. 一旦已选择 master 并尝试 Schedule/Cancel RPC，超时或连接失败都是不确定交付：
+   不在 follower 本地执行相同 reducer。Schedule 会尽力向 master 发送取消协调，以免 master
+   已提交请求后调用方已离开。
 
-- Curator recipe：**LeaderSelector**（非 LeaderLatch），namespace `whale-master`，路径
-  `/master_lb_leader/<deploymentId>`，`setId(本机IP)`，`autoRequeue()`，重试
-  `ExponentialBackoffRetry(1000, 3)`。
-- `takeLeadership()`：置 `isMaster=true`，**主动 HTTP 通知所有非 leader 参与者**
-  `POST http://<ip>:<port>/rtp_llm/notify_master`（1s 超时）；然后阻塞在 CountDownLatch 上
-  保持领导权。
-- `stateChanged()`：`SUSPENDED`/`LOST` → 抛 `CancelLeadershipException` 放弃领导权
-  （LOST 同时清空 master 缓存）。
-- master 缓存：每 5s `updateLatestMaster()` 从 `leaderSelector.getLeader().getId()` 刷新
-  `cachedMasterHostIp`；每 1s 上报 master 节点指标。
-- **优雅让主**：`offline()` 置 `markOffline`、关闭 autoRejoin；若自己是 master，释放 latch
-  后（多节点时）**每 1s 轮询直到 leader 变成别的 IP 才返回**——pre_stop 会等领导权实际转移。
+因此一致性是“有可达 master 时单一调度所有者”的保证；master 缓存缺失时优先可用性。本地
+fallback 只发生在没有选中 master 的早期边界，不能把 RPC 失败解释为安全的本地重试。
 
-### LBStatusConsistencyService（Spring 门面，实现 MasterElectService）
-
-- `handleMasterChange(req)`：`/rtp_llm/notify_master` 的接收端——校验 `roleId` 匹配后
-  `refreshMasterHost(true)` 强刷缓存。
-- `getMasterHostIpPort()`：master IP + 本机 serverPort。
-- `syncLBStatusFromMaster`（每 500ms 调度）与 `dumpLBStatus()` 目前是 **TODO 空实现**
-  （`/rtp_llm/schedule_snapshot` 恒返回成功占位）。
-
-### "只有 master 路由"的实际语义
-
-靠 **slave 转发而非拒绝**，只有两处检查 `isMaster()`：
-
-1. `HttpLoadBalanceServer.processScheduledRequest`：启用一致性且非 master →
-   `forwardRequestToMaster()` 把原始请求代理到 `http://master:port/rtp_llm/schedule`；
-   **master 为空/不可达/超时时降级为本地路由**（`fallbackToLocalRouting`，上报
-   `MASTER_NULL`/`TIMEOUT`/`CONNECT_FAILED`）。所有响应都携带 `realMasterHost` 供客户端
-   感知真正的 master。
-2. `FlexlbControlServer`：cache-match failover 操作非 master 时转发给 master（master 不可用
-   返回 503）。
-
-因此该保证是 best-effort：网络分区或 master 缺位时 slave 会自行路由（可用性优先）。
+Cache match failover 的 HTTP 控制操作也在 follower 转发给 master；没有 master 或转发失败返回
+503，而不是在 follower 改变 local active source。

--- a/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
+++ b/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
@@ -217,3 +217,16 @@ logger group `flexlb` 包含 `org.flexlb`、`flexlbLogger`、`syncLogger`、
 
 Spring profile 与日志、监控 provider 的具体默认值见
 `flexlb-api/src/main/resources/application.yml`。
+
+## Multi-engine endpoint 与观测
+
+`MODEL_SERVICE_CONFIG` 的 endpoint 支持 `multi_engine_num`（默认 1）。显式
+`worker_status_port` 必须处于 `[1, 65535]`；N>1 必须指定该端口，并保证
+`worker_status_port + N - 1 <= 65535`。每个 index 使用独立的 status gRPC 端口，
+frontend HTTP/gRPC 仍为共享物理地址。protocol 只解释 frontend discovery port。
+N=1 沿用 discovery 的 legacy gRPC port，因而兼容未配置 `worker_status_port` 的 RTP-LLM。
+
+逻辑 worker identity 为 `ip:http_port@engineIndex`，包括 N=1 的 `@0`。
+引擎与 cache 指标的 `engineIp` 使用完整 logical identity `ip:http_port@engineIndex`；
+网络连接仍使用物理地址。schedule 在 N=1 时省略 `engine_index`，内部 identity 和观测仍保留
+index 0。

--- a/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
+++ b/rtp_llm/flexlb/docs/architecture/06-configuration-and-observability.md
@@ -2,231 +2,113 @@
 
 ## 配置边界
 
-FlexLB 保留两个职责独立的配置文档：
+FlexLB 使用两份职责独立的配置：
 
-- `FLEXLB_CONFIG`：唯一的 FlexLB 行为配置，包含调度、分发、路由、worker registry、
-  observability、服务发现运行参数、cache matching、Optimizer 和一致性/主选举。
-- `MODEL_SERVICE_CONFIG`：只保存模型、endpoint、KVCM、Optimizer 的地址和服务发现定位信息。
+- FLEXLB_CONFIG：负载均衡行为，包括 scheduler、dispatcher、路由、worker registry、cache
+  matching、observability、服务发现运行参数、optimizer 和 consistency。
+- MODEL_SERVICE_CONFIG：模型服务拓扑，包括 service_id、按 group 的 role_endpoints，以及 KVCM /
+  Optimizer 的地址和 discovery 定位。
 
-`MODEL_SERVICE_CONFIG` 不属于动态 `FlexlbConfig` 快照，也不会被 UniConfig 或 Nacos
-的动态更新覆盖。UniConfig 开关、Nacos 连接、部署标识、日志路径、Spring/OTEL 等
-基础设施环境变量仍各自独立；它们不构成
-FlexLB 行为配置的别名。
+MODEL_SERVICE_CONFIG 在进程启动时解析为 ServiceRoute；动态 FLEXLB_CONFIG 更新不改变模型拓扑。
+相反，MODEL_SERVICE_CONFIG 不接受调度、cache matching、服务发现 timeout/poll 或主选举等行为字段。
 
-## FlexlbConfig 加载与动态更新
+当前公共行为配置的 schemaVersion 是 2。ConfigService 严格拒绝未知字段、null、重复 key、类型
+coercion 和不符合 active tagged-union 分支的字段。版本 0 的历史合并配置仍可由 V0 parser
+归一化；版本 1 到版本 2 的迁移由 FlexlbConfigMigration 显式完成，不应把 v1 作为运行时标准
+文档发布。
 
-`ConfigService` 是统一读取入口。`ConfigSourceSelection` 在启动时根据 FlexLB 进程的
-环境变量选择唯一的行为配置字符串来源，先判断 UniConfig，再判断 Nacos：
+## 配置来源与更新
 
-| 条件（按顺序判断） | 字符串来源 | 动态更新方式 |
+进程启动时按以下优先级选择一个行为配置来源：
+
+| 条件 | 来源 | 更新方式 |
 |---|---|---|
-| `FLEXLB_UNICONF_ENABLE=true` | `UniConfigConfigSource` | 轮询本机 Turbo UniConfig HTTP 接口 |
-| 否则，`FLEXLB_NACOS_SERVER_ADDR` 非空 | `NacosConfigSource` | Nacos listener |
-| 否则 | `EnvironmentConfigSource` | 启动时读取 `FLEXLB_CONFIG` |
+| FLEXLB_UNICONF_ENABLE=true | UniConfigConfigSource | 本机 Turbo UniConfig 轮询 |
+| 否则 FLEXLB_NACOS_SERVER_ADDR 非空 | NacosConfigSource | Nacos listener |
+| 否则 | EnvironmentConfigSource | 启动时读取 FLEXLB_CONFIG |
 
-`true` 忽略大小写和两端空白。开启 UniConfig 后，即使配置了 Nacos 地址，也不会
-创建 Nacos 客户端或 listener。使用外部来源时，环境变量中的 `FLEXLB_CONFIG` 不参与
-校验或合并；初始文档中省略的行为字段使用对应格式解析器和 `FlexlbConfig` 的默认值。
-`EnvironmentConfigSource` 仍负责读取独立的 `MODEL_SERVICE_CONFIG` 启动拓扑。
-来源选择和连接参数在启动时确定，修改它们需要重启进程。
+不论行为来源为何，EnvironmentConfigSource 都读取 MODEL_SERVICE_CONFIG。来源内容经相应 parser
+归一化后由 FlexlbConfigMerger 与默认配置深度合并：对象字段递归覆盖，数组/标量替换；带 type
+的对象只有 type 相同才递归合并，切换 type 则整体替换。结果必须通过 schema 与跨字段校验，才会
+原子替换当前 FlexlbConfig；非法运行时更新保留 last-known-good 快照。
 
-三种来源都返回原始字符串，复用 `ConfigDocumentParserResolver` 和原有 v0/v1 解析器：
-优先使用文档内的 `schemaVersion`，否则使用 `FLEXLB_CONFIG_SCHEMA_VERSION`（默认 `0`）。
-UniConfig 和 Nacos 的内容直接使用同一种配置 JSON，不增加包装层。
+组件是否热生效取决于其读取方式。RouteService 和选择器从请求绑定的快照读取行为；在 Bean
+构造时缓存的线程池规模、同步间隔、delivery strategy、ZooKeeper 客户端和模型拓扑需要重启
+才能改变。
 
-格式归一化后，由现有 `FlexlbConfigMerger` 执行递归部分更新：
-对象字段递归覆盖，未出现或从外部配置删除的字段保留当前内存值，数组和标量整体替换；
-tagged union 的 `type` 变化会替换整个分支。v1 文档 `{"schemaVersion":1}` 是 no-op；
-没有显式版本的 `{}` 则按版本选择规则解析，默认走 v0 兼容转换。
-每次合并后都使用与 `FLEXLB_CONFIG` 相同的严格解析和跨字段校验：
+### UniConfig 与 Nacos
 
-- 拒绝重复 key、未知字段、`null`、标量 coercion、数值枚举和尾随 JSON；
-- 拒绝 tagged union 非活动分支的字段；
-- 拒绝违反 scheduler / dispatcher / router 等组合约束的配置。
+UniConfig 要求 Spectrum deployment identity（SPECTRUM_WORKSPACE_ID、
+SPECTRUM_APPLICATION_NAME、SPECTRUM_DEPLOYMENT_NAME）和
+FLEXLB_UNICONF_ENABLE=true。它请求：
 
-选定的外部来源初次读取或校验失败会阻止应用启动，不会自动切换到低优先级来源。
-运行时读取失败或非法更新不会替换当前 last-known-good 快照，后续更新恢复正常后
-继续应用；合法更新原子替换 `FlexlbConfig`，随后通知监听器。
+    GET http://127.0.0.1:18080/v2/configs/modelstudio.spectrum.deployment.<workspace>.<deployment>.runtime.meta
 
-配置来源层不区分“热生效”与“重启生效”：它只发布最新有效快照。业务组件每次读取快照，
-就可以热生效；在 Bean 初始化时缓存的值，则在重启后生效。
+连接和读取 timeout 都是 3 秒。启动阶段如果本机 agent 尚未就绪，会以 1 秒间隔持续重试；
+成功后每 30 秒 fixed-delay 轮询，内容变化才发布。运行时读取失败保留当前快照。
 
-旧的字段级行为变量 `BLOCK_HASH_STRATEGY`、`FLEXLB_LOG_LEVEL`、
-`ENABLE_STDOUT_LOG`、`ENABLE_FALLBACK` 不再覆盖 JSON。行为配置只认
-所选来源的 `FLEXLB_CONFIG` 文档，避免嵌套字段到环境变量名的隐式转换。
-
-### UniConfig 连接
-
-Spectrum 部署的扩展配置中启用 Turbo UniConfig：
-
-```json
-{
-  "turbo": {
-    "env": {
-      "UNICONF_ENABLE": "true"
-    }
-  }
-}
-```
-
-同时需要在部署的 worker 环境变量中显式配置，让 FlexLB Java 进程读取到：
-
-```text
-FLEXLB_UNICONF_ENABLE=true
-```
-
-两个开关分别控制不同进程，启用 UniConfig 时需要同时配置：Turbo 的
-`turbo.env.UNICONF_ENABLE=true` 开启本机配置服务；Java 的
-`FLEXLB_UNICONF_ENABLE=true` 选择 UniConfig 配置来源。Java 只读取带 `FLEXLB_` 前缀的
-开关，未设置或不为 `true` 时继续按 Nacos 地址、环境变量的顺序选择来源。
-部署标识沿用 `DeploymentIdentity`，要求设置 `SPECTRUM_WORKSPACE_ID`、
-`SPECTRUM_APPLICATION_NAME` 和 `SPECTRUM_DEPLOYMENT_NAME`。
-
-`UniConfigConfigSource` 读取以下部署级 key 的 HTTP 响应正文：
-
-```text
-GET http://127.0.0.1:18080/v2/configs/modelstudio.spectrum.deployment.<workspace>.<deployment>.runtime.meta
-```
-
-正文就是完整的配置 JSON 字符串，与 Nacos 文档格式一致。连接和读取超时各为 3 秒。
-启动时立即读取初始配置，后续每次请求完成后等待 30 秒再轮询，仅在正文变化时发布更新。
-Turbo 侧通常有约 1 分钟缓存，采用 30 秒轮询可兼顾本机请求频率和变化发现延迟；缓存刷新后，
-Java 还可能等待接近 30 秒才发现新内容。因此两段等待叠加时，生效延迟可能接近 90 秒，
-另加请求耗时，不能将轮询间隔理解为端到端生效时间保证。
-启动阶段遇到本机 agent 尚未监听端口导致的连接拒绝（`ConnectException`）时，每隔 1 秒
-重试，最多尝试 30 次；重试耗尽或线程被中断后启动失败。非 HTTP 200（包括 key 不存在时
-的 404）和非法配置仍会阻止启动。启动前应先在部署 UniConfig 页面保存合法配置。
-运行时 HTTP 异常保留有效快照并继续按 30 秒间隔重试。
-
-### Nacos 连接
-
-| 环境变量 | 默认值 | 说明 |
-|---|---|---|
-| `FLEXLB_NACOS_SERVER_ADDR` | 无 | 仅在 UniConfig 未开启且地址非空时启用 Nacos |
-| `FLEXLB_NACOS_DATA_ID` | 部署标识 | 显式 DataId |
-| `FLEXLB_NACOS_GROUP` | `DEFAULT_GROUP` | Nacos group |
-| `FLEXLB_NACOS_NAMESPACE` | 空 | Nacos namespace |
-
-未显式配置 DataId 时，部署标识优先使用
-`SPECTRUM_WORKSPACE_ID`、`SPECTRUM_APPLICATION_NAME`、
-`SPECTRUM_DEPLOYMENT_NAME` 组成
-`spectrum:<workspace>:<application>:<deployment>`；旧环境回退 `HIPPO_ROLE`。
-
-UniConfig / Nacos 的 v1 部分更新示例：
-
-```json
-{
-  "schemaVersion": 1,
-  "router": {
-    "availabilityHysteresisPercent": 12
-  },
-  "observability": {
-    "logging": {
-      "level": "warn",
-      "stdoutEnabled": true
-    }
-  }
-}
-```
+Nacos 的可选环境变量为 FLEXLB_NACOS_SERVER_ADDR、FLEXLB_NACOS_DATA_ID、
+FLEXLB_NACOS_GROUP 和 FLEXLB_NACOS_NAMESPACE。未显式设置 data id 时，使用
+DeploymentIdentity 的 deployment id。
 
 ## FLEXLB_CONFIG 结构
 
-公共 schema 当前为 version 1，按责任分区：
+顶层字段及其所有权如下：
 
-- `scheduler`：`DIRECT` / `QUEUE`；QUEUE 拥有 ordering、capacity 和 lifecycle。
-- `dispatcher`：`BATCH` / `NON_BATCH`。
-- `router`：角色 availability、execution estimator、selector、cache affinity 和
-  group selector。
-- `workerRegistry`：worker health 与 cache-status 刷新策略。
-- `observability.cacheHit`：recent-key window、指标和理论命中日志。
-- `observability.logging`：FlexLB logger group 级别与 root/PV stdout 开关。
-- `serviceDiscovery`：connect/read timeout、poll interval 与连接池运行参数。
-- `cacheMatching`：`LOCAL_SYNC` / `KVCM` tagged union；KVCM 分支拥有查询、健康、P2P
-  和 Local Standby 参数。
-- `optimizer`：启用开关和服务发现轮询间隔。
-- `consistency`：`NONE` / `ZOOKEEPER` tagged union；ZooKeeper 分支拥有连接和 master
-  刷新参数。
-- `blockHashStrategy`：cache block hash 策略。
-- `enableFallback`：默认 `false`；启用时调度入口在转发和路由前返回错误码 `8600`，
-  由调用方执行 domain fallback。
-- `fallbackBatchTokenCapacity`：默认 `1048576`；Engine 未声明
-  `max_batch_tokens_size` 和 `max_seq_len` 时使用的最终 batch token 容量兜底值。
-  优先使用 Engine 上报的 `max_batch_tokens_size`，其次使用 `max_seq_len`。
-- `internalRuntime`：代码内部设置，不接受公共 JSON 输入。
+| 字段 | 责任 |
+|---|---|
+| scheduler | DIRECT/QUEUE、QUEUE timeout、排序、decision、全局容量和 lifecycle |
+| dispatcher | BATCH/NON_BATCH 的交付类型、per-Prefill in-flight 上限和 enqueue timeout |
+| router | Prefill estimator/candidate/cache affinity、Decode KV/load 策略和 group selector |
+| workerRegistry | worker status/cache status 的轮询、timeout、陈旧与 cache interval 参数 |
+| cacheMatching | LOCAL_SYNC 或 KVCM；KVCM 分支包含 health、retry、P2P 与 Local Standby 参数 |
+| observability | cache-hit recent key window 与 FlexLB logger 配置 |
+| serviceDiscovery | discovery client 的连接、读取、轮询和 keep-alive 运行参数 |
+| optimizer | Optimizer 开关与 discovery poll interval |
+| consistency | NONE 或 ZOOKEEPER |
+| blockHashStrategy | VLLM 或 SGLANG |
+| enableFallback | 当前由 RouteService.isFallbackEnabled() 暴露给调用方；本检出中的 Schedule 路径不据此短路请求 |
+| fallbackBatchTokenCapacity | 引擎没有声明 batch/sequence 容量时的 reservation 兜底 |
 
-`DIRECT + BATCH` 非法；可选配置应省略，不能写 `null`。完整示例和 selector
-矩阵见根目录 [README](../../README.md)。
+DIRECT 要求 dispatcher.type=NON_BATCH。QUEUE 的 ordering.type=FIFO 不允许 preemption；
+PRIORITY 的 engine-owned Decode preemption 必须同时配置 engineCancellation。decision.type=SINGLE
+不允许 fixed-window 字段；FIXED_WINDOW 才使用 maxRequests、maxCollectionWaitMs 和
+maxPredictedExecutionMs。
 
-## MODEL_SERVICE_CONFIG
+内部线程池参数位于 InternalRuntimeSettings，不能通过公共 JSON 覆盖。它包括全局规划线程数、
+batch dispatch completion 线程数与 worker/status 同步线程数等实现参数。
 
-独立反序列化为 `ServiceRoute`：
+## 端口与控制面
 
-- `service_id` 和 `role_endpoints`；
-- endpoint 的 `address`、`protocol`、`path`、`worker_status_port`、`discovery`；
-- discovery 定位字段：类型 `static-env`、`vipserver`、`dashscope`，以及可选
-  `base_url` / `hosts`；
-- 可选 KVCM 定位字段 `address`、`namespace`、`port`、`discovery`；
-- 可选 Optimizer 定位字段 `address`、`port`、`path`、`discovery`。
+application.yml 的默认端口如下：
 
-旧的 `load_balance`、KVCM/Optimizer `enabled`、discovery timeout/poll、KVCM 健康与
-Local Standby 等行为字段会被拒绝，并提示迁移到 `FLEXLB_CONFIG`。该拓扑在相关 Spring
-Bean 创建时使用；动态 `FLEXLB_CONFIG` 更新不会改变模型拓扑。服务发现 provider 仍通过
-`DiscoveryConfig` 的运行参数 getter 读取当前 `FlexlbConfig.serviceDiscovery`，因此不需要
-把运行参数复制回 topology JSON。
+| 服务 | 默认端口 |
+|---|---|
+| WebFlux HTTP | 7001 |
+| Spring management / actuator | 7002 |
+| FlexLB gRPC | HTTP 端口 + 2，即默认 7003 |
 
-## 日志
+后端 engine 的 HTTP/gRPC 转换规则与 FlexLB 自身 gRPC 端口无关。多 engine endpoint 的
+worker_status_port 是 worker-control gRPC 基址；N>1 时 index i 使用 base+i，且配置加载时检查
+端口范围。frontend HTTP/gRPC 地址仍是共享物理地址。
 
-`logback-spring.xml` 定义 application、PV、sync、sync-consistency 和 FlexLB 文件输出。
-日志路径由 `FLEXLB_LOG_PATH` / `FLEXLB_APP_LOG_PATH` 控制，AsyncAppender queue
-由 `FLEXLB_LOG_ASYNC_QUEUE_SIZE` 控制。
+主要 HTTP 端点：
 
-logger group `flexlb` 包含 `org.flexlb`、`flexlbLogger`、`syncLogger`、
-`syncConsistencyLogger`。`FlexlbLogManager` 监听配置快照：
+- /health；/hook/process_ok、/hook/after_start、/hook/pre_stop；
+- /flexlb/update_log_level、/flexlb/cache_match/status、/flexlb/cache_match/failover；
+- /rtp_llm/master/info、/rtp_llm/schedule_snapshot、/rtp_llm/notify_master；
+- /rtp_llm/queue_snapshot、/rtp_llm/inflight_status；
+- /rtp_llm/server_latency、/rtp_llm/server_latency/reset。
 
-- `observability.logging.level` 热更新整个 group；
-- `observability.logging.stdoutEnabled` 动态挂载或卸载 root/PV 的
-  `CONSOLE-async`，文件输出始终保留。
+Schedule、GetRequestState 和 Cancel 是 FlexLB gRPC 服务的方法，不是 HTTP schedule 路由。
 
-`/flexlb/update_log_level` 继续提供显式 HTTP 调级入口。
+## 日志与指标
 
-## 指标
+FLEXLB_LOG_PATH、FLEXLB_APP_LOG_PATH 和 FLEXLB_LOG_ASYNC_QUEUE_SIZE 控制 logback 文件输出。
+observability.logging.level 更新 flexlb logger group，stdoutEnabled 动态控制 root/PV console
+appender；/flexlb/update_log_level 提供显式运行时调整。
 
-`FlexMonitor` 提供 GAUGE、COUNTER、QPS 与优先级窗口抽象。opensource 默认使用
-`NoOpFlexMonitor`；internal profile 可启用 KMonitor/Prometheus provider。
-
-指标名集中在 `MetricConstant`，主要覆盖：
-
-- engine health、worker status 与状态转换时延；
-- routing、queue、dispatch、forward-to-master；
-- cache hit、KVCM retry/failure、Local Standby capacity/fallback/comparison；
-- block hash、线程池、graceful lifecycle；
-- request payload、optimizer trace 与 PV decision 数据。
-
-上报器分布在 common、grpc、cache、sync 模块。新增指标应复用现有 reporter ownership，
-不要恢复已删除的旧监控层。
-
-## HTTP 与端口
-
-- 主服务：7001。
-- 管理端口：7002。
-- `/health` 与 lifecycle hook。
-- `/flexlb/update_log_level`。
-- `/flexlb/cache_match/status`、`/flexlb/cache_match/failover`。
-- `/rtp_llm/schedule`、master notification 和 queue snapshot 等路由入口。
-- gRPC 调度入口及 follower-to-master forwarding。
-
-Spring profile 与日志、监控 provider 的具体默认值见
-`flexlb-api/src/main/resources/application.yml`。
-
-## Multi-engine endpoint 与观测
-
-`MODEL_SERVICE_CONFIG` 的 endpoint 支持 `multi_engine_num`（默认 1）。显式
-`worker_status_port` 必须处于 `[1, 65535]`；N>1 必须指定该端口，并保证
-`worker_status_port + N - 1 <= 65535`。每个 index 使用独立的 status gRPC 端口，
-frontend HTTP/gRPC 仍为共享物理地址。protocol 只解释 frontend discovery port。
-N=1 沿用 discovery 的 legacy gRPC port，因而兼容未配置 `worker_status_port` 的 RTP-LLM。
-
-逻辑 worker identity 为 `ip:http_port@engineIndex`，包括 N=1 的 `@0`。
-引擎与 cache 指标的 `engineIp` 使用完整 logical identity `ip:http_port@engineIndex`；
-网络连接仍使用物理地址。schedule 在 N=1 时省略 `engine_index`，内部 identity 和观测仍保留
-index 0。
+FlexMonitor 是统一的指标抽象。默认 provider 是 noop；启用的 provider 负责 engine health、worker
+poll、routing、queue、delivery、preemption、forward-to-master、cache/KVCM/standby、block hash、
+优雅生命周期和请求延迟等指标。FlexlbGrpcServer 还直接向可用的 MeterRegistry 注册其 executor
+active threads、队列长度、pool size、completed tasks 和 rejection counter。

--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/FlexlbServiceImpl.java
@@ -672,7 +672,7 @@ public class FlexlbServiceImpl extends FlexlbServiceGrpc.FlexlbServiceImplBase {
             if (ctx.getResponse() != null && ctx.getResponse().getServerStatus() != null) {
                 for (ServerStatus ss : ctx.getResponse().getServerStatus()) {
                     if (ss.getRole() == RoleType.PREFILL) {
-                        prefillIp = ss.getServerIp() != null ? ss.getServerIp() : "";
+                        prefillIp = ss.getLogicalIpPort() != null ? ss.getLogicalIpPort() : "";
                         break;
                     }
                 }
@@ -985,12 +985,16 @@ public class FlexlbServiceImpl extends FlexlbServiceGrpc.FlexlbServiceImplBase {
 
         if (response.getServerStatus() != null) {
             for (ServerStatus ss : response.getServerStatus()) {
-                builder.addServerStatus(FlexlbScheduleProtocol.FlexlbServerStatusPB.newBuilder()
-                        .setRole(ss.getRole().getCode())
-                        .setServerIp(ss.getServerIp() != null ? ss.getServerIp() : "")
-                        .setHttpPort(ss.getHttpPort())
-                        .setGrpcPort(ss.getGrpcPort())
-                        .build());
+                FlexlbScheduleProtocol.FlexlbServerStatusPB.Builder status =
+                        FlexlbScheduleProtocol.FlexlbServerStatusPB.newBuilder()
+                                .setRole(ss.getRole().getCode())
+                                .setServerIp(ss.getServerIp() != null ? ss.getServerIp() : "")
+                                .setHttpPort(ss.getHttpPort())
+                                .setGrpcPort(ss.getGrpcPort());
+                if (ss.getEngineIndex() != null) {
+                    status.setEngineIndex(ss.getEngineIndex());
+                }
+                builder.addServerStatus(status);
             }
         }
         return builder.build();

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/RequestSchedulerTestRuntime.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/RequestSchedulerTestRuntime.java
@@ -162,11 +162,11 @@ public final class RequestSchedulerTestRuntime implements AutoCloseable {
         Objects.requireNonNull(observation, "observation");
         RoleType role = observation.role();
         WorkerEndpoint endpoint = registry.get(
-                role, status.getIpPort(), status);
+                role, status.getLogicalIpPort(), status);
         if (endpoint == null) {
             throw new IllegalStateException(
                     "status generation has no published endpoint: "
-                            + status.getIpPort() + "#" + status.getGenerationId());
+                            + status.getLogicalIpPort() + "#" + status.getGenerationId());
         }
 
         Runnable projection;
@@ -213,7 +213,7 @@ public final class RequestSchedulerTestRuntime implements AutoCloseable {
                 if (status == null) {
                     continue;
                 }
-                String address = status.getServerIp() + ":" + status.getHttpPort();
+                String address = status.getLogicalIpPort();
                 WorkerEndpoint.GenerationPin pin = registry.capture(
                         status.getRole(), address);
                 if (pin == null) {

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/TransientCapacityQueueContractTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/balance/scheduler/TransientCapacityQueueContractTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -580,44 +581,53 @@ class TransientCapacityQueueContractTest {
 
         try (Fixture fixture = new Fixture(null, config)) {
             fixture.submission.blockPreparation();
-            CompletableFuture<Response> waiting =
-                    fixture.runtime.scheduler().submit(
-                            fixture.context(501L, 50, 128_000L));
-            assertTrue(fixture.submission.awaitPreparation(
-                    2, TimeUnit.SECONDS));
+            try {
+                CompletableFuture<Response> waiting =
+                        fixture.runtime.scheduler().submit(
+                                fixture.context(501L, 50, 128_000L));
+                assertTrue(fixture.submission.awaitPreparation(
+                        2, TimeUnit.SECONDS));
+                assertSame(fixture.decodeStatus,
+                        fixture.runtime.endpointRegistry().get(
+                                RoleType.DECODE,
+                                fixture.decodeStatus.getLogicalIpPort())
+                                .getStatus());
 
-            fixture.runtime.applyStatus(
-                    fixture.decodeStatus,
-                    statusResponse(RoleType.DECODE, 2L, true));
-            WorkerStatus spareStatus = initializedStatus(
-                    RoleType.DECODE, "127.0.0.2", 18_082);
-            DecodeEndpoint spareEndpoint = (DecodeEndpoint)
-                    publishEndpoint(
-                            fixture.runtime.endpointRegistry(),
-                            RoleType.DECODE,
-                            "127.0.0.2:18082",
-                            spareStatus);
+                fixture.runtime.applyStatus(
+                        fixture.decodeStatus,
+                        statusResponse(RoleType.DECODE, 2L, true));
+                WorkerStatus spareStatus = initializedStatus(
+                        RoleType.DECODE, "127.0.0.2", 18_082);
+                DecodeEndpoint spareEndpoint = (DecodeEndpoint)
+                        publishEndpoint(
+                                fixture.runtime.endpointRegistry(),
+                                RoleType.DECODE,
+                                "127.0.0.2:18082",
+                                spareStatus);
 
-            fixture.submission.unblockPreparation();
+                fixture.submission.unblockPreparation();
 
-            assertFalse(fixture.submission.awaitCommands(
-                    1, 200, TimeUnit.MILLISECONDS));
-            assertFalse(waiting.isDone(),
-                    "the committed route waits for its exact Decode capacity");
-            assertEquals(0, spareEndpoint.routingView().engineLoad(),
-                    "a committed route must not switch to a newly idle Decode");
+                assertFalse(fixture.submission.awaitCommands(
+                        1, 200, TimeUnit.MILLISECONDS));
+                assertFalse(waiting.isDone(),
+                        "the committed route waits for its exact Decode capacity");
+                assertEquals(0, spareEndpoint.routingView().engineLoad(),
+                        "a committed route must not switch to a newly idle Decode");
 
-            fixture.runtime.applyStatus(
-                    fixture.decodeStatus,
-                    statusResponse(RoleType.DECODE, 3L, false));
+                fixture.runtime.applyStatus(
+                        fixture.decodeStatus,
+                        statusResponse(RoleType.DECODE, 3L, false));
 
-            Response response = waiting.get(2, TimeUnit.SECONDS);
-            assertTrue(response.isSuccess());
-            assertEquals("127.0.0.1:18081", decodeAddress(response));
-            assertEquals(List.of("127.0.0.1:18081"),
-                    fixture.submission.decodeAddresses());
-            assertEquals(0, spareEndpoint.routingView().engineLoad(),
-                    "a committed route must not switch to a newly idle Decode");
+                Response response = waiting.get(2, TimeUnit.SECONDS);
+                assertTrue(response.isSuccess());
+                assertEquals("127.0.0.1:18081", decodeAddress(response));
+                assertEquals(List.of("127.0.0.1:18081"),
+                        fixture.submission.decodeAddresses());
+                assertEquals(0, spareEndpoint.routingView().engineLoad(),
+                        "a committed route must not switch to a newly idle Decode");
+            } finally {
+                fixture.submission.unblockPreparation();
+            }
         }
     }
 
@@ -1316,15 +1326,17 @@ class TransientCapacityQueueContractTest {
     private static WorkerEndpoint publishEndpoint(
             EndpointRegistry registry,
             RoleType role,
-            String address,
+            String physicalAddress,
             WorkerStatus status) {
+        assertEquals(physicalAddress, status.getPhysicalIpPort());
         WorkerStatusResponse response = statusResponse(role, 1L, false);
         status.lock.lock();
         try {
             WorkerStatus.PreparedStatus prepared = status.prepareNewStatus(
                     status.freezeStatusResponse(response));
             WorkerEndpoint endpoint = registry
-                    .publishPreparedEndpoint(address, status, prepared)
+                    .publishPreparedEndpoint(
+                            status.getLogicalIpPort(), status, prepared)
                     .endpoint();
             status.recordSuccessfulPoll(true);
             return endpoint;
@@ -1431,7 +1443,8 @@ class TransientCapacityQueueContractTest {
                 new CopyOnWriteArrayList<>();
         private final Semaphore commandSignals = new Semaphore(0);
         private final Semaphore preparationSignals = new Semaphore(0);
-        private final Semaphore preparationReleases = new Semaphore(0);
+        private final CountDownLatch preparationReleases =
+                new CountDownLatch(1);
         private final AtomicBoolean holdCompletions = new AtomicBoolean();
         private final AtomicBoolean blockPreparation = new AtomicBoolean();
 
@@ -1440,7 +1453,18 @@ class TransientCapacityQueueContractTest {
                 tryPrepareSubmission() {
             if (blockPreparation.get()) {
                 preparationSignals.release();
-                preparationReleases.acquireUninterruptibly();
+                boolean interrupted = false;
+                while (true) {
+                    try {
+                        preparationReleases.await();
+                        break;
+                    } catch (InterruptedException interruption) {
+                        interrupted = true;
+                    }
+                }
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
             }
             return CapacityBoundary.Attempt.accepted(
                     new BatchDeliveryStrategy.PreparedSubmission() {
@@ -1504,7 +1528,7 @@ class TransientCapacityQueueContractTest {
 
         private void unblockPreparation() {
             blockPreparation.set(false);
-            preparationReleases.release();
+            preparationReleases.countDown();
         }
 
         private void holdCompletions() {

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/httpserver/FlexlbScheduleEngineIndexTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/httpserver/FlexlbScheduleEngineIndexTest.java
@@ -1,0 +1,138 @@
+package org.flexlb.httpserver;
+
+import io.grpc.stub.StreamObserver;
+import org.flexlb.cache.match.CacheAwareService;
+import org.flexlb.config.ConfigService;
+import org.flexlb.config.FlexlbConfig;
+import org.flexlb.consistency.LBStatusConsistencyService;
+import org.flexlb.dao.BalanceContext;
+import org.flexlb.dao.loadbalance.Response;
+import org.flexlb.dao.loadbalance.ServerStatus;
+import org.flexlb.dao.route.RoleType;
+import org.flexlb.schedule.grpc.FlexlbScheduleProtocol;
+import org.flexlb.service.RouteService;
+import org.flexlb.service.grace.ActiveRequestCounter;
+import org.flexlb.service.monitor.BatchSchedulerReporter;
+import org.flexlb.service.monitor.EngineHealthReporter;
+import org.flexlb.service.monitor.RequestSchedulerReporter;
+import org.flexlb.service.optimizer.OptimizerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FlexlbScheduleEngineIndexTest {
+
+    private RouteService routeService;
+    private FlexlbServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        routeService = mock(RouteService.class);
+        LBStatusConsistencyService consistencyService =
+                mock(LBStatusConsistencyService.class);
+        when(consistencyService.isNeedConsistency()).thenReturn(false);
+
+        ConfigService configService = mock(ConfigService.class);
+        when(configService.loadBalanceConfig()).thenReturn(new FlexlbConfig());
+
+        ActiveRequestCounter activeRequestCounter = mock(ActiveRequestCounter.class);
+        when(activeRequestCounter.acquire()).thenReturn(
+                mock(ActiveRequestCounter.RequestToken.class));
+
+        CacheAwareService cacheAwareService = mock(CacheAwareService.class);
+        when(cacheAwareService.prepareBlockCacheKeys(any(BalanceContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        service = new FlexlbServiceImpl(
+                routeService,
+                consistencyService,
+                mock(EngineHealthReporter.class),
+                activeRequestCounter,
+                null,
+                configService,
+                mock(BatchSchedulerReporter.class),
+                mock(ServerScheduleLatencyRecorder.class),
+                mock(RequestSchedulerReporter.class),
+                cacheAwareService,
+                mock(OptimizerClient.class));
+    }
+
+    @Test
+    void scheduleIncludesEngineIndexForMultiEngineWorker() {
+        when(routeService.route(any(BalanceContext.class))).thenReturn(
+                CompletableFuture.completedFuture(response(serverStatus(1, 2))));
+
+        FlexlbScheduleProtocol.FlexlbScheduleResponsePB response = schedule();
+
+        assertTrue(response.getSuccess());
+        assertEquals(1, response.getServerStatusCount());
+        FlexlbScheduleProtocol.FlexlbServerStatusPB selected =
+                response.getServerStatus(0);
+        assertEquals("127.0.0.1", selected.getServerIp());
+        assertEquals(8080, selected.getHttpPort());
+        assertEquals(8081, selected.getGrpcPort());
+        assertTrue(selected.hasEngineIndex());
+        assertEquals(1, selected.getEngineIndex());
+    }
+
+    @Test
+    void scheduleOmitsEngineIndexForSingleEngineWorker() {
+        when(routeService.route(any(BalanceContext.class))).thenReturn(
+                CompletableFuture.completedFuture(response(serverStatus(0, 1))));
+
+        FlexlbScheduleProtocol.FlexlbScheduleResponsePB response = schedule();
+
+        assertTrue(response.getSuccess());
+        assertEquals(1, response.getServerStatusCount());
+        assertFalse(response.getServerStatus(0).hasEngineIndex());
+    }
+
+    private FlexlbScheduleProtocol.FlexlbScheduleResponsePB schedule() {
+        StreamObserver<FlexlbScheduleProtocol.FlexlbScheduleResponsePB> observer =
+                mock(StreamObserver.class);
+        service.schedule(FlexlbScheduleProtocol.FlexlbScheduleRequestPB.newBuilder()
+                .setRequestId("5001")
+                .setSeqLen(16)
+                .addInputIds(1)
+                .build(), observer);
+
+        ArgumentCaptor<FlexlbScheduleProtocol.FlexlbScheduleResponsePB> captor =
+                ArgumentCaptor.forClass(
+                        FlexlbScheduleProtocol.FlexlbScheduleResponsePB.class);
+        org.mockito.Mockito.verify(observer).onNext(captor.capture());
+        org.mockito.Mockito.verify(observer).onCompleted();
+        return captor.getValue();
+    }
+
+    private static Response response(ServerStatus status) {
+        Response response = new Response();
+        response.setSuccess(true);
+        response.setCode(200);
+        response.setServerStatus(List.of(status));
+        return response;
+    }
+
+    private static ServerStatus serverStatus(int engineIndex, int multiEngineNum) {
+        ServerStatus status = new ServerStatus();
+        status.setSuccess(true);
+        status.setRole(RoleType.DECODE);
+        status.setServerIp("127.0.0.1");
+        status.setHttpPort(8080);
+        status.setGrpcPort(8081);
+        status.setDpRank(0);
+        status.setGroup("test-group");
+        status.setRequestId("5001");
+        status.setSelectedEngineIndex(engineIndex, multiEngineNum);
+        return status;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/FlexLBMockTestBase.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/FlexLBMockTestBase.java
@@ -350,12 +350,12 @@ public abstract class FlexLBMockTestBase {
 
     protected PrefillEndpoint getPrefillEndpoint() {
         return (PrefillEndpoint) endpointRegistry.get(
-                RoleType.PREFILL, prefillIpPort);
+                RoleType.PREFILL, logicalWorkerIpPort(prefillIpPort));
     }
 
     protected DecodeEndpoint getDecodeEndpoint() {
         return (DecodeEndpoint) endpointRegistry.get(
-                RoleType.DECODE, decodeIpPort);
+                RoleType.DECODE, logicalWorkerIpPort(decodeIpPort));
     }
 
     // ==================== Helper: multi-worker support ====================
@@ -405,10 +405,31 @@ public abstract class FlexLBMockTestBase {
     }
 
     /**
-     * Get the {@code ip:httpPort} string for a mock worker (for routing/endpoint lookup).
+     * Get the {@code ip:httpPort} string for a mock worker.
      */
     protected static String workerIpPort(MockWorker worker) {
         return "127.0.0.1:" + worker.getHttpPort();
+    }
+
+    protected static String logicalWorkerIpPort(String ipPort) {
+        return ipPort.contains("@") ? ipPort : ipPort + "@0";
+    }
+
+    /**
+     * Get the physical {@code ip:httpPort} address exposed by the RTP-LLM mock frontend.
+     */
+    protected static String physicalWorkerIpPort(MockWorker worker) {
+        return "127.0.0.1:" + worker.getHttpPort();
+    }
+
+    /** Get a physical frontend address from its independent host and port fields. */
+    protected static String physicalIpPort(String ip, int httpPort) {
+        return ip + ":" + httpPort;
+    }
+
+    protected static String physicalIpPort(String ipPort) {
+        int separator = ipPort.indexOf('@');
+        return separator >= 0 ? ipPort.substring(0, separator) : ipPort;
     }
 
     /**
@@ -523,7 +544,7 @@ public abstract class FlexLBMockTestBase {
 
     private void discover(WorkerStatus status) {
         engineWorkerStatus.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
     }
 
     /** Apply one already immutable gRPC status observation. */
@@ -561,8 +582,10 @@ public abstract class FlexLBMockTestBase {
         try {
             WorkerStatus.PreparedStatus prepared = status.prepareNewStatus(
                     status.freezeStatusResponse(initial));
-            return endpointRegistry.publishPreparedEndpoint(
-                    status.getIpPort(), status, prepared).endpoint();
+            WorkerEndpoint endpoint = endpointRegistry.publishPreparedEndpoint(
+                    status.getLogicalIpPort(), status, prepared).endpoint();
+            status.recordSuccessfulPoll(initial.isAlive());
+            return endpoint;
         } finally {
             status.lock.unlock();
         }

--- a/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/grpc/FileDiscoveryDynamicScaleEndToEndTest.java
+++ b/rtp_llm/flexlb/flexlb-api/src/test/java/org/flexlb/mock/grpc/FileDiscoveryDynamicScaleEndToEndTest.java
@@ -126,7 +126,9 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
 
         // Initial discovery file: A + B on the prefill domain, base decode worker.
         discoveryFile = tempDir.resolve("discovery-" + System.nanoTime() + ".json");
-        writeDiscoveryFileAtomic(List.of(prefillIpPort, workerIpPort(workerB)));
+        writeDiscoveryFileAtomic(List.of(
+                physicalIpPort(prefillIp, prefillHttpPort),
+                physicalWorkerIpPort(workerB)));
 
         // Real file-backed ServiceDiscovery — re-reads the file on every poll.
         fileServiceDiscovery = new RoutingServiceDiscovery(
@@ -255,7 +257,10 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
         workerC = new MockPrefillWorker(MockWorkerBehavior.builder().build());
         workerC.start(0);
         String cIpPort = workerIpPort(workerC);
-        writeDiscoveryFileAtomic(List.of(prefillIpPort, workerIpPort(workerB), cIpPort));
+        writeDiscoveryFileAtomic(List.of(
+                physicalIpPort(prefillIp, prefillHttpPort),
+                physicalWorkerIpPort(workerB),
+                physicalWorkerIpPort(workerC)));
 
         long addStartMs = System.nanoTime();
         AtomicBoolean cReceived = new AtomicBoolean(false);
@@ -272,15 +277,18 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
         assertTrue(cReceived.get(),
                 "worker C should start receiving requests within " + CONVERGENCE_CAP_MS + " ms "
                         + "of appearing in the discovery file");
-        assertNotNull(endpointRegistry.get(RoleType.PREFILL, cIpPort),
+        assertNotNull(endpointRegistry.get(RoleType.PREFILL, logicalWorkerIpPort(cIpPort)),
                 "worker C must be registered in the EndpointRegistry after discovery");
 
         // ─── Phase 3: remove A from the file → A must stop receiving new requests ───
-        writeDiscoveryFileAtomic(List.of(workerIpPort(workerB), cIpPort));
+        writeDiscoveryFileAtomic(List.of(
+                physicalWorkerIpPort(workerB),
+                physicalWorkerIpPort(workerC)));
 
         long removeStartMs = System.nanoTime();
         awaitUntil(CONVERGENCE_CAP_MS, () ->
-                        endpointRegistry.get(RoleType.PREFILL, prefillIpPort) == null,
+                        endpointRegistry.get(RoleType.PREFILL,
+                                logicalWorkerIpPort(prefillIpPort)) == null,
                 "worker A should be evicted from the EndpointRegistry after removal from the file");
         long removeConvergenceMs = elapsedMs(removeStartMs);
 
@@ -308,7 +316,7 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
     private void writeDiscoveryFileAtomic(List<String> prefillHosts) throws IOException {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put(PREFILL_DOMAIN, prefillHosts);
-        payload.put(DECODE_DOMAIN, List.of(decodeIpPort));
+        payload.put(DECODE_DOMAIN, List.of(physicalIpPort(decodeIp, decodeHttpPort)));
         Path tmp = discoveryFile.resolveSibling(discoveryFile.getFileName() + ".tmp");
         MAPPER.writerWithDefaultPrettyPrinter().writeValue(tmp.toFile(), payload);
         try {
@@ -342,7 +350,12 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
             }
             Collections.sort(candidates);
             String chosen = candidates.get(routerCounter.getAndIncrement() % candidates.size());
-            String[] parts = chosen.split(":");
+            int engineSeparator = chosen.lastIndexOf('@');
+            String physicalAddress = engineSeparator < 0
+                    ? chosen : chosen.substring(0, engineSeparator);
+            int engineIndex = engineSeparator < 0
+                    ? 0 : Integer.parseInt(chosen.substring(engineSeparator + 1));
+            String[] parts = physicalAddress.split(":");
             String ip = parts[0];
             int httpPort = Integer.parseInt(parts[1]);
             // admittedRoute() converts this response into the exact pinned
@@ -351,29 +364,36 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
             // later marks queued; without it admission would hit NOT_QUEUED ->
             // OwnershipLost and the request would never complete.
             return admittedRoute(ctx,
-                    routeResponse(ctx.getRequestId(), ip, httpPort, httpPort + 1));
+                    routeResponse(ctx.getRequestId(), ip, httpPort, httpPort + 1, engineIndex));
         });
         return roundRobin;
     }
 
     private Response routeResponse(String requestId, String prefillIpAddr, int prefillHttpPort,
-                                    int prefillGrpcPort) {
+                                    int prefillGrpcPort, int prefillEngineIndex) {
         Response response = new Response();
         response.setSuccess(true);
         response.setServerStatus(List.of(
-                serverStatus(RoleType.PREFILL, prefillIpAddr, prefillHttpPort, prefillGrpcPort, requestId),
+                serverStatus(RoleType.PREFILL, prefillIpAddr, prefillHttpPort, prefillGrpcPort,
+                        prefillEngineIndex, requestId),
                 serverStatus(RoleType.DECODE, decodeIp, decodeHttpPort, decodeGrpcPort, requestId)));
         return response;
     }
 
     private static ServerStatus serverStatus(RoleType role, String ip, int httpPort, int grpcPort,
                                               String requestId) {
+        return serverStatus(role, ip, httpPort, grpcPort, 0, requestId);
+    }
+
+    private static ServerStatus serverStatus(RoleType role, String ip, int httpPort, int grpcPort,
+                                              int engineIndex, String requestId) {
         ServerStatus status = new ServerStatus();
         status.setSuccess(true);
         status.setRole(role);
         status.setServerIp(ip);
         status.setHttpPort(httpPort);
         status.setGrpcPort(grpcPort);
+        status.setSelectedEngineIndex(engineIndex, 1);
         status.setDpRank(0);
         status.setGroup("test-group");
         status.setRequestId(requestId);
@@ -416,7 +436,7 @@ class FileDiscoveryDynamicScaleEndToEndTest extends FlexLBMockTestBase {
         List<String> routable =
                 endpointRegistry.endpointAddressSnapshot(RoleType.PREFILL);
         for (String ipPort : ipPorts) {
-            if (!routable.contains(ipPort)) {
+            if (!routable.contains(logicalWorkerIpPort(ipPort))) {
                 return false;
             }
         }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheHitComparisonResult.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheHitComparisonResult.java
@@ -3,9 +3,14 @@ package org.flexlb.cache.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.flexlb.dao.master.WorkerIdentity;
 
 /**
  * Cache-hit comparison result and PV log payload.
+ *
+ * @param workerIdentity worker identity providing the routing/PV identity
+ *                       {@code ip:port@engineIndex} and legacy short identity
+ *                       {@code ip@engineIndex}; omitted from PV JSON itself
  */
 @JsonPropertyOrder({
         "event", "requestId", "source", "role", "group", "worker", "state", "inputTokens",
@@ -17,13 +22,24 @@ public record CacheHitComparisonResult(
         String source,
         String role,
         String group,
-        String worker,
+        @JsonIgnore WorkerIdentity workerIdentity,
         String state,
         long inputTokens,
         Actual actual,
         @JsonIgnore HitComparison routing,
         HitComparison localStandby,
         @JsonIgnore KvcmDetails kvcmDetails) {
+
+    /** Routing/PV identity in {@code ip:port@engineIndex} format. */
+    @JsonProperty("worker")
+    public String worker() {
+        return workerIdentity == null ? null : workerIdentity.getLogicalIpPort();
+    }
+
+    /** Legacy short identity in {@code ip@engineIndex} format; omitted from PV JSON. */
+    public String ipIndex() {
+        return workerIdentity == null ? null : workerIdentity.getIpIndex();
+    }
 
     @JsonProperty("kvcm")
     public KvcmComparison kvcm() {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheMatchResult.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/CacheMatchResult.java
@@ -1,6 +1,7 @@
 package org.flexlb.cache.domain;
 
 import org.flexlb.dao.cache.HostCacheMatch;
+import org.flexlb.dao.master.WorkerStatus;
 
 import java.util.Collections;
 import java.util.Map;
@@ -8,7 +9,9 @@ import java.util.Map;
 /**
  * Cache matches and the block size used to produce them.
  *
- * <p>Each worker has one {@link HostCacheMatch} containing the raw local/P2P block counts.
+ * <p>Each map key normally is a logical worker identity in {@code ip:port@engineIndex} format
+ * and has one {@link HostCacheMatch} containing the raw local/P2P block counts. KVCM responses
+ * from legacy single-engine deployments can use the physical {@code ip:port} identity.
  */
 public record CacheMatchResult(
         Map<String, HostCacheMatch> hostMatches,
@@ -32,8 +35,34 @@ public record CacheMatchResult(
         return inputTokens > 0 ? Math.min(inputTokens, matchedTokens) : matchedTokens;
     }
 
-    public HostCacheMatch hostMatch(String workerIpPort) {
+    /**
+     * Returns the match stored under the given key, without any KVCM legacy fallback. Routing
+     * paths should use {@link #hostMatch(WorkerStatus)} instead.
+     *
+     * @param workerIpPort worker identity key, typically logical {@code ip:port@engineIndex}
+     */
+    public HostCacheMatch exactHostMatch(String workerIpPort) {
         return hostMatches.get(workerIpPort);
+    }
+
+    /**
+     * Returns the match for a worker, preserving legacy KVCM host identities for one engine.
+     *
+     * <p>KVCM formerly returned a physical {@code ip:port} host identity. A single-engine
+     * worker has an unambiguous logical {@code @0} identity, so it can use that legacy entry
+     * when no exact logical match exists. Multi-engine workers require an exact logical match.
+     */
+    public HostCacheMatch hostMatch(WorkerStatus workerStatus) {
+        if (workerStatus == null) {
+            return null;
+        }
+        HostCacheMatch exactMatch = exactHostMatch(workerStatus.getLogicalIpPort());
+        if (exactMatch != null
+                || source != CacheMatchSource.KVCM
+                || workerStatus.getMultiEngineNum() != 1) {
+            return exactMatch;
+        }
+        return exactHostMatch(workerStatus.getPhysicalIpPort());
     }
 
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/WorkerCacheUpdateResult.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/domain/WorkerCacheUpdateResult.java
@@ -15,8 +15,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class WorkerCacheUpdateResult {
+
     private boolean success;
-    private String engineIpPort;
+    /**
+     * Logical worker identity in {@code ip:port@engineIndex} format.
+     *
+     * @see org.flexlb.dao.master.WorkerIdentity#getEngineIndex()
+     */
+    private String logicalIpPort;
     private long cacheBlockCount;
     private long availableKvCache;
     private long totalKvCache;

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMatchProvider.java
@@ -14,6 +14,11 @@ public interface CacheMatchProvider {
 
     CacheMatchSource source();
 
+    /**
+     * Finds cache matches keyed by logical worker identity in
+     * {@code ip:port@engineIndex} format. The index identifies one independently routable
+     * engine behind the physical frontend.
+     */
     Map<String, HostCacheMatch> findMatchingEngines(
             String requestId,
             List<Long> blockCacheKeys,

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMetadataUpdateOrchestrator.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/CacheMetadataUpdateOrchestrator.java
@@ -39,10 +39,10 @@ public class CacheMetadataUpdateOrchestrator {
             return localSyncProvider.updateFromWorkerStatus(workerStatus);
         }
 
-        String engineIpPort = workerStatus == null ? null : workerStatus.getIpPort();
+        String logicalIpPort = workerStatus == null ? null : workerStatus.getLogicalIpPort();
         return WorkerCacheUpdateResult.builder()
                 .success(false)
-                .engineIpPort(engineIpPort)
+                .logicalIpPort(logicalIpPort)
                 .errorMessage("Local Sync cache metadata updates are disabled when KVCM is enabled")
                 .build();
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProvider.java
@@ -27,6 +27,10 @@ public class KvcmCacheMatchProvider implements CacheMatchProvider {
         return CacheMatchSource.KVCM;
     }
 
+    /**
+     * Returns KVCM matches without rewriting their keys. KVCM {@code host_ip_port} values follow
+     * the logical {@code ip:port@engineIndex} identity reported by the Subscriber.
+     */
     @Override
     public Map<String, HostCacheMatch> findMatchingEngines(String requestId, List<Long> blockCacheKeys, long blockSize,
                                                            RoleType roleType, String group) {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheIndex.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheIndex.java
@@ -67,6 +67,13 @@ class LocalStandbyCacheIndex {
         }
     }
 
+    /**
+     * Adds predicted block ownership for one logical worker.
+     *
+     * @param workerIpPort logical worker identity in {@code ip:port@engineIndex} format
+     * @param blockCacheKeys predicted block hashes
+     * @return number of mappings rejected by the capacity limit
+     */
     int addWorkerBlockMappings(String workerIpPort, List<Long> blockCacheKeys) {
         if (workerIpPort == null || workerIpPort.isEmpty() || blockCacheKeys == null || blockCacheKeys.isEmpty()) {
             return 0;

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManager.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManager.java
@@ -76,6 +76,10 @@ public class LocalStandbyCacheManager {
                 enabled);
     }
 
+    /**
+     * Finds prefix matches keyed by logical worker identity in
+     * {@code ip:port@engineIndex} format.
+     */
     public Map<String, Integer> findMatchingEngines(List<Long> blockCacheKeys, RoleType roleType, String group) {
         if (!enabled || blockCacheKeys == null || blockCacheKeys.isEmpty()) {
             return Collections.emptyMap();
@@ -97,7 +101,7 @@ public class LocalStandbyCacheManager {
             if (workerStatus == null) {
                 continue;
             }
-            String workerIpPort = workerStatus.getIpPort();
+            String workerIpPort = workerStatus.getLogicalIpPort();
             if (StringUtils.isNotBlank(workerIpPort)) {
                 candidateWorkers.add(workerIpPort);
             }
@@ -149,7 +153,7 @@ public class LocalStandbyCacheManager {
             if (workerStatus == null || workerStatus.getCacheMatchRollbackBlocks() <= 0) {
                 continue;
             }
-            String workerIpPort = workerStatus.getIpPort();
+            String workerIpPort = workerStatus.getLogicalIpPort();
             Integer matchedBlocks = prefixMatches.get(workerIpPort);
             if (matchedBlocks != null) {
                 prefixMatches.put(workerIpPort,
@@ -158,6 +162,14 @@ public class LocalStandbyCacheManager {
         }
     }
 
+    /**
+     * Records predicted block ownership for a routed logical worker.
+     *
+     * @param workerIpPort logical worker identity in {@code ip:port@engineIndex} format; the
+     *                     index identifies one independently routable engine behind the physical
+     *                     frontend
+     * @param blockCacheKeys routed request block hashes
+     */
     public void addRoutedRequestBlocks(String workerIpPort, List<Long> blockCacheKeys) {
         int rejectedMappings = cacheIndex.addWorkerBlockMappings(workerIpPort, blockCacheKeys);
         if (rejectedMappings <= 0) {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProvider.java
@@ -135,7 +135,7 @@ public class LocalStandbyCacheMatchProvider implements CacheMatchProvider {
                 continue;
             }
             cacheManager.addRoutedRequestBlocks(
-                    selectedWorker.getServerIp() + ":" + selectedWorker.getHttpPort(),
+                    selectedWorker.getLogicalIpPort(),
                     cacheableBlockCacheKeys);
         }
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonService.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonService.java
@@ -93,7 +93,7 @@ public class LocalStandbyComparisonService {
     }
 
     private CacheHitComparisonResult withLocalStandbyPrediction(CacheHitFeedback feedback, StandbyPrediction standbyPrediction) {
-        String workerIpPort = feedback.workerIp() + ":" + feedback.workerPort();
+        String workerIpPort = feedback.logicalWorkerId();
         HostCacheMatch match = standbyPrediction.matches().get(workerIpPort);
         long localStandbyPredictedHitTokens = match == null
                 ? 0
@@ -138,7 +138,7 @@ public class LocalStandbyComparisonService {
                 feedback.cacheMatchSource(),
                 feedback.role(),
                 feedback.group(),
-                feedback.workerIp(),
+                feedback.workerIdentity(),
                 feedback.taskState(),
                 feedback.inputTokens(),
                 new CacheHitComparisonResult.Actual(feedback.actualHitTokens()),

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/EngineLocalView.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/EngineLocalView.java
@@ -2,7 +2,6 @@ package org.flexlb.cache.match.localsync;
 
 import lombok.extern.slf4j.Slf4j;
 import org.flexlb.cache.domain.DiffResult;
-import org.flexlb.cache.telemetry.CacheMetricsReporter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,12 +33,6 @@ public class EngineLocalView {
     private final ForkJoinPool customPool = new ForkJoinPool(Math.min(Runtime.getRuntime().availableProcessors(), 8));
 
     /**
-     * Cache metrics reporter
-     */
-    @Autowired
-    private CacheMetricsReporter cacheMetricsReporter;
-
-    /**
      * Dynamic sync interval manager
      */
     @Autowired
@@ -48,12 +41,11 @@ public class EngineLocalView {
     /**
      * Calculate diff result
      *
-     * @param engineIPort       Engine IP
+     * @param engineIPort    Engine IP
      * @param newCacheBlocks New cache block set
-     * @param role           Engine role
      * @return Diff calculation result
      */
-    public DiffResult calculateDiff(String engineIPort, Set<Long> newCacheBlocks, String role) {
+    public DiffResult calculateDiff(String engineIPort, Set<Long> newCacheBlocks) {
         if (engineIPort == null || newCacheBlocks == null) {
             return DiffResult.empty(engineIPort);
         }
@@ -79,8 +71,6 @@ public class EngineLocalView {
 
         addedTask.join();
         removedTask.join();
-
-        cacheMetricsReporter.reportCacheDiffMetrics(role, addedBlocks.size(), removedBlocks.size());
 
         // Update statistics in dynamic sync interval manager
         int diffSize = addedBlocks.size() + removedBlocks.size();

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/GlobalCacheIndex.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/GlobalCacheIndex.java
@@ -45,7 +45,9 @@ public class GlobalCacheIndex {
      * Add cache block to specified engine
      *
      * @param blockCacheKey Cache block hash value
-     * @param engineIpPort  Engine IP:Port
+     * @param engineIpPort  logical worker identity in {@code ip:port@engineIndex} format; the
+     *                      index identifies one independently routable engine behind the physical
+     *                      frontend
      */
     public void addCacheBlock(Long blockCacheKey, String engineIpPort) {
         if (blockCacheKey == null || engineIpPort == null) {
@@ -72,7 +74,7 @@ public class GlobalCacheIndex {
     /**
      * Remove cache block from specified engine
      *
-     * @param engineIp      Engine IP
+     * @param engineIp      logical worker identity in {@code ip:port@engineIndex} format
      * @param blockCacheKey Cache block hash value
      */
     public void removeCacheBlock(String engineIp, Long blockCacheKey) {
@@ -105,7 +107,7 @@ public class GlobalCacheIndex {
     /**
      * Remove an engine
      *
-     * @param engineIp Engine IP
+     * @param engineIp logical worker identity in {@code ip:port@engineIndex} format
      */
     public void removeAllCacheBlockOfEngine(String engineIp) {
         if (engineIp == null) {
@@ -134,9 +136,9 @@ public class GlobalCacheIndex {
     /**
      * Calculate engine prefix match length based on prefix matching
      *
-     * @param engineIpPorts  Engine IP:Port list
+     * @param engineIpPorts  logical worker identities in {@code ip:port@engineIndex} format
      * @param blockCacheKeys Ordered cache block hash value list
-     * @return Map<EngineIP:EnginePort, PrefixMatchLength>
+     * @return prefix match lengths keyed by logical worker identity
      */
     public Map<String, Integer> batchCalculatePrefixMatchLength(List<String> engineIpPorts,
                                                                 List<Long> blockCacheKeys) {
@@ -150,9 +152,9 @@ public class GlobalCacheIndex {
     /**
      * Prefix match calculation
      *
-     * @param engineIpPorts  Engine IP:Port list
+     * @param engineIpPorts  logical worker identities in {@code ip:port@engineIndex} format
      * @param blockCacheKeys Ordered cache block hash value list
-     * @return Map<EngineIP:EnginePort, PrefixMatchLength>
+     * @return prefix match lengths keyed by logical worker identity
      */
     private Map<String, Integer> calculatePrefixMatchLength(List<String> engineIpPorts,
                                                             List<Long> blockCacheKeys) {

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/KvCacheManager.java
@@ -3,6 +3,7 @@ package org.flexlb.cache.match.localsync;
 import lombok.extern.slf4j.Slf4j;
 import org.flexlb.cache.domain.DiffResult;
 import org.flexlb.cache.telemetry.CacheMetricsReporter;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.master.WorkerStatusProvider;
 import org.flexlb.dao.route.RoleType;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * KV cache manager
@@ -45,6 +47,9 @@ public class KvCacheManager implements EngineCacheInvalidator {
      */
     @Autowired
     private CacheMetricsReporter cacheMetricsReporter;
+
+    private final Map<String, String> physicalIpPortByLogicalIpPort =
+            new ConcurrentHashMap<>();
 
     @PostConstruct
     public void init() {
@@ -96,7 +101,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
 
         List<String> engineIpPorts = workerStatusProvider.getWorkerStatuses(roleType, group)
                 .stream()
-                .map(WorkerStatus::getIpPort)
+                .map(WorkerStatus::getLogicalIpPort)
                 .toList();
 
         return globalCacheIndex.batchCalculatePrefixMatchLength(
@@ -106,17 +111,22 @@ public class KvCacheManager implements EngineCacheInvalidator {
     /**
      * Update engine cache status
      *
-     * @param engineIPort    Engine IP:Port
+     * @param identity       Worker identity
      * @param role           Engine role
      * @param newCacheBlocks New cache block set (blockCacheKeys)
      */
-    public void updateEngineCache(String engineIPort, String role, Set<Long> newCacheBlocks) {
+    public void updateEngineCache(WorkerIdentity identity, String role, Set<Long> newCacheBlocks) {
+        String engineIPort = identity == null ? null : identity.getLogicalIpPort();
         if (engineIPort == null || newCacheBlocks == null) {
             return;
         }
+        physicalIpPortByLogicalIpPort.put(engineIPort, identity.getPhysicalIpPort());
 
         // Calculate diff
-        DiffResult diffResult = engineLocalView.calculateDiff(engineIPort, newCacheBlocks, role);
+        DiffResult diffResult = engineLocalView.calculateDiff(engineIPort, newCacheBlocks);
+        cacheMetricsReporter.reportCacheDiffMetrics(
+                identity.getLogicalIpPort(), role,
+                diffResult.getAddedBlocks().size(), diffResult.getRemovedBlocks().size());
         if (!diffResult.hasChanges()) {
             return;
         }
@@ -142,7 +152,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
 
         // Report metrics
         cacheMetricsReporter.reportEngineLocalMetrics(
-                engineIPort.split(":")[0], role, engineLocalView.size(engineIPort));
+                identity.getLogicalIpPort(), role, engineLocalView.size(engineIPort));
         cacheMetricsReporter.reportGlobalCacheMetrics(globalCacheIndex.totalBlocks(), globalCacheIndex.totalMappings());
         cacheMetricsReporter.reportEngineViewsMapSize(engineLocalView.getEngineViewsMapSize());
     }
@@ -154,6 +164,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
         }
         engineLocalView.removeAllCacheBlockOfEngine(engineIpPort);
         globalCacheIndex.removeAllCacheBlockOfEngine(engineIpPort);
+        physicalIpPortByLogicalIpPort.remove(engineIpPort);
         cacheMetricsReporter.reportGlobalCacheMetrics(
                 globalCacheIndex.totalBlocks(),
                 globalCacheIndex.totalMappings());
@@ -167,12 +178,15 @@ public class KvCacheManager implements EngineCacheInvalidator {
         if (activeEngineIpPorts == null) {
             return;
         }
+        Set<String> activePhysicalIpPorts = new HashSet<>(activeEngineIpPorts);
         Set<String> staleEngineIpPorts = new HashSet<>(engineLocalView.getAllEngineIpPorts());
-        staleEngineIpPorts.removeAll(new HashSet<>(activeEngineIpPorts));
+        staleEngineIpPorts.removeIf(engineIpPort -> activePhysicalIpPorts.contains(
+                physicalIpPortByLogicalIpPort.getOrDefault(engineIpPort, engineIpPort)));
         for (String staleEngineIpPort : staleEngineIpPorts) {
             long startTime = System.nanoTime() / 1000;
             engineLocalView.removeAllCacheBlockOfEngine(staleEngineIpPort);
             globalCacheIndex.removeAllCacheBlockOfEngine(staleEngineIpPort);
+            physicalIpPortByLogicalIpPort.remove(staleEngineIpPort);
             log.info("Removed stale engine cache: {}, cost={}us",
                     staleEngineIpPort, System.nanoTime() / 1000 - startTime);
         }
@@ -185,6 +199,7 @@ public class KvCacheManager implements EngineCacheInvalidator {
 
         globalCacheIndex.clear();
         engineLocalView.clear();
+        physicalIpPortByLogicalIpPort.clear();
 
         // Report
         cacheMetricsReporter.reportGlobalCacheMetrics(globalCacheIndex.totalBlocks(), globalCacheIndex.totalMappings());

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProvider.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProvider.java
@@ -47,34 +47,32 @@ public class LocalSyncCacheMatchProvider implements CacheMatchProvider {
 
     public WorkerCacheUpdateResult updateFromWorkerStatus(WorkerStatus workerStatus) {
         long startTime = System.nanoTime() / 1000;
-        String engineIpPort = workerStatus.getIpPort();
-        String role = workerStatus.getRole() == null
-                ? null
-                : workerStatus.getRole().name();
+        String logicalIpPort = workerStatus.getLogicalIpPort();
+        String role = workerStatus.getRole() == null ? null : workerStatus.getRole().name();
 
         try {
             CacheStatus cacheStatus = workerStatus.getCacheStatus();
             if (cacheStatus == null) {
-                WorkerCacheUpdateResult result = buildFailureResult(engineIpPort, "Worker Cache Status is null");
-                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "0");
+                WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, "Worker Cache Status is null");
+                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "0");
                 return result;
             }
 
             Set<Long> cachedKeys = cacheStatus.getCachedKeys();
             if (cachedKeys == null) {
-                WorkerCacheUpdateResult result = buildFailureResult(engineIpPort, "Worker Cached Keys is null");
-                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "0");
+                WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, "Worker Cached Keys is null");
+                cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "0");
                 return result;
             }
 
-            kvCacheManager.updateEngineCache(engineIpPort, role, cachedKeys);
+            kvCacheManager.updateEngineCache(workerStatus.getWorkerIdentity(), role, cachedKeys);
             WorkerCacheUpdateResult result = buildSuccessResult(workerStatus, cacheStatus);
-            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "1");
+            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "1");
             return result;
         } catch (Throwable e) {
-            log.error("Error updating worker cache for: {}", engineIpPort, e);
-            WorkerCacheUpdateResult result = buildFailureResult(engineIpPort, e.getMessage());
-            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(engineIpPort, role, startTime, "0");
+            log.error("Error updating worker cache for: {}", logicalIpPort, e);
+            WorkerCacheUpdateResult result = buildFailureResult(logicalIpPort, e.getMessage());
+            cacheMetricsReporter.reportUpdateEngineBlockCacheRT(logicalIpPort, role, startTime, "0");
             return result;
         }
     }
@@ -86,7 +84,7 @@ public class LocalSyncCacheMatchProvider implements CacheMatchProvider {
     private WorkerCacheUpdateResult buildSuccessResult(WorkerStatus workerStatus, CacheStatus cacheStatus) {
         return WorkerCacheUpdateResult.builder()
                 .success(true)
-                .engineIpPort(workerStatus.getIpPort())
+                .logicalIpPort(workerStatus.getLogicalIpPort())
                 .cacheBlockCount(cacheStatus.getCachedKeys().size())
                 .availableKvCache(cacheStatus.getAvailableKvCache())
                 .totalKvCache(cacheStatus.getTotalKvCache())
@@ -94,10 +92,10 @@ public class LocalSyncCacheMatchProvider implements CacheMatchProvider {
                 .build();
     }
 
-    private WorkerCacheUpdateResult buildFailureResult(String engineIpPort, String errorMessage) {
+    private WorkerCacheUpdateResult buildFailureResult(String logicalIpPort, String errorMessage) {
         return WorkerCacheUpdateResult.builder()
                 .success(false)
-                .engineIpPort(engineIpPort)
+                .logicalIpPort(logicalIpPort)
                 .errorMessage(errorMessage)
                 .build();
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/telemetry/CacheMetricsReporter.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/main/java/org/flexlb/cache/telemetry/CacheMetricsReporter.java
@@ -135,19 +135,19 @@ public class CacheMetricsReporter {
     /**
      * Report local cache metrics for a single engine
      *
-     * @param engineIp   Engine IP
+     * @param ipIndex    metrics identity in {@code ip:port@engineIndex} format
      * @param role       Engine role
      * @param cacheCount Cache count
      */
-    public void reportEngineLocalMetrics(String engineIp, String role, int cacheCount) {
-        if (engineIp == null) {
+    public void reportEngineLocalMetrics(String ipIndex, String role, int cacheCount) {
+        if (ipIndex == null) {
             return;
         }
 
         // Calculate cache count and bytes
         long cacheBytes = calculateEngineCacheBytes(cacheCount);
 
-        FlexMetricTags tags = FlexMetricTags.of("engineIp", engineIp, "role", role);
+        FlexMetricTags tags = FlexMetricTags.of("engineIp", ipIndex, "role", role);
 
         monitor.report(CACHE_ENGINE_LOCAL_COUNT, tags, cacheCount);
         monitor.report(CACHE_ENGINE_LOCAL_BYTES, tags, cacheBytes);
@@ -172,13 +172,13 @@ public class CacheMetricsReporter {
      * Report cache hit rate metrics
      *
      * @param roleType  Role type
+     * @param ipIndex   logical engine address in {@code ip:port@engineIndex} format
      * @param hitTokens Number of hit tokens
      * @param hitRatio  Hit percentage
      */
-    public void reportCacheHitMetrics(RoleType roleType, long hitTokens, double hitRatio) {
-        FlexMetricTags baseTags = FlexMetricTags.of(
-                "role", roleType.name()
-        );
+    public void reportCacheHitMetrics(RoleType roleType, String ipIndex, long hitTokens, double hitRatio) {
+
+        FlexMetricTags baseTags = FlexMetricTags.of("role", roleType.name(), "engineIp", ipIndex);
 
         // Report hit token count and hit percentage
         monitor.report(CACHE_HIT_COUNT, baseTags, hitTokens);
@@ -187,13 +187,11 @@ public class CacheMetricsReporter {
     }
 
     public void reportKvcmSelectedMatch(RoleType roleType,
-                                        String engineIp,
+                                        String ipIndex,
                                         long localMatchTokens,
                                         long p2pFetchTokens,
                                         long p2pTotalMatchTokens) {
-        FlexMetricTags tags = FlexMetricTags.of(
-                "role", roleType.name(),
-                "engineIp", engineIp);
+        FlexMetricTags tags = FlexMetricTags.of("role", roleType.name(), "engineIp", ipIndex);
         monitor.report(CACHE_KVCM_SELECTED_LOCAL_MATCH_TOKENS, tags, localMatchTokens);
         monitor.report(CACHE_KVCM_SELECTED_P2P_FETCH_TOKENS, tags, p2pFetchTokens);
         monitor.report(CACHE_KVCM_SELECTED_P2P_TOTAL_MATCH_TOKENS, tags, p2pTotalMatchTokens);
@@ -454,20 +452,14 @@ public class CacheMetricsReporter {
     /**
      * Report local cache metadata update time in microseconds.
      *
-     * @param role         Engine role
-     * @param startTime    Start time in microseconds
-     * @param success      Whether successful
+     * @param ipIndex   metrics identity in {@code ip:port@engineIndex} format
+     * @param role      Engine role
+     * @param startTime Start time in microseconds
+     * @param success   Whether successful
      */
-    public void reportUpdateEngineBlockCacheRT(String role, long startTime, String success) {
-        FlexMetricTags tags = FlexMetricTags.of(
-                "role", role,
-                "success", success
-        );
-        monitor.report(CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT, tags, ((double) System.nanoTime() / 1000) - startTime);
-    }
-
-    public void reportUpdateEngineBlockCacheRT(String engineIpPort, String role, long startTime, String success) {
-        FlexMetricTags tags = FlexMetricTags.of("engineIpPort", engineIpPort, "role", role, "success", success);
+    public void reportUpdateEngineBlockCacheRT(
+            String ipIndex, String role, long startTime, String success) {
+        FlexMetricTags tags = FlexMetricTags.of("engineIp", ipIndex, "role", role, "success", success);
 
         monitor.report(CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT, tags, ((double) System.nanoTime() / 1000) - startTime);
     }
@@ -475,23 +467,20 @@ public class CacheMetricsReporter {
     /**
      * Report cache diff calculation metrics
      *
+     * @param ipIndex           metrics identity in {@code ip:port@engineIndex} format
      * @param role              Role
      * @param addedBlocksSize   Number of added blocks
      * @param removedBlocksSize Number of removed blocks
      */
-    public void reportCacheDiffMetrics(String role, int addedBlocksSize, int removedBlocksSize) {
-        FlexMetricTags tags = FlexMetricTags.of(
-                "role", role != null ? role : "unknown"
-        );
-        reportCacheDiffMetrics(tags, addedBlocksSize, removedBlocksSize);
-    }
-
-    public void reportCacheDiffMetrics(String engineIp, String role, int addedBlocksSize, int removedBlocksSize) {
-        if (engineIp == null) {
+    public void reportCacheDiffMetrics(
+            String ipIndex, String role, int addedBlocksSize, int removedBlocksSize) {
+        if (ipIndex == null) {
             return;
         }
 
-        FlexMetricTags tags = FlexMetricTags.of("engineIp", engineIp, "role", role != null ? role : "unknown");
+        FlexMetricTags tags = FlexMetricTags.of(
+                "engineIp", ipIndex,
+                "role", role != null ? role : "unknown");
 
         reportCacheDiffMetrics(tags, addedBlocksSize, removedBlocksSize);
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheHitComparisonResultTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheHitComparisonResultTest.java
@@ -1,5 +1,6 @@
 package org.flexlb.cache.domain;
 
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.util.JsonUtils;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ class CacheHitComparisonResultTest {
     void serializesNestedCacheHitComparison() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
                 "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "default",
-                "127.0.0.1", "running", 200,
+                new WorkerIdentity("127.0.0.1", 8080, 0), "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
                 new CacheHitComparisonResult.HitComparison(70, 50),
@@ -27,7 +28,7 @@ class CacheHitComparisonResultTest {
 
         assertTrue(json.contains("\"event\":\"cache_hit_comparison\""));
         assertTrue(json.contains("\"source\":\"KVCM\""));
-        assertTrue(json.contains("\"worker\":\"127.0.0.1\""));
+        assertTrue(json.contains("\"worker\":\"127.0.0.1:8080@0\""));
         assertTrue(json.contains("\"state\":\"running\""));
         assertTrue(json.contains("\"actual\":{\"hit\":120}"));
         assertTrue(json.contains(
@@ -45,13 +46,14 @@ class CacheHitComparisonResultTest {
         assertTrue(json.indexOf("\"kvcm\"") < json.indexOf("\"localStandby\""));
         assertFalse(json.contains("\"p2pFetch\""));
         assertFalse(json.contains("\"workerPort\""));
+        assertFalse(json.contains("\"ipIndex\""));
     }
 
     @Test
     void omitsUnavailableLocalStandbyPrediction() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
                 "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "default",
-                "127.0.0.1", "running", 200,
+                new WorkerIdentity("127.0.0.1", 8080, 0), "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
                 null,
@@ -66,7 +68,7 @@ class CacheHitComparisonResultTest {
     void omitsKvcmForNonKvcmSource() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
                 "cache_hit_comparison", "request-1", "LOCAL_SYNC", "PREFILL", "default",
-                "127.0.0.1", "running", 200,
+                new WorkerIdentity("127.0.0.1", 8080, 0), "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
                 null,

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheMatchResultTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/domain/CacheMatchResultTest.java
@@ -1,13 +1,61 @@
 package org.flexlb.cache.domain;
 
 import org.flexlb.dao.cache.HostCacheMatch;
+import org.flexlb.dao.master.WorkerStatus;
+import org.flexlb.dao.route.RoleType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class CacheMatchResultTest {
+
+    @Test
+    void shouldMatchLegacyPhysicalKvcmHostForSingleEngineWorker() {
+        HostCacheMatch legacyMatch = HostCacheMatch.local(2);
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080", legacyMatch), CacheMatchSource.KVCM, 0, 1000);
+        WorkerStatus worker = worker("10.0.0.1", 8080, 0, 1);
+
+        assertSame(legacyMatch, result.hostMatch(worker));
+    }
+
+    @Test
+    void shouldPreferLogicalKvcmHostForSingleEngineWorker() {
+        HostCacheMatch logicalMatch = HostCacheMatch.local(3);
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of(
+                        "10.0.0.1:8080@0", logicalMatch,
+                        "10.0.0.1:8080", HostCacheMatch.local(2)),
+                CacheMatchSource.KVCM,
+                0,
+                1000);
+
+        assertSame(logicalMatch, result.hostMatch(worker("10.0.0.1", 8080, 0, 1)));
+    }
+
+    @Test
+    void shouldIgnoreLegacyPhysicalKvcmHostForMultiEngineWorker() {
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
+
+        assertNull(result.hostMatch(worker("10.0.0.1", 8080, 0, 2)));
+    }
+
+    @Test
+    void shouldNotFallbackPhysicalHostOutsideKvcm() {
+        WorkerStatus worker = worker("10.0.0.1", 8080, 0, 1);
+        for (CacheMatchSource source : new CacheMatchSource[]{
+                CacheMatchSource.LOCAL_SYNC, CacheMatchSource.LOCAL_STANDBY}) {
+            CacheMatchResult result = new CacheMatchResult(
+                    Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), source, 0, 1000);
+
+            assertNull(result.hostMatch(worker));
+        }
+    }
 
     @Test
     void shouldPreserveRawKvcmP2pMatchFields() {
@@ -17,9 +65,9 @@ class CacheMatchResultTest {
                 0,
                 1000);
 
-        assertEquals(2, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
-        assertEquals(8, result.hostMatch("10.0.0.1:8080").p2pFetchBlocks());
-        assertEquals(10, result.hostMatch("10.0.0.1:8080").p2pTotalMatchBlocks());
+        assertEquals(2, result.exactHostMatch("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(8, result.exactHostMatch("10.0.0.1:8080").p2pFetchBlocks());
+        assertEquals(10, result.exactHostMatch("10.0.0.1:8080").p2pTotalMatchBlocks());
     }
 
     @Test
@@ -27,7 +75,29 @@ class CacheMatchResultTest {
         CacheMatchResult result = new CacheMatchResult(
                 Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
 
-        assertEquals(2, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(2, result.exactHostMatch("10.0.0.1:8080").localMatchBlocks());
+    }
+
+    @Test
+    void returnsNullHostMatchForNullWorker() {
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
+
+        assertNull(result.hostMatch((WorkerStatus) null));
+    }
+
+    @Test
+    void guardsMatchedTokensAgainstDegenerateInputs() {
+        assertEquals(0, CacheMatchResult.matchedTokens(0, 4096, 100));
+        assertEquals(0, CacheMatchResult.matchedTokens(2, 0, 100));
+    }
+
+    @Test
+    void pinsFallbackExpectationForSingleEngineWorker() {
+        CacheMatchResult result = new CacheMatchResult(
+                Map.of("10.0.0.1:8080", HostCacheMatch.local(2)), CacheMatchSource.KVCM, 0, 1000);
+
+        assertEquals(2, result.hostMatch(worker("10.0.0.1", 8080, 0, 1)).localMatchBlocks());
     }
 
     @Test
@@ -38,5 +108,18 @@ class CacheMatchResultTest {
     @Test
     void shouldKeepMatchedTokensWhenRequestLengthIsUnknown() {
         assertEquals(8, CacheMatchResult.matchedTokens(2, 4, 0));
+    }
+
+    private static WorkerStatus worker(String ip, int port, int engineIndex, int multiEngineNum) {
+        return WorkerStatus.createDiscovered(
+                RoleType.PREFILL,
+                "default",
+                ip,
+                port,
+                port + 1,
+                "",
+                null,
+                engineIndex,
+                multiEngineNum);
     }
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/CacheMatchQueryOrchestratorTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/CacheMatchQueryOrchestratorTest.java
@@ -56,7 +56,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(query);
 
         assertEquals(CacheMatchSource.LOCAL_SYNC, result.source());
-        assertEquals(2, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(2, result.exactHostMatch("10.0.0.1:8080").localMatchBlocks());
         verify(kvcmProvider, never()).findMatchingEngines(
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.any(),
@@ -77,7 +77,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(query);
 
         assertEquals(CacheMatchSource.KVCM, result.source());
-        assertEquals(1, result.hostMatch("10.0.0.2:8080").localMatchBlocks());
+        assertEquals(1, result.exactHostMatch("10.0.0.2:8080").localMatchBlocks());
         verify(comparisonService).trackLocalStandbyPrediction(query);
     }
 
@@ -147,7 +147,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(query);
 
         assertEquals(CacheMatchSource.KVCM, result.source());
-        assertEquals(1, result.hostMatch("10.0.0.2:8080").localMatchBlocks());
+        assertEquals(1, result.exactHostMatch("10.0.0.2:8080").localMatchBlocks());
     }
 
     @Test
@@ -169,7 +169,7 @@ class CacheMatchQueryOrchestratorTest {
         CacheMatchResult result = orchestrator().findMatchingEngines(standbyQuery);
 
         assertEquals(CacheMatchSource.LOCAL_STANDBY, result.source());
-        assertEquals(1, result.hostMatch("10.0.0.3:8080").localMatchBlocks());
+        assertEquals(1, result.exactHostMatch("10.0.0.3:8080").localMatchBlocks());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProviderTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/kvcm/KvcmCacheMatchProviderTest.java
@@ -23,13 +23,13 @@ class KvcmCacheMatchProviderTest {
         KvcmGrpcClient client = mock(KvcmGrpcClient.class);
         when(client.findMatchingEngines(
                 "request-1", List.of(11L), 2192, RoleType.PREFILL, "default"))
-                .thenReturn(Map.of("10.0.0.1:8080", new HostCacheMatch(1, 0, 1)));
+                .thenReturn(Map.of("10.0.0.1:8080@1", new HostCacheMatch(1, 0, 1)));
         KvcmCacheMatchProvider provider = new KvcmCacheMatchProvider(client);
 
         Map<String, HostCacheMatch> result = provider.findMatchingEngines(
                 "request-1", List.of(11L), 2192, RoleType.PREFILL, "default");
 
-        assertEquals(1, result.get("10.0.0.1:8080").localMatchBlocks());
+        assertEquals(1, result.get("10.0.0.1:8080@1").localMatchBlocks());
         verify(client).findMatchingEngines(
                 "request-1", List.of(11L), 2192, RoleType.PREFILL, "default");
     }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManagerTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheManagerTest.java
@@ -39,16 +39,16 @@ class LocalStandbyCacheManagerTest {
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
 
-        manager.addRoutedRequestBlocks(worker1.getIpPort(), List.of(11L, 22L, 33L));
-        manager.addRoutedRequestBlocks(worker2.getIpPort(), List.of(11L, 33L));
+        manager.addRoutedRequestBlocks(worker1.getLogicalIpPort(), List.of(11L, 22L, 33L));
+        manager.addRoutedRequestBlocks(worker2.getLogicalIpPort(), List.of(11L, 33L));
 
         Map<String, Integer> matches =
                 manager.findMatchingEngines(List.of(11L, 22L, 33L), RoleType.PREFILL, "default");
 
-        assertEquals(3, matches.get(worker1.getIpPort()));
-        assertEquals(1, matches.get(worker2.getIpPort()));
+        assertEquals(3, matches.get(worker1.getLogicalIpPort()));
+        assertEquals(1, matches.get(worker2.getLogicalIpPort()));
         assertEquals(
-                Map.of(worker1.getIpPort(), 1, worker2.getIpPort(), 1),
+                Map.of(worker1.getLogicalIpPort(), 1, worker2.getLogicalIpPort(), 1),
                 manager.findMatchingEngines(List.of(11L), RoleType.PREFILL, "default"));
         manager.shutdown();
     }
@@ -64,18 +64,18 @@ class LocalStandbyCacheManagerTest {
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
 
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L, 22L, 33L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L, 22L, 33L));
 
         assertEquals(
                 2,
                 manager.findMatchingEngines(
                                 List.of(11L, 22L, 33L), RoleType.PDFUSION, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         assertEquals(
                 0,
                 manager.findMatchingEngines(
                                 List.of(11L), RoleType.PDFUSION, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         manager.shutdown();
     }
 
@@ -89,13 +89,13 @@ class LocalStandbyCacheManagerTest {
                 configuration(300_000),
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L, 22L, 33L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L, 22L, 33L));
 
         assertEquals(
                 3,
                 manager.findMatchingEngines(
                                 List.of(11L, 22L, 33L), RoleType.PDFUSION, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         manager.shutdown();
     }
 
@@ -109,14 +109,14 @@ class LocalStandbyCacheManagerTest {
                 configuration(20),
                 workerStatusProvider,
                 mock(CacheMetricsReporter.class));
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L));
 
         Thread.sleep(30);
 
         assertEquals(
                 0,
                 manager.findMatchingEngines(List.of(11L), RoleType.PREFILL, "default")
-                        .get(worker.getIpPort()));
+                        .get(worker.getLogicalIpPort()));
         assertEquals(0, manager.mappingCount());
         manager.shutdown();
     }
@@ -141,7 +141,7 @@ class LocalStandbyCacheManagerTest {
                 mock(CacheMetricsReporter.class));
 
         manager.refreshCapacityLimits();
-        manager.addRoutedRequestBlocks(worker.getIpPort(), List.of(11L));
+        manager.addRoutedRequestBlocks(worker.getLogicalIpPort(), List.of(11L));
 
         assertEquals(1_000, manager.maximumEntryCount());
         manager.shutdown();
@@ -202,7 +202,7 @@ class LocalStandbyCacheManagerTest {
                 cacheMetricsReporter);
 
         manager.addRoutedRequestBlocks(
-                worker.getIpPort(),
+                worker.getLogicalIpPort(),
                 List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L));
 
         manager.reportMappingCount();

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProviderTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyCacheMatchProviderTest.java
@@ -11,6 +11,8 @@ import org.flexlb.dao.route.KvcmConfig;
 import org.flexlb.dao.route.RoleType;
 import org.flexlb.dao.route.ServiceRoute;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.List;
 import java.util.Map;
@@ -42,7 +44,7 @@ class LocalStandbyCacheMatchProviderTest {
         CompletableFuture<LocalStandbyHashResult> pendingHash = new CompletableFuture<>();
         when(hashService.getHashResult("request-1", null, 4096)).thenReturn(pendingHash);
         when(cacheManager.findMatchingEngines(List.of(101L), RoleType.PREFILL, "default"))
-                .thenReturn(Map.of("10.0.0.1:8080", 1));
+                .thenReturn(Map.of("10.0.0.1:8080@0", 1));
 
         try {
             CompletableFuture<CacheMatchResult> match = provider.asyncLocalStandbyMatch(query);
@@ -51,7 +53,7 @@ class LocalStandbyCacheMatchProviderTest {
             pendingHash.complete(new LocalStandbyHashResult(List.of(101L), 4096));
             CacheMatchResult result = match.get(1, TimeUnit.SECONDS);
 
-            assertEquals(1, result.hostMatch("10.0.0.1:8080").localMatchBlocks());
+            assertEquals(1, result.exactHostMatch("10.0.0.1:8080@0").localMatchBlocks());
             assertEquals(4096, result.blockSize());
             verify(cacheManager).findMatchingEngines(List.of(101L), RoleType.PREFILL, "default");
         } finally {
@@ -59,8 +61,10 @@ class LocalStandbyCacheMatchProviderTest {
         }
     }
 
-    @Test
-    void updatesRequestDerivedCacheMetadataAsynchronously() {
+    @ParameterizedTest
+    @CsvSource({"0, 1, 10.0.0.1:8080@0", "1, 2, 10.0.0.1:8080@1"})
+    void updatesRequestDerivedCacheMetadataAsynchronously(
+            int engineIndex, int multiEngineNum, String logicalIpPort) {
         LocalStandbyCacheManager cacheManager = mock(LocalStandbyCacheManager.class);
         LocalStandbyHashService hashService = mock(LocalStandbyHashService.class);
         LocalStandbyCacheMatchProvider provider =
@@ -82,6 +86,7 @@ class LocalStandbyCacheMatchProviderTest {
         selectedWorker.setHttpPort(8080);
         selectedWorker.setRole(RoleType.PREFILL);
         selectedWorker.setGroup("default");
+        selectedWorker.setSelectedEngineIndex(engineIndex, multiEngineNum);
 
         try {
             provider.updateFromRoutedRequest(request, List.of(selectedWorker));
@@ -90,7 +95,7 @@ class LocalStandbyCacheMatchProviderTest {
             pendingHash.complete(new LocalStandbyHashResult(List.of(11L, 22L), 4096));
 
             verify(cacheManager, timeout(1_000))
-                    .addRoutedRequestBlocks("10.0.0.1:8080", List.of(11L));
+                    .addRoutedRequestBlocks(logicalIpPort, List.of(11L));
         } finally {
             provider.shutdown();
         }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonServiceTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localstandby/LocalStandbyComparisonServiceTest.java
@@ -47,7 +47,7 @@ class LocalStandbyComparisonServiceTest {
 
         verify(provider).asyncLocalStandbyMatch(query);
         pendingMatch.complete(new CacheMatchResult(
-                Map.of("10.0.0.1:8080", HostCacheMatch.local(1)),
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(1)),
                 CacheMatchSource.LOCAL_STANDBY,
                 10,
                 4096));
@@ -86,7 +86,7 @@ class LocalStandbyComparisonServiceTest {
                 RoleType.PREFILL,
                 "default");
         comparisonService.trackResolvedLocalStandbyPrediction(query, new CacheMatchResult(
-                Map.of("10.0.0.1:8080", HostCacheMatch.local(1)),
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(1)),
                 CacheMatchSource.LOCAL_STANDBY,
                 10,
                 4096));
@@ -104,6 +104,74 @@ class LocalStandbyComparisonServiceTest {
         assertNotNull(result.localStandby());
         assertEquals(4096, result.localStandby().hit());
         assertEquals(1904, result.localStandby().delta());
+    }
+
+    @Test
+    void matchesLocalStandbyPredictionByEngineIndex() throws Exception {
+        LocalStandbyCacheMatchProvider provider = mock(LocalStandbyCacheMatchProvider.class);
+        LocalStandbyComparisonService comparisonService = new LocalStandbyComparisonService(
+                kvcm(modelMetaConfig()), provider);
+        CacheMatchQuery query = new CacheMatchQuery(
+                "request-index-1",
+                List.of(11L),
+                1024,
+                List.of(101L),
+                4096,
+                RoleType.PREFILL,
+                "default");
+        comparisonService.trackResolvedLocalStandbyPrediction(query, new CacheMatchResult(
+                Map.of(
+                        "10.0.0.1:8080@0", HostCacheMatch.local(1),
+                        "10.0.0.1:8080@1", HostCacheMatch.local(2)),
+                CacheMatchSource.LOCAL_STANDBY,
+                10,
+                4096));
+
+        CacheHitFeedback feedback = new CacheHitFeedback(
+                "cache_hit_comparison", "request-index-1", "LOCAL_STANDBY", "PREFILL", "default",
+                "10.0.0.1", 8080, 1, "running", 12000, 4096, 4096,
+                false, 0, 0, 0,
+                9000, 4904);
+
+        CacheHitComparisonResult result =
+                comparisonService.buildCacheHitComparison(feedback).get(1, TimeUnit.SECONDS);
+
+        assertEquals("10.0.0.1:8080@1", result.worker());
+        assertEquals(8192, result.localStandby().hit());
+        assertEquals(808, result.localStandby().delta());
+    }
+
+    @Test
+    void degradesToZeroStandbyHitWhenPredictionMissesLogicalWorker() throws Exception {
+        LocalStandbyCacheMatchProvider provider = mock(LocalStandbyCacheMatchProvider.class);
+        LocalStandbyComparisonService comparisonService = new LocalStandbyComparisonService(
+                kvcm(modelMetaConfig()), provider);
+        CacheMatchQuery query = new CacheMatchQuery(
+                "request-miss-1",
+                List.of(11L),
+                1024,
+                List.of(101L),
+                4096,
+                RoleType.PREFILL,
+                "default");
+        comparisonService.trackResolvedLocalStandbyPrediction(query, new CacheMatchResult(
+                Map.of("10.0.0.1:8080@0", HostCacheMatch.local(2)),
+                CacheMatchSource.LOCAL_STANDBY,
+                10,
+                4096));
+
+        CacheHitFeedback feedback = new CacheHitFeedback(
+                "cache_hit_comparison", "request-miss-1", "LOCAL_STANDBY", "PREFILL", "default",
+                "10.0.0.1", 8080, 1, "running", 12000, 4096, 4096,
+                false, 0, 0, 0,
+                9000, 4904);
+
+        CacheHitComparisonResult result =
+                comparisonService.buildCacheHitComparison(feedback).get(1, TimeUnit.SECONDS);
+
+        assertNotNull(result.localStandby());
+        assertEquals(0, result.localStandby().hit());
+        assertEquals(9000, result.localStandby().delta());
     }
 
     private ModelMetaConfig modelMetaConfig() {

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/KvCacheManagerTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/KvCacheManagerTest.java
@@ -1,6 +1,8 @@
 package org.flexlb.cache.match.localsync;
 
+import org.flexlb.cache.domain.DiffResult;
 import org.flexlb.cache.telemetry.CacheMetricsReporter;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatusProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -44,6 +47,105 @@ class KvCacheManagerTest {
         verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080");
         verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080");
         verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.2:8080");
+    }
+
+    @Test
+    void keepsLogicalCacheWhenItsPhysicalEngineRemainsDiscoverable() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+    }
+
+    @Test
+    void removesLogicalCacheWhenItsPhysicalEngineDisappears() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.2:8080"));
+
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+    }
+
+    @Test
+    void directRetirementRemovesTheLogicalToPhysicalMapping() {
+        String logicalIpPort = "10.0.0.1:8080@0";
+        when(engineLocalView.calculateDiff(logicalIpPort, Set.of()))
+                .thenReturn(DiffResult.empty(logicalIpPort));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+
+        kvCacheManager.removeEngineCache(logicalIpPort);
+        when(engineLocalView.getAllEngineIpPorts()).thenReturn(Set.of(logicalIpPort));
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView, times(2)).removeAllCacheBlockOfEngine(logicalIpPort);
+        verify(globalCacheIndex, times(2)).removeAllCacheBlockOfEngine(logicalIpPort);
+    }
+
+    @Test
+    void keepsAllSiblingLogicalCachesWhenTheirPhysicalEngineRemainsDiscoverable() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0", "10.0.0.1:8080@1"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@1", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@1"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 1), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(engineLocalView, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+        verify(globalCacheIndex, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex, never()).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+    }
+
+    @Test
+    void removesAllSiblingLogicalCachesWhenTheirPhysicalEngineDisappears() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0", "10.0.0.1:8080@1"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@0", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@0"));
+        when(engineLocalView.calculateDiff("10.0.0.1:8080@1", Set.of()))
+                .thenReturn(DiffResult.empty("10.0.0.1:8080@1"));
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 0), "PREFILL", Set.of());
+        kvCacheManager.updateEngineCache(
+                new WorkerIdentity("10.0.0.1", 8080, 1), "PREFILL", Set.of());
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.2:8080"));
+
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@1");
+    }
+
+    @Test
+    void treatsUnmappedLogicalKeyAsStaleEvenWhenItsPhysicalEngineRemainsDiscoverable() {
+        when(engineLocalView.getAllEngineIpPorts())
+                .thenReturn(Set.of("10.0.0.1:8080@0"));
+
+        kvCacheManager.removeStaleEngineCaches(List.of("10.0.0.1:8080"));
+
+        verify(engineLocalView).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
+        verify(globalCacheIndex).removeAllCacheBlockOfEngine("10.0.0.1:8080@0");
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProviderTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/match/localsync/LocalSyncCacheMatchProviderTest.java
@@ -3,6 +3,7 @@ package org.flexlb.cache.match.localsync;
 import org.flexlb.cache.domain.WorkerCacheUpdateResult;
 import org.flexlb.cache.telemetry.CacheMetricsReporter;
 import org.flexlb.dao.master.CacheStatus;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.route.RoleType;
 import org.junit.jupiter.api.Test;
@@ -11,11 +12,14 @@ import java.util.Set;
 
 import static org.flexlb.cache.WorkerStatusTestSupport.workerStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 class LocalSyncCacheMatchProviderTest {
 
@@ -31,8 +35,87 @@ class LocalSyncCacheMatchProviderTest {
 
         assertTrue(result.isSuccess());
         assertEquals(2, result.getCacheBlockCount());
-        verify(kvCacheManager).updateEngineCache("127.0.0.1:8080", "PREFILL", Set.of(11L, 22L));
-        verify(metricsReporter).reportUpdateEngineBlockCacheRT(eq("127.0.0.1:8080"), eq("PREFILL"), anyLong(), eq("1"));
+        assertEquals(100L, result.getAvailableKvCache());
+        assertEquals(200L, result.getTotalKvCache());
+        assertEquals(3L, result.getCacheVersion());
+        verify(kvCacheManager).updateEngineCache(
+                new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of(11L, 22L));
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("1"));
+    }
+
+    @Test
+    void rejectsMissingCacheStatus() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatus(
+                "127.0.0.1", 8080, RoleType.PREFILL, false, null);
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertFalse(result.isSuccess());
+        assertEquals("127.0.0.1:8080@0", result.getLogicalIpPort());
+        assertEquals("Worker Cache Status is null", result.getErrorMessage());
+        verifyNoInteractions(kvCacheManager);
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("0"));
+    }
+
+    @Test
+    void rejectsMissingCachedKeys() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatusWithCachedKeys(null);
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Worker Cached Keys is null", result.getErrorMessage());
+        verifyNoInteractions(kvCacheManager);
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("0"));
+    }
+
+    @Test
+    void acceptsEmptyCachedKeys() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatusWithCachedKeys(Set.of());
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertTrue(result.isSuccess());
+        assertEquals(0, result.getCacheBlockCount());
+        verify(kvCacheManager).updateEngineCache(
+                new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of());
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("1"));
+    }
+
+    @Test
+    void reportsCacheManagerFailure() {
+        KvCacheManager kvCacheManager = mock(KvCacheManager.class);
+        CacheMetricsReporter metricsReporter = mock(CacheMetricsReporter.class);
+        LocalSyncCacheMatchProvider provider =
+                new LocalSyncCacheMatchProvider(kvCacheManager, metricsReporter);
+        WorkerStatus workerStatus = workerStatusFixture();
+        doThrow(new IllegalStateException("cache update failed"))
+                .when(kvCacheManager)
+                .updateEngineCache(
+                        new WorkerIdentity("127.0.0.1", 8080, 0), "PREFILL", Set.of(11L, 22L));
+
+        WorkerCacheUpdateResult result = provider.updateFromWorkerStatus(workerStatus);
+
+        assertFalse(result.isSuccess());
+        assertEquals("cache update failed", result.getErrorMessage());
+        verify(metricsReporter).reportUpdateEngineBlockCacheRT(
+                eq("127.0.0.1:8080@0"), eq("PREFILL"), anyLong(), eq("0"));
     }
 
     private WorkerStatus workerStatusFixture() {
@@ -43,5 +126,10 @@ class LocalSyncCacheMatchProviderTest {
                 .totalKvCache(200L)
                 .version(3L)
                 .build());
+    }
+
+    private WorkerStatus workerStatusWithCachedKeys(Set<Long> cachedKeys) {
+        return workerStatus("127.0.0.1", 8080, RoleType.PREFILL, false,
+                CacheStatus.builder().cachedKeys(cachedKeys).build());
     }
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/monitor/CacheMetricsReporterTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/monitor/CacheMetricsReporterTest.java
@@ -24,7 +24,10 @@ import static org.flexlb.constant.MetricConstant.CACHE_ROUTING_SELECTED_MATCH_TO
 import static org.flexlb.constant.MetricConstant.CACHE_THEORY_HIT_COUNT;
 import static org.flexlb.constant.MetricConstant.CACHE_THEORY_HIT_RATIO;
 import static org.flexlb.constant.MetricConstant.CACHE_THEORY_TOTAL_COUNT;
+import static org.flexlb.constant.MetricConstant.CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -64,10 +67,10 @@ class CacheMetricsReporterTest {
     }
 
     @Test
-    void should_report_engine_local_metrics_without_engine_ip_port() {
-        reporter.reportEngineLocalMetrics("10.0.0.1", "PREFILL", 2);
+    void should_report_engine_local_metrics_with_logical_worker_address() {
+        reporter.reportEngineLocalMetrics("10.0.0.1:8080@0", "PREFILL", 2);
 
-        FlexMetricTags tags = FlexMetricTags.of("engineIp", "10.0.0.1", "role", "PREFILL");
+        FlexMetricTags tags = FlexMetricTags.of("engineIp", "10.0.0.1:8080@0", "role", "PREFILL");
         verify(monitor).report(CACHE_ENGINE_LOCAL_COUNT, tags, 2);
         verify(monitor).report(CACHE_ENGINE_LOCAL_BYTES, tags, 272L);
     }
@@ -116,12 +119,22 @@ class CacheMetricsReporterTest {
 
     @Test
     void should_report_cache_affinity_decision() {
-        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1", "CACHE_LEADER");
+        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1:8080@0", "CACHE_LEADER");
 
         FlexMetricTags tags = FlexMetricTags.of(
                 "role", "PREFILL",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "decision", "CACHE_LEADER");
         verify(monitor).report(CACHE_AFFINITY_DECISION, tags, 1.0);
+    }
+
+    @Test
+    void reportsCacheUpdateLatencyWithIndexedEngineIp() {
+        reporter.reportUpdateEngineBlockCacheRT("10.0.0.8:8080@1", "PREFILL", 0L, "1");
+
+        verify(monitor).report(
+                eq(CACHE_UPDATE_ENGINE_BLOCK_CACHE_RT),
+                eq(FlexMetricTags.of("engineIp", "10.0.0.8:8080@1", "role", "PREFILL", "success", "1")),
+                anyDouble());
     }
 }

--- a/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/update/CacheMetadataUpdateOrchestratorTest.java
+++ b/rtp_llm/flexlb/flexlb-cache/src/test/java/org/flexlb/cache/update/CacheMetadataUpdateOrchestratorTest.java
@@ -53,7 +53,7 @@ class CacheMetadataUpdateOrchestratorTest {
         WorkerCacheUpdateResult result = orchestrator().updateFromWorkerStatus(workerStatus);
 
         assertFalse(result.isSuccess());
-        assertEquals("127.0.0.1:8080", result.getEngineIpPort());
+        assertEquals("127.0.0.1:8080@0", result.getLogicalIpPort());
         verifyNoInteractions(localSyncProvider);
     }
 

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/config/ModelServiceConfiguration.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/config/ModelServiceConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Configuration;
 public class ModelServiceConfiguration {
 
     private static final String MODEL_SERVICE_CONFIG = "MODEL_SERVICE_CONFIG";
+    private static final int MAX_TCP_PORT = 65_535;
 
     @Bean
     public ModelMetaConfig modelMetaConfig(ConfigService configService, RoutingServiceDiscovery serviceDiscovery) {
@@ -49,11 +50,42 @@ public class ModelServiceConfiguration {
             throw new IllegalArgumentException("MODEL_SERVICE_CONFIG must contain at least one role endpoint");
         }
         for (Endpoint endpoint : endpoints) {
+            validateEngineEndpointConfiguration(endpoint);
             serviceDiscovery.validate(endpoint);
         }
 
         validateKvcm(serviceRoute.getKvcm(), serviceDiscovery);
         validateOptimizer(serviceRoute.getOptimizer(), serviceDiscovery);
+    }
+
+    private void validateEngineEndpointConfiguration(Endpoint endpoint) {
+        int multiEngineNum = endpoint.getMultiEngineNum();
+        if (multiEngineNum < 1) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint multi_engine_num must be greater than zero: "
+                            + endpoint.getAddress());
+        }
+        Integer workerStatusPort = endpoint.getWorkerStatusPort();
+        if (workerStatusPort != null && (workerStatusPort < 1 || workerStatusPort > MAX_TCP_PORT)) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint worker_status_port must be between 1 and "
+                            + MAX_TCP_PORT + ": "
+                            + endpoint.getAddress());
+        }
+        if (multiEngineNum == 1) {
+            return;
+        }
+        if (workerStatusPort == null) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint worker_status_port must be configured "
+                            + "when multi_engine_num is greater than one: " + endpoint.getAddress());
+        }
+        if ((long) workerStatusPort + multiEngineNum - 1 > MAX_TCP_PORT) {
+            throw new IllegalArgumentException(
+                    "MODEL_SERVICE_CONFIG endpoint worker_status_port range exceeds "
+                            + MAX_TCP_PORT + ": "
+                            + endpoint.getAddress());
+        }
     }
 
     private void validateKvcm(KvcmConfig kvcm, RoutingServiceDiscovery serviceDiscovery) {

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/constant/CommonConstants.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/constant/CommonConstants.java
@@ -8,6 +8,9 @@ public class CommonConstants {
 
     public static final String TIMEOUT_HANDLER = "timeoutHandler";
 
+    /** Separator between a physical {@code ip:port} address and its logical engine index. */
+    public static final String LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR = "@";
+
     /**
      * gRPC timeout message
      */

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/cache/HostCacheMatch.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/cache/HostCacheMatch.java
@@ -18,6 +18,9 @@ public record HostCacheMatch(
         return new HostCacheMatch(matchBlocks, 0, matchBlocks);
     }
 
+    /**
+     * Converts local match counts while preserving logical {@code ip:port@engineIndex} keys.
+     */
     public static Map<String, HostCacheMatch> fromLocalMatches(Map<String, Integer> localMatches) {
         return localMatches.entrySet().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/loadbalance/ServerStatus.java
@@ -1,8 +1,16 @@
 package org.flexlb.dao.loadbalance;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.route.RoleType;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,6 +30,35 @@ public class ServerStatus {
 
     @JsonProperty("dp_rank")
     private long dpRank;
+
+    /**
+     * Selected logical engine index exposed in the schedule response. This field is present
+     * when a physical frontend owns multiple logical engines and omitted when there is only
+     * one engine.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("engine_index")
+    private Integer engineIndex;
+
+    /**
+     * Selected logical engine index used only inside FlexLB. Unlike {@link #engineIndex}, this
+     * value is always available, including {@code 0} for a single-engine frontend, so routing
+     * and rollback can address the exact logical worker.
+     */
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private int routingEngineIndex;
+
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private int routingMultiEngineNum = 1;
+
+    @JsonIgnore
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private WorkerIdentity workerIdentity = new WorkerIdentity(null, 0, 0);
 
     @JsonProperty("prefill_time")
     private long prefillTime;
@@ -50,5 +87,57 @@ public class ServerStatus {
         result.setCode(code.getErrorCode());
         result.setMessage(code.getErrorMsg());
         return result;
+    }
+
+    /**
+     * Sets the selected engine identity for internal routing and the schedule wire response.
+     * Single-engine routes keep the internal {@code @0} identity but omit the wire field.
+     */
+    public void setSelectedEngineIndex(int selectedEngineIndex, int multiEngineNum) {
+        if (multiEngineNum < 1
+                || selectedEngineIndex < 0
+                || selectedEngineIndex >= multiEngineNum) {
+            throw new IllegalArgumentException(
+                    "selected engine index must be in [0, multiEngineNum)");
+        }
+        routingEngineIndex = selectedEngineIndex;
+        routingMultiEngineNum = multiEngineNum;
+        engineIndex = multiEngineNum > 1 ? selectedEngineIndex : null;
+        refreshWorkerIdentity();
+    }
+
+    /** Returns the logical worker count used to derive the schedule response. */
+    @JsonIgnore
+    public int getRoutingMultiEngineNum() {
+        return routingMultiEngineNum;
+    }
+
+    /**
+     * Returns the internal logical worker identity in {@code ip:port@engineIndex} format.
+     * The index identifies one independently routable engine behind the physical frontend.
+     */
+    @JsonIgnore
+    public String getLogicalIpPort() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    /** Returns the legacy port-free identity in {@code ip@engineIndex} format. */
+    @JsonIgnore
+    public String getIpIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public void setServerIp(String serverIp) {
+        this.serverIp = serverIp;
+        refreshWorkerIdentity();
+    }
+
+    public void setHttpPort(int httpPort) {
+        this.httpPort = httpPort;
+        refreshWorkerIdentity();
+    }
+
+    private void refreshWorkerIdentity() {
+        workerIdentity = new WorkerIdentity(serverIp, httpPort, routingEngineIndex);
     }
 }

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/CacheHitFeedback.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/CacheHitFeedback.java
@@ -2,6 +2,8 @@ package org.flexlb.dao.master;
 
 /**
  * Engine feedback comparing the routing cache-hit prediction with the actual cache hit.
+ * The embedded {@link WorkerIdentity} preserves both the routing identity
+ * ({@code ip:port@engineIndex}) and legacy short identity ({@code ip@engineIndex}).
  */
 public record CacheHitFeedback(
         String eventType,
@@ -9,8 +11,7 @@ public record CacheHitFeedback(
         String cacheMatchSource,
         String role,
         String group,
-        String workerIp,
-        int workerPort,
+        WorkerIdentity workerIdentity,
         String taskState,
         long inputTokens,
         long blockSize,
@@ -21,6 +22,83 @@ public record CacheHitFeedback(
         long kvcmP2pTotalMatchTokens,
         long actualHitTokens,
         long deltaHitTokens) {
+
+    public CacheHitFeedback(
+            String eventType,
+            String requestId,
+            String cacheMatchSource,
+            String role,
+            String group,
+            String workerIp,
+            int workerPort,
+            int engineIndex,
+            String taskState,
+            long inputTokens,
+            long blockSize,
+            long predictedHitTokens,
+            boolean kvcmMatchAvailable,
+            long kvcmLocalMatchTokens,
+            long kvcmP2pFetchTokens,
+            long kvcmP2pTotalMatchTokens,
+            long actualHitTokens,
+            long deltaHitTokens) {
+        this(
+                eventType,
+                requestId,
+                cacheMatchSource,
+                role,
+                group,
+                new WorkerIdentity(workerIp, workerPort, engineIndex),
+                taskState,
+                inputTokens,
+                blockSize,
+                predictedHitTokens,
+                kvcmMatchAvailable,
+                kvcmLocalMatchTokens,
+                kvcmP2pFetchTokens,
+                kvcmP2pTotalMatchTokens,
+                actualHitTokens,
+                deltaHitTokens);
+    }
+
+    public CacheHitFeedback(
+            String eventType,
+            String requestId,
+            String cacheMatchSource,
+            String role,
+            String group,
+            String workerIp,
+            int workerPort,
+            String taskState,
+            long inputTokens,
+            long blockSize,
+            long predictedHitTokens,
+            boolean kvcmMatchAvailable,
+            long kvcmLocalMatchTokens,
+            long kvcmP2pFetchTokens,
+            long kvcmP2pTotalMatchTokens,
+            long actualHitTokens,
+            long deltaHitTokens) {
+        this(
+                eventType,
+                requestId,
+                cacheMatchSource,
+                role,
+                group,
+                workerIp,
+                workerPort,
+                0,
+                taskState,
+                inputTokens,
+                blockSize,
+                predictedHitTokens,
+                kvcmMatchAvailable,
+                kvcmLocalMatchTokens,
+                kvcmP2pFetchTokens,
+                kvcmP2pTotalMatchTokens,
+                actualHitTokens,
+                deltaHitTokens);
+    }
 
     public CacheHitFeedback(
             String eventType,
@@ -44,6 +122,7 @@ public record CacheHitFeedback(
                 group,
                 workerIp,
                 workerPort,
+                0,
                 taskState,
                 inputTokens,
                 blockSize,
@@ -54,5 +133,26 @@ public record CacheHitFeedback(
                 0,
                 actualHitTokens,
                 deltaHitTokens);
+    }
+
+    /**
+     * Returns the feedback target in {@code ip:port@engineIndex} format. The index identifies
+     * one independently routable engine behind the physical frontend.
+     */
+    public String logicalWorkerId() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    /** Returns the legacy short identity in {@code ip@engineIndex} format. */
+    public String ipIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public int workerPort() {
+        return workerIdentity.getPort();
+    }
+
+    public int engineIndex() {
+        return workerIdentity.getEngineIndex();
     }
 }

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerHost.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerHost.java
@@ -1,5 +1,6 @@
 package org.flexlb.dao.master;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 
 /**
@@ -29,9 +30,29 @@ public class WorkerHost {
      */
     private final int httpServerPort;
     /**
-     * gRPC port for GetWorkerStatus.
+     * Per-engine gRPC port for worker control RPCs, including GetWorkerStatus and GetCacheStatus.
      */
     private final int workerStatusPort;
+    /**
+     * Logical engine index behind the shared frontend.
+     */
+    private final int engineIndex;
+    /**
+     * Expected number of logical engines for this physical frontend.
+     */
+    private final int multiEngineNum;
+    /**
+     * Canonical identity for this logical worker. It precomputes the physical frontend
+     * identity ({@code ip:port}), routable/cache identity ({@code ip:port@engineIndex}), and
+     * legacy short identity ({@code ip@engineIndex}); callers use the corresponding semantic getters
+     * exposed by {@link WorkerHost}.
+     */
+    @Getter(AccessLevel.NONE)
+    private final WorkerIdentity workerIdentity;
+    /**
+     * Endpoint configuration address that produced this host.
+     */
+    private final String endpointAddress;
     /**
      * Data center/site information
      */
@@ -68,11 +89,29 @@ public class WorkerHost {
 
     public WorkerHost(String ip, int httpPort, int grpcPort, int httpServerPort, int workerStatusPort,
                       String site, String group, String deploymentName) {
+        this(ip, httpPort, grpcPort, httpServerPort, workerStatusPort,
+                site, group, deploymentName, 0, 1, "");
+    }
+
+    public WorkerHost(String ip, int httpPort, int grpcPort, int httpServerPort, int workerStatusPort,
+                      String site, String group, String deploymentName,
+                      int engineIndex, int multiEngineNum) {
+        this(ip, httpPort, grpcPort, httpServerPort, workerStatusPort,
+                site, group, deploymentName, engineIndex, multiEngineNum, "");
+    }
+
+    public WorkerHost(String ip, int httpPort, int grpcPort, int httpServerPort, int workerStatusPort,
+                      String site, String group, String deploymentName,
+                      int engineIndex, int multiEngineNum, String endpointAddress) {
         this.ip = ip;
         this.httpPort = httpPort;
         this.grpcPort = grpcPort;
         this.httpServerPort = httpServerPort;
         this.workerStatusPort = workerStatusPort;
+        this.engineIndex = engineIndex;
+        this.multiEngineNum = multiEngineNum;
+        this.workerIdentity = new WorkerIdentity(ip, httpPort, engineIndex);
+        this.endpointAddress = endpointAddress != null ? endpointAddress : "";
         this.site = site != null ? site : "";
         this.group = group != null ? group : "";
         this.deploymentName = deploymentName != null ? deploymentName : "";
@@ -100,12 +139,34 @@ public class WorkerHost {
     }
 
     /**
-     * Get IP:Port format string
+     * Get the physical frontend address.
      *
-     * @return IP:Port format string
+     * @return physical address in {@code ip:port} format, without an engine index
      */
     public String getIpPort() {
-        return ip + ":" + httpPort;
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    /** Returns the physical frontend address in {@code ip:port} format. */
+    public String getPhysicalIpPort() {
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    /**
+     * Returns the logical worker identity in {@code ip:port@engineIndex} format. The index
+     * identifies one independently routable engine behind the physical frontend.
+     */
+    public String getLogicalIpPort() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    /** Returns the legacy port-free identity in {@code ip@engineIndex} format. */
+    public String getIpIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public String getPhysicalGroupKey() {
+        return endpointAddress + "|" + group + "|" + getPhysicalIpPort();
     }
 
     /**

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerIdentity.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerIdentity.java
@@ -1,0 +1,52 @@
+package org.flexlb.dao.master;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import static org.flexlb.constant.CommonConstants.LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR;
+
+/**
+ * Immutable worker identity with all commonly used address representations precomputed.
+ *
+ * <ul>
+ *   <li>{@code ip}: raw host IP</li>
+ *   <li>{@code port}: raw shared frontend port</li>
+ *   <li>{@code engineIndex}: raw logical engine index</li>
+ *   <li>{@code physicalIpPort}: {@code ip:port}, identifying the shared frontend</li>
+ *   <li>{@code logicalIpPort}: {@code ip:port@engineIndex}, used by routing and cache matching</li>
+ *   <li>{@code ipIndex}: legacy short form {@code ip@engineIndex}</li>
+ *   <li>{@code logicalIpPort}: {@code ip:port@engineIndex}, used by per-engine metrics</li>
+ * </ul>
+ */
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class WorkerIdentity {
+
+    /** Raw host IP, without a port or engine index. */
+    private final String ip;
+    /** Raw shared frontend port. */
+    private final int port;
+    /** Raw logical engine index behind the shared frontend. */
+    private final int engineIndex;
+    /** Shared physical frontend identity in {@code ip:port} format. */
+    private final String physicalIpPort;
+    /** Routable/cache identity in {@code ip:port@engineIndex} format. */
+    private final String logicalIpPort;
+    /** Legacy short per-engine identity in {@code ip@engineIndex} format. */
+    private final String ipIndex;
+
+    public WorkerIdentity(String ip, int port, int engineIndex) {
+        this.ip = ip;
+        this.port = port;
+        this.engineIndex = engineIndex;
+        this.physicalIpPort = ip == null ? null : ip + ":" + port;
+        this.logicalIpPort = physicalIpPort == null
+                ? null
+                : physicalIpPort + LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR + engineIndex;
+        this.ipIndex = ip == null
+                ? null
+                : ip + LOGICAL_WORKER_ENGINE_INDEX_SEPARATOR + engineIndex;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerStatus.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/master/WorkerStatus.java
@@ -52,7 +52,10 @@ public class WorkerStatus {
             int port,
             int grpcPort,
             String site,
-            String deploymentName) {
+            String deploymentName,
+            String physicalGroupKey,
+            int engineIndex,
+            int multiEngineNum) {
 
         public TopologySnapshot(
                 String group,
@@ -60,7 +63,8 @@ public class WorkerStatus {
                 int port,
                 int grpcPort,
                 String site) {
-            this(group, ip, port, grpcPort, site, null);
+            this(group, ip, port, grpcPort, site, null,
+                    defaultPhysicalGroupKey(group, ip, port), 0, 1);
         }
     }
 
@@ -294,6 +298,8 @@ public class WorkerStatus {
 
     private final AtomicReference<TopologySnapshot> topology;
 
+    private final WorkerIdentity workerIdentity;
+
     private final AtomicReference<CommittedWorkerStatus> committedStatus;
 
     private final AtomicReference<PollHealth> pollHealth;
@@ -341,6 +347,8 @@ public class WorkerStatus {
             TopologySnapshot initialTopology,
             EngineObservation initialStatus) {
         topology = new AtomicReference<>(initialTopology);
+        workerIdentity = new WorkerIdentity(
+                initialTopology.ip(), initialTopology.port(), initialTopology.engineIndex());
         committedStatus = new AtomicReference<>(new CommittedWorkerStatus(
                 initialStatus,
                 new AppliedStatusCursor(-1L, -1L)));
@@ -369,15 +377,52 @@ public class WorkerStatus {
             int grpcPort,
             String site,
             String deploymentName) {
+        return createDiscovered(
+                role, group, ip, port, grpcPort, site, deploymentName, 0, 1);
+    }
+
+    public static WorkerStatus createDiscovered(
+            RoleType role,
+            String group,
+            String ip,
+            int port,
+            int grpcPort,
+            String site,
+            String deploymentName,
+            int engineIndex,
+            int multiEngineNum) {
+        return createDiscovered(
+                role, group, ip, port, grpcPort, site, deploymentName,
+                engineIndex, multiEngineNum,
+                defaultPhysicalGroupKey(group, ip, port));
+    }
+
+    public static WorkerStatus createDiscovered(
+            RoleType role,
+            String group,
+            String ip,
+            int port,
+            int grpcPort,
+            String site,
+            String deploymentName,
+            int engineIndex,
+            int multiEngineNum,
+            String physicalGroupKey) {
         Objects.requireNonNull(role, "role");
         Objects.requireNonNull(ip, "ip");
         if (port <= 0 || grpcPort <= 0) {
             throw new IllegalArgumentException(
                     "worker ports must be positive");
         }
+        if (engineIndex < 0 || multiEngineNum <= 0 || engineIndex >= multiEngineNum) {
+            throw new IllegalArgumentException("invalid logical worker index");
+        }
         return new WorkerStatus(
                 new TopologySnapshot(
-                        group, ip, port, grpcPort, site, deploymentName),
+                        group, ip, port, grpcPort, site, deploymentName,
+                        normalizePhysicalGroupKey(
+                                physicalGroupKey, group, ip, port),
+                        engineIndex, multiEngineNum),
                 new EngineObservation(
                         role,
                         null,
@@ -393,6 +438,19 @@ public class WorkerStatus {
                         0L,
                         0L,
                         0L));
+    }
+
+    private static String defaultPhysicalGroupKey(
+            String group, String ip, int port) {
+        return normalizePhysicalGroupKey(null, group, ip, port);
+    }
+
+    private static String normalizePhysicalGroupKey(
+            String physicalGroupKey, String group, String ip, int port) {
+        if (physicalGroupKey != null && !physicalGroupKey.isBlank()) {
+            return physicalGroupKey;
+        }
+        return "|" + (group == null ? "" : group) + "|" + ip + ":" + port;
     }
 
     @JsonIgnore
@@ -620,7 +678,10 @@ public class WorkerStatus {
                 current.port(),
                 current.grpcPort(),
                 site,
-                deploymentName));
+                deploymentName,
+                current.physicalGroupKey(),
+                current.engineIndex(),
+                current.multiEngineNum()));
     }
 
     public RoleType getRole() {
@@ -645,6 +706,10 @@ public class WorkerStatus {
 
     public String getDeploymentName() {
         return topology.get().deploymentName();
+    }
+
+    public String getPhysicalGroupKey() {
+        return topology.get().physicalGroupKey();
     }
 
     public String getSite() {
@@ -789,11 +854,31 @@ public class WorkerStatus {
 
     /** Get the HTTP IP:PORT address. */
     public String getIpPort() {
-        TopologySnapshot current = topology.get();
-        if (current.ip() == null) {
-            return null;
-        }
-        return current.ip() + ":" + current.port();
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    public WorkerIdentity getWorkerIdentity() {
+        return workerIdentity;
+    }
+
+    public String getPhysicalIpPort() {
+        return workerIdentity.getPhysicalIpPort();
+    }
+
+    public String getLogicalIpPort() {
+        return workerIdentity.getLogicalIpPort();
+    }
+
+    public String getIpIndex() {
+        return workerIdentity.getIpIndex();
+    }
+
+    public int getEngineIndex() {
+        return workerIdentity.getEngineIndex();
+    }
+
+    public int getMultiEngineNum() {
+        return topology.get().multiEngineNum();
     }
 
     private static Map<String, TaskObservation> freezeTaskMap(

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/pv/ShortestTtftDecision.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/pv/ShortestTtftDecision.java
@@ -31,6 +31,8 @@ public record ShortestTtftDecision(
 
     /**
      * Cache-affinity-specific inputs for one routing decision. Null for other TTFT strategies.
+     * Both worker fields use logical {@code ip:port@engineIndex} identities so different engines
+     * behind the same physical frontend remain distinguishable.
      */
     public record CacheAffinityDecision(
             String cacheLeaderIpPort,

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/route/Endpoint.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/route/Endpoint.java
@@ -18,8 +18,23 @@ public class Endpoint {
     @JsonProperty("path")
     private String path;
 
+    /**
+     * Base TCP port of the per-engine worker-control gRPC endpoint. Engine with index i exposes
+     * its worker status and cache status RPCs at {@code workerStatusPort + i}. Required when
+     * {@code multiEngineNum > 1}; when unset for a single engine, discovery falls back to
+     * the engine gRPC port. Validated at config load against the port range.
+     */
     @JsonProperty("worker_status_port")
     private Integer workerStatusPort;
+
+    /**
+     * Number of engine processes sharing this physical endpoint (DS_LLM_MULTI_ENGINE_NUM).
+     * Service discovery expands one endpoint into this many logical workers, each identified
+     * by an engine index in {@code [0, multiEngineNum)} and its own worker status port.
+     * Defaults to 1 for single-engine deployments.
+     */
+    @JsonProperty("multi_engine_num")
+    private int multiEngineNum = 1;
 
     @JsonProperty("discovery")
     private DiscoveryConfig discovery;

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/discovery/RoutingServiceDiscovery.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/discovery/RoutingServiceDiscovery.java
@@ -117,23 +117,29 @@ public class RoutingServiceDiscovery implements ServiceDiscovery {
 
         boolean grpcEndpoint = BackendServiceProtocolEnum.GRPC.getName()
                 .equals(endpoint.getProtocol());
-        List<WorkerHost> normalizedHosts = new ArrayList<>(discoveredHosts.size());
+        int multiEngineNum = endpoint.getMultiEngineNum();
+        List<WorkerHost> normalizedHosts = new ArrayList<>(discoveredHosts.size() * multiEngineNum);
         for (WorkerHost host : discoveredHosts) {
             int discoveredPort = host.getPort();
             int httpPort = grpcEndpoint ? discoveredPort - 1 : discoveredPort;
             int grpcPort = grpcEndpoint ? discoveredPort : discoveredPort + 1;
-            int workerStatusPort = endpoint.getWorkerStatusPort() == null
+            int workerStatusBasePort = endpoint.getWorkerStatusPort() == null
                     ? grpcPort
                     : endpoint.getWorkerStatusPort();
-            normalizedHosts.add(new WorkerHost(
-                    host.getIp(),
-                    httpPort,
-                    grpcPort,
-                    httpPort + 5,
-                    workerStatusPort,
-                    host.getSite(),
-                    endpoint.getGroup(),
-                    host.getDeploymentName()));
+            for (int engineIndex = 0; engineIndex < multiEngineNum; engineIndex++) {
+                normalizedHosts.add(new WorkerHost(
+                        host.getIp(),
+                        httpPort,
+                        grpcPort,
+                        httpPort + 5,
+                        workerStatusBasePort + engineIndex,
+                        host.getSite(),
+                        endpoint.getGroup(),
+                        host.getDeploymentName(),
+                        engineIndex,
+                        multiEngineNum,
+                        endpoint.getAddress()));
+            }
         }
         return normalizedHosts;
     }

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/config/ModelServiceConfigurationTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/config/ModelServiceConfigurationTest.java
@@ -5,6 +5,8 @@ import org.flexlb.dao.route.ServiceRoute;
 import org.flexlb.discovery.ServiceDiscoveryType;
 import org.flexlb.util.JsonUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +50,70 @@ class ModelServiceConfigurationTest {
                     assertThat(endpoint.getDiscovery().getHosts())
                             .containsExactly("127.0.0.1:8080");
                     assertThat(endpoint.getWorkerStatusPort()).isEqualTo(18002);
+                    assertThat(endpoint.getMultiEngineNum()).isEqualTo(1);
                 });
+    }
+
+    @Test
+    void loadsMultiEngineEndpointConfiguration() {
+        withModelConfig(staticModelConfig().replace(
+                "\"worker_status_port\":18002,",
+                "\"worker_status_port\":18002,\"multi_engine_num\":2,"))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    var endpoint = context.getBean(ModelMetaConfig.class)
+                            .getServiceRoute("test-service")
+                            .getAllEndpoints()
+                            .getFirst();
+                    assertThat(endpoint.getMultiEngineNum()).isEqualTo(2);
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void rejectsNonPositiveMultiEngineCount(int multiEngineNum) {
+        assertEndpointRejected(
+                "\"worker_status_port\":18002,\"multi_engine_num\":" + multiEngineNum + ",",
+                "MODEL_SERVICE_CONFIG endpoint multi_engine_num must be greater than zero: service-a");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 65_536})
+    void rejectsWorkerStatusPortOutsideTcpRange(int workerStatusPort) {
+        assertEndpointRejected(
+                "\"worker_status_port\":" + workerStatusPort + ",",
+                "MODEL_SERVICE_CONFIG endpoint worker_status_port must be between 1 and 65535: service-a");
+    }
+
+    @Test
+    void acceptsMultiEngineWorkerStatusPortRangeEndingAtMaximumTcpPort() {
+        String config = staticModelConfig().replace(
+                "\"worker_status_port\":18002,",
+                "\"worker_status_port\":65534,\"multi_engine_num\":2,");
+
+        withModelConfig(config).run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    void rejectsMultiEngineEndpointWithoutWorkerStatusPort() {
+        String config = staticModelConfig()
+                .replace("\"worker_status_port\":18002,", "\"multi_engine_num\":2,");
+
+        withModelConfig(config)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseMessage(
+                                    "MODEL_SERVICE_CONFIG endpoint worker_status_port must be configured "
+                                            + "when multi_engine_num is greater than one: service-a");
+                });
+    }
+
+    @Test
+    void rejectsMultiEngineWorkerStatusPortOverflow() {
+        assertEndpointRejected(
+                "\"worker_status_port\":65535,\"multi_engine_num\":2,",
+                "MODEL_SERVICE_CONFIG endpoint worker_status_port range exceeds 65535: service-a");
     }
 
     @Test
@@ -164,6 +229,15 @@ class ModelServiceConfigurationTest {
 
     private void assertOptimizerRejected(String optimizerConfig, String message) {
         withModelConfig(modelConfig(optimizerConfig))
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).hasRootCauseMessage(message);
+                });
+    }
+
+    private void assertEndpointRejected(String endpointFields, String message) {
+        String config = staticModelConfig().replace("\"worker_status_port\":18002,", endpointFields);
+        withModelConfig(config)
                 .run(context -> {
                     assertThat(context).hasFailed();
                     assertThat(context.getStartupFailure()).hasRootCauseMessage(message);

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/loadbalance/ServerStatusTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/loadbalance/ServerStatusTest.java
@@ -1,0 +1,75 @@
+package org.flexlb.dao.loadbalance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServerStatusTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serializesSelectedEngineIndexWithoutChangingPhysicalAddress() {
+        ServerStatus status = new ServerStatus();
+        status.setServerIp("10.0.0.8");
+        status.setHttpPort(8080);
+        status.setGrpcPort(8081);
+        status.setSelectedEngineIndex(1, 2);
+
+        var json = objectMapper.valueToTree(status);
+
+        assertEquals("10.0.0.8", json.get("server_ip").asText());
+        assertEquals(8080, json.get("http_port").asInt());
+        assertEquals(8081, json.get("grpc_port").asInt());
+        assertEquals(1, json.get("engine_index").asInt());
+        assertFalse(json.has("routingEngineIndex"));
+        assertFalse(json.has("logicalIpPort"));
+        assertFalse(json.has("ipIndex"));
+        assertEquals("10.0.0.8:8080@1", status.getLogicalIpPort());
+        assertEquals("10.0.0.8@1", status.getIpIndex());
+    }
+
+    @Test
+    void omitsSingleEngineIndexButKeepsIndexedRoutingIdentity() {
+        ServerStatus status = new ServerStatus();
+        status.setServerIp("10.0.0.8");
+        status.setHttpPort(8080);
+        status.setSelectedEngineIndex(0, 1);
+
+        var json = objectMapper.valueToTree(status);
+
+        assertFalse(json.has("engine_index"));
+        assertFalse(json.has("routingEngineIndex"));
+        assertFalse(json.has("logicalIpPort"));
+        assertEquals("10.0.0.8:8080@0", status.getLogicalIpPort());
+    }
+
+    @Test
+    void serializesIndexZeroWhenItBelongsToAMultiEngineWorker() {
+        ServerStatus status = new ServerStatus();
+        status.setServerIp("10.0.0.8");
+        status.setHttpPort(8080);
+        status.setSelectedEngineIndex(0, 2);
+
+        var json = objectMapper.valueToTree(status);
+
+        assertEquals(0, json.get("engine_index").asInt());
+        assertFalse(json.has("logicalIpPort"));
+        assertEquals("10.0.0.8:8080@0", status.getLogicalIpPort());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"-1,1", "1,1", "0,0", "0,-1"})
+    void rejectsInvalidSelectedEngineIdentity(int engineIndex, int multiEngineNum) {
+        ServerStatus status = new ServerStatus();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> status.setSelectedEngineIndex(engineIndex, multiEngineNum));
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerHostTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerHostTest.java
@@ -1,0 +1,35 @@
+package org.flexlb.dao.master;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WorkerHostTest {
+
+    @Test
+    void exposesItsStoredIdentityRepresentations() {
+        WorkerHost host = new WorkerHost(
+                "10.0.0.8", 8080, 8081, 8085, 18003,
+                "site-a", "group-a", "deployment-a", 1, 2);
+
+        assertEquals("10.0.0.8", host.getIp());
+        assertEquals(8080, host.getPort());
+        assertEquals(1, host.getEngineIndex());
+        assertEquals("10.0.0.8:8080", host.getPhysicalIpPort());
+        assertEquals("10.0.0.8:8080@1", host.getLogicalIpPort());
+        assertEquals("10.0.0.8@1", host.getIpIndex());
+    }
+
+    @Test
+    void exposesMultiEnginePortsAndTopology() {
+        WorkerHost host = new WorkerHost(
+                "10.0.0.8", 8080, 8081, 8085, 18003,
+                "site-a", "group-a", "deployment-a", 1, 2);
+
+        assertEquals(18003, host.getWorkerStatusPort());
+        assertEquals(2, host.getMultiEngineNum());
+        assertEquals("site-a", host.getSite());
+        assertEquals("group-a", host.getGroup());
+        assertEquals("deployment-a", host.getDeploymentName());
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerIdentityTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerIdentityTest.java
@@ -1,0 +1,41 @@
+package org.flexlb.dao.master;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WorkerIdentityTest {
+
+    @Test
+    void storesEveryWorkerIdentityRepresentation() {
+        WorkerIdentity identity = new WorkerIdentity("10.0.0.8", 8080, 1);
+
+        assertEquals("10.0.0.8", identity.getIp());
+        assertEquals(8080, identity.getPort());
+        assertEquals(1, identity.getEngineIndex());
+        assertEquals("10.0.0.8:8080", identity.getPhysicalIpPort());
+        assertEquals("10.0.0.8:8080@1", identity.getLogicalIpPort());
+        assertEquals("10.0.0.8@1", identity.getIpIndex());
+    }
+
+    @Test
+    void leavesDerivedRepresentationsNullUntilIpIsKnown() {
+        WorkerIdentity identity = new WorkerIdentity(null, 8080, 1);
+
+        assertNull(identity.getPhysicalIpPort());
+        assertNull(identity.getLogicalIpPort());
+        assertNull(identity.getIpIndex());
+    }
+
+    @Test
+    void equalsAndHashCodeCompareAllIdentityFields() {
+        WorkerIdentity identity = new WorkerIdentity("10.0.0.8", 8080, 1);
+
+        assertEquals(identity, new WorkerIdentity("10.0.0.8", 8080, 1));
+        assertEquals(identity.hashCode(), new WorkerIdentity("10.0.0.8", 8080, 1).hashCode());
+        assertNotEquals(identity, new WorkerIdentity("10.0.0.8", 8080, 0));
+        assertNotEquals(identity, new WorkerIdentity("10.0.0.9", 8080, 1));
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerStatusTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/dao/master/WorkerStatusTest.java
@@ -44,6 +44,21 @@ class WorkerStatusTest {
                 RoleType.PREFILL, "group-a", "10.0.0.1", 8080, 9090, "site-a");
     }
 
+    @Test
+    @DisplayName("Discovery identity keeps a physical transport address and logical engine key")
+    void discoveredWorkerSeparatesPhysicalAndLogicalIdentity() {
+        WorkerStatus status = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-a", "10.0.0.1", 8080, 9090,
+                "site-a", "deployment-a", 1, 2);
+
+        assertEquals("10.0.0.1:8080", status.getIpPort());
+        assertEquals("10.0.0.1:8080", status.getPhysicalIpPort());
+        assertEquals("10.0.0.1:8080@1", status.getLogicalIpPort());
+        assertEquals("10.0.0.1@1", status.getIpIndex());
+        assertEquals(1, status.getEngineIndex());
+        assertEquals(2, status.getMultiEngineNum());
+    }
+
     /**
      * Run one whole status transaction exactly as the production reducers do:
      * freeze the RPC response, prepare a strictly-newer committed holder under

--- a/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/discovery/RoutingServiceDiscoveryTest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/test/java/org/flexlb/discovery/RoutingServiceDiscoveryTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 class RoutingServiceDiscoveryTest {
 
@@ -48,6 +49,10 @@ class RoutingServiceDiscoveryTest {
         assertEquals("site-a", normalizedHost.getSite());
         assertEquals("group-a", normalizedHost.getGroup());
         assertEquals("deployment-a", normalizedHost.getDeploymentName());
+        assertEquals(0, normalizedHost.getEngineIndex());
+        assertEquals(1, normalizedHost.getMultiEngineNum());
+        assertEquals("10.0.0.1:8080", normalizedHost.getPhysicalIpPort());
+        assertEquals("10.0.0.1:8080@0", normalizedHost.getLogicalIpPort());
     }
 
     @Test
@@ -80,6 +85,29 @@ class RoutingServiceDiscoveryTest {
 
         current.set(runtimeConfig(900));
         assertEquals(900, endpoint.getDiscovery().getConnectTimeoutMs());
+    }
+
+    @Test
+    void expandsDiscoveredHostIntoIndexedLogicalWorkers() {
+        WorkerHost discoveredHost = WorkerHost.of("10.0.0.1", 8080);
+        RecordingProvider provider = new RecordingProvider(List.of(discoveredHost));
+        RoutingServiceDiscovery discovery = new RoutingServiceDiscovery(List.of(provider));
+        Endpoint endpoint = endpoint();
+        endpoint.setProtocol("http");
+        endpoint.setWorkerStatusPort(18002);
+        endpoint.setMultiEngineNum(2);
+
+        List<WorkerHost> hosts = discovery.getHosts(endpoint);
+
+        assertEquals(2, hosts.size());
+        assertIterableEquals(List.of(0, 1), hosts.stream().map(WorkerHost::getEngineIndex).toList());
+        assertIterableEquals(List.of(18002, 18003),
+                hosts.stream().map(WorkerHost::getWorkerStatusPort).toList());
+        assertIterableEquals(List.of("10.0.0.1:8080@0", "10.0.0.1:8080@1"),
+                hosts.stream().map(WorkerHost::getLogicalIpPort).toList());
+        assertIterableEquals(List.of("10.0.0.1:8080", "10.0.0.1:8080"),
+                hosts.stream().map(WorkerHost::getPhysicalIpPort).toList());
+        assertIterableEquals(List.of(2, 2), hosts.stream().map(WorkerHost::getMultiEngineNum).toList());
     }
 
     private Endpoint endpoint() {

--- a/rtp_llm/flexlb/flexlb-grpc/src/main/proto/kvcm_meta_service.proto
+++ b/rtp_llm/flexlb/flexlb-grpc/src/main/proto/kvcm_meta_service.proto
@@ -77,7 +77,9 @@ message GetHostCacheStateRequest {
 }
 
 message HostCacheMatch {
-  string host_ip_port = 1;            // Must match WorkerStatus#getIpPort().
+  // Logical worker identity emitted by the KVCM subscriber: ip:port@engineIndex.
+  // A legacy physical ip:port key is accepted only for an unambiguous N=1 worker.
+  string host_ip_port = 1;
   int64 local = 2;                    // Local continuous prefix matches.
   int64 p2p_1_fetch = 3;              // Local-miss blocks fetched from one remote peer.
   int64 p2p_1_total_match = 4;        // Continuous prefix matches after that P2P fetch.

--- a/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/FlexlbScheduleProtocolTest.java
+++ b/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/FlexlbScheduleProtocolTest.java
@@ -9,8 +9,10 @@ import java.io.ByteArrayOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FlexlbScheduleProtocolTest {
 
@@ -45,6 +47,30 @@ class FlexlbScheduleProtocolTest {
         assertEquals(Descriptors.FieldDescriptor.Type.STRING,
                 EngineRpcService.WorkerStatusPB.getDescriptor().findFieldByNumber(1).getType());
         assertNull(FlexlbScheduleProtocol.FlexlbServerStatusPB.getDescriptor().findFieldByNumber(5));
+    }
+
+    @Test
+    void engineIndexDistinguishesAbsentFromExplicitZeroOnTheWire() throws Exception {
+        var descriptor = FlexlbScheduleProtocol.FlexlbServerStatusPB.getDescriptor();
+        var field = descriptor.findFieldByName("engine_index");
+        assertNotNull(field);
+        assertEquals(6, field.getNumber());
+        assertEquals(Descriptors.FieldDescriptor.Type.INT32, field.getType());
+        assertTrue(field.hasPresence());
+        assertNull(descriptor.findFieldByNumber(5));
+
+        var absent = FlexlbScheduleProtocol.FlexlbServerStatusPB.parseFrom(new byte[0]);
+        assertFalse(absent.hasField(field));
+        for (int index : new int[]{0, 1}) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            CodedOutputStream coded = CodedOutputStream.newInstance(output);
+            coded.writeInt32(6, index);
+            coded.flush();
+            var parsed = FlexlbScheduleProtocol.FlexlbServerStatusPB.parseFrom(output.toByteArray());
+            assertTrue(parsed.hasField(field));
+            assertEquals(index, parsed.getField(field));
+            assertArrayEquals(output.toByteArray(), parsed.toByteArray());
+        }
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/client/KvcmGrpcClientTest.java
+++ b/rtp_llm/flexlb/flexlb-grpc/src/test/java/org/flexlb/engine/grpc/client/KvcmGrpcClientTest.java
@@ -37,7 +37,7 @@ class KvcmGrpcClientTest {
     }
 
     @Test
-    void returnsP2pAwareMatches() {
+    void preservesLogicalWorkerIdentitiesInP2pAwareMatches() {
         CacheMatchConfiguration configuration = mock(CacheMatchConfiguration.class);
         KvcmConfig config = new KvcmConfig();
         KvcmCacheMatchingConfig runtimeConfig = new KvcmCacheMatchingConfig();
@@ -60,7 +60,7 @@ class KvcmGrpcClientTest {
                 .thenReturn(GetHostCacheStateResponse.newBuilder()
                         .setHeader(okHeader())
                         .addHosts(HostCacheMatch.newBuilder()
-                                .setHostIpPort("10.0.0.1:8601")
+                                .setHostIpPort("10.0.0.1:8601@1")
                                 .setLocal(2)
                                 .setP2P1Fetch(8)
                                 .setP2P1TotalMatch(10))
@@ -78,9 +78,9 @@ class KvcmGrpcClientTest {
                         "request-1", List.of(11L, 22L), 2192L,
                         RoleType.PREFILL, "default");
 
-        assertEquals(2, result.get("10.0.0.1:8601").localMatchBlocks());
-        assertEquals(8, result.get("10.0.0.1:8601").p2pFetchBlocks());
-        assertEquals(10, result.get("10.0.0.1:8601").p2pTotalMatchBlocks());
+        assertEquals(2, result.get("10.0.0.1:8601@1").localMatchBlocks());
+        assertEquals(8, result.get("10.0.0.1:8601@1").p2pFetchBlocks());
+        assertEquals(10, result.get("10.0.0.1:8601@1").p2pTotalMatchBlocks());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/delivery/DeliveryMetrics.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/delivery/DeliveryMetrics.java
@@ -87,7 +87,7 @@ public final class DeliveryMetrics {
     }
 
     private static String prefillIp(ScheduledRequest item) {
-        return item.prefillEp().getIp();
+        return item.prefillEp().getStatus().getLogicalIpPort();
     }
 
     private static long saturatedAdd(long left, long right) {

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/DecodeEndpoint.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/DecodeEndpoint.java
@@ -2952,11 +2952,12 @@ public class DecodeEndpoint extends WorkerEndpoint {
      * Called periodically by {@link org.flexlb.balance.scheduler.RequestScheduler}.
      */
     public void reportBatchMetrics(BatchSchedulerReporter reporter) {
-        reporter.reportInflightRequestCount(RoleType.DECODE.name(), getIp(), getInflightCount());
-        reporter.reportDecodeTotalLoad(getIp(), getTotalLoad());
-        reporter.reportDecodeInflightKvReserved(getIp(), inflightKvReserved());
-        reporter.reportDecodeInflightHardKvReserved(getIp(), inflightHardKvReserved());
-        reporter.reportInflightMaxAgeMs(RoleType.DECODE.name(), getIp(),
+        String engineIp = getStatus().getLogicalIpPort();
+        reporter.reportInflightRequestCount(RoleType.DECODE.name(), engineIp, getInflightCount());
+        reporter.reportDecodeTotalLoad(engineIp, getTotalLoad());
+        reporter.reportDecodeInflightKvReserved(engineIp, inflightKvReserved());
+        reporter.reportDecodeInflightHardKvReserved(engineIp, inflightHardKvReserved());
+        reporter.reportInflightMaxAgeMs(RoleType.DECODE.name(), engineIp,
                 inflightMaxAgeMs(System.currentTimeMillis()));
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/EndpointRegistry.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/EndpointRegistry.java
@@ -771,10 +771,10 @@ public class EndpointRegistry {
 
     private void prepareEndpointMetrics(RoleType roleType, WorkerStatus status) {
         try {
-            reporter.prepareEndpointMetrics(roleType.name(), status.getIp());
+            reporter.prepareEndpointMetrics(roleType.name(), status.getLogicalIpPort());
         } catch (RuntimeException telemetryFailure) {
             Logger.warn("Endpoint metric preparation failed: role={}, engine={}",
-                    roleType, status.getIp(), telemetryFailure);
+                    roleType, status.getLogicalIpPort(), telemetryFailure);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/PrefillEndpoint.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/PrefillEndpoint.java
@@ -100,7 +100,7 @@ public class PrefillEndpoint extends WorkerEndpoint {
         this.maximumDirectRequests = configuredLimit == null ? 0 : configuredLimit;
         this.predictor = createPredictor(config);
         this.runtime = new WorkerBatcher(
-                status.getIpPort(), this, config,
+                status.getLogicalIpPort(), this, config,
                 deliveryStrategy, endpointEvents);
         this.prefillState = runtime.ownedState();
     }
@@ -566,23 +566,24 @@ public class PrefillEndpoint extends WorkerEndpoint {
      * Called periodically by {@link org.flexlb.balance.scheduler.RequestScheduler}.
      */
     public void reportBatchMetrics(BatchSchedulerReporter reporter) {
+        String engineIp = getStatus().getLogicalIpPort();
         int queueSize = runtime.queueSize();
-        reporter.reportBatcherQueueSize(RoleType.PREFILL.name(), getIp(), queueSize);
+        reporter.reportBatcherQueueSize(RoleType.PREFILL.name(), engineIp, queueSize);
         // Priority-bucketed batch queue length — single-report with priority tag.
         // Empty queue fallback: report priority=0 depth=0 so tagged panels don't gap.
         Map<Integer, Integer> sizeByPriority =
                 runtime.queueSizeByPriority();
         if (sizeByPriority.isEmpty()) {
-            reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), getIp(), 0, 0);
+            reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), engineIp, 0, 0);
         } else {
             sizeByPriority.forEach((priority, size) ->
-                    reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), getIp(), priority, size));
+                    reporter.reportBatcherQueueDepthByPriority(RoleType.PREFILL.name(), engineIp, priority, size));
         }
-        reporter.reportInflightBatchCount(RoleType.PREFILL.name(), getIp(), getInflightBatchCount());
-        reporter.reportInflightRequestCount(RoleType.PREFILL.name(), getIp(), getLocallyOwnedRequestCount());
+        reporter.reportInflightBatchCount(RoleType.PREFILL.name(), engineIp, getInflightBatchCount());
+        reporter.reportInflightRequestCount(RoleType.PREFILL.name(), engineIp, getLocallyOwnedRequestCount());
         reporter.reportInflightMaxAgeMs(
                 RoleType.PREFILL.name(),
-                getIp(),
+                engineIp,
                 prefillState.stats().maxObservedAgeMs());
     }
 
@@ -633,19 +634,22 @@ public class PrefillEndpoint extends WorkerEndpoint {
         // a metrics outage cannot suppress the scheduler's WorkerStatus
         // reducer or prevent the remaining observations.
         try {
-            reporter.reportBatchPredictedTimeMs(RoleType.PREFILL.name(), getIp(), predictedMs);
+            reporter.reportBatchPredictedTimeMs(
+                    RoleType.PREFILL.name(), getStatus().getLogicalIpPort(), predictedMs);
         } catch (RuntimeException telemetryFailure) {
             logger.warn("batch predicted-time metric failed: batchId={} engine={}",
                     batchId, getIp(), telemetryFailure);
         }
         try {
-            reporter.reportBatchActualTimeMs(RoleType.PREFILL.name(), getIp(), actualMs);
+            reporter.reportBatchActualTimeMs(
+                    RoleType.PREFILL.name(), getStatus().getLogicalIpPort(), actualMs);
         } catch (RuntimeException telemetryFailure) {
             logger.warn("batch actual-time metric failed: batchId={} engine={}",
                     batchId, getIp(), telemetryFailure);
         }
         try {
-            reporter.reportBatchPredictGapMs(RoleType.PREFILL.name(), getIp(), gapMs);
+            reporter.reportBatchPredictGapMs(
+                    RoleType.PREFILL.name(), getStatus().getLogicalIpPort(), gapMs);
         } catch (RuntimeException telemetryFailure) {
             logger.warn("batch prediction-gap metric failed: batchId={} engine={}",
                     batchId, getIp(), telemetryFailure);

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/WorkerEndpoint.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/endpoint/WorkerEndpoint.java
@@ -56,7 +56,7 @@ public class WorkerEndpoint {
     // ==================== identity (delegated to status) ====================
 
     public String ipPort() {
-        return status.getIpPort();
+        return status.getLogicalIpPort();
     }
 
     public String getIp() {

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/eviction/EvictionManager.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/eviction/EvictionManager.java
@@ -481,7 +481,7 @@ public class EvictionManager {
         try {
             deliveryReporter.reportRouteSubmitTimeMs(
                     org.flexlb.dao.route.RoleType.PREFILL.name(),
-                    item.prefillEp().getIp(),
+                    item.prefillEp().ipPort(),
                     System.currentTimeMillis() - context.getStartTime());
         } catch (RuntimeException telemetryFailure) {
             Logger.warn(

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/BatchDeliveryStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/BatchDeliveryStrategy.java
@@ -81,9 +81,7 @@ public final class BatchDeliveryStrategy implements DeliveryStrategy {
         ScheduledRequest head = candidates.get(0);
 
         CapacityBoundary.Attempt<BatchTransaction> groupAttempt =
-                requests.prepareIfOwned(head, () -> prepareAdmission(head))
-                        .orElseGet(() -> BatchDeliveryStrategy
-                                .<BatchTransaction>ownershipLost());
+                prepareHeadAdmission(head);
         if (!groupAttempt.accepted()) {
             return BatchTransaction.blocked(
                     this,
@@ -191,6 +189,23 @@ public final class BatchDeliveryStrategy implements DeliveryStrategy {
         } catch (Throwable failure) {
             return failed(failure);
         }
+    }
+
+    private CapacityBoundary.Attempt<BatchTransaction> prepareHeadAdmission(
+            ScheduledRequest head) {
+        if (requests.prepareIfOwned(head, () -> Boolean.TRUE).isEmpty()) {
+            return ownershipLost();
+        }
+        CapacityBoundary.Attempt<BatchTransaction> attempt =
+                prepareAdmission(head);
+        if (!attempt.accepted()) {
+            return attempt;
+        }
+        if (requests.prepareIfOwned(head, () -> Boolean.TRUE).isPresent()) {
+            return attempt;
+        }
+        Throwable cleanup = close(attempt.value());
+        return cleanup == null ? ownershipLost() : failed(cleanup);
     }
 
     @Override

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/GlobalQueueCoordinator.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/GlobalQueueCoordinator.java
@@ -639,7 +639,7 @@ final class GlobalQueueCoordinator implements AutoCloseable {
         try {
             reporter.reportRouteSubmitTimeMs(
                     item.prefill().getRole().name(),
-                    item.prefillEp().getIp(),
+                    item.prefillEp().ipPort(),
                     System.currentTimeMillis() - context.getStartTime());
         } catch (Throwable failure) {
             Logger.warn("Failed to record route-submit telemetry", failure);

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/RequestRegistry.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/scheduler/RequestRegistry.java
@@ -2535,6 +2535,9 @@ public class RequestRegistry {
         status.setHttpPort(src.getHttpPort());
         status.setGrpcPort(src.getGrpcPort());
         status.setDpRank(src.getDpRank());
+        status.setSelectedEngineIndex(
+                src.getRoutingEngineIndex(),
+                src.getRoutingMultiEngineNum());
         status.setPrefillTime(src.getPrefillTime());
         status.setGroup(src.getGroup());
         status.setDebugInfo(copyOf(src.getDebugInfo()));

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedDecodeStrategy.java
@@ -101,6 +101,10 @@ public class CostBasedDecodeStrategy {
             WorkerEndpoint.GenerationPin pin =
                     workerDirectory.captureDecodeGeneration(selected);
             if (pin != null) {
+                if (!workerDirectory.isPhysicalGroupHealthy(pin.endpoint())) {
+                    pin.close();
+                    continue;
+                }
                 return PlacementResult.success(buildSelectedRole(
                         selected, pin, roleType, balanceContext));
             }
@@ -476,6 +480,8 @@ public class CostBasedDecodeStrategy {
             result.setDpRank(status.dpRank());
             result.setGroup(topology.group());
             result.setRequestId(balanceContext.getRequestId());
+            result.setSelectedEngineIndex(
+                    topology.engineIndex(), topology.multiEngineNum());
 
             // SelectedRole consumes the pin even if its validation rejects.
             WorkerEndpoint.GenerationPin factoryPin = selectedPin;
@@ -630,4 +636,5 @@ public class CostBasedDecodeStrategy {
                     tierCounts, capacity);
         }
     }
+
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/CostBasedPrefillStrategy.java
@@ -129,7 +129,8 @@ public class CostBasedPrefillStrategy {
                 workerDirectory.captureEndpoint(
                         roleType,
                         survivors.endpointAddress(selectedIndex));
-        if (selectedPin == null || selectedPin.endpoint() != best) {
+        if (selectedPin == null || selectedPin.endpoint() != best
+                || !workerDirectory.isPhysicalGroupHealthy(best)) {
             if (selectedPin != null) {
                 selectedPin.close();
             }
@@ -156,7 +157,8 @@ public class CostBasedPrefillStrategy {
                 config,
                 selectedTtft,
                 selectedPrefillMs);
-        reportCacheHitMetrics(roleType, bestCacheHit, seqLen);
+        reportCacheHitMetrics(
+                roleType, best.getStatus().getLogicalIpPort(), bestCacheHit, seqLen);
         reportRoutingCacheMatchMetrics(
                 roleType,
                 survivors.routingCacheMatchTokens(selectedIndex),
@@ -279,7 +281,7 @@ public class CostBasedPrefillStrategy {
 
         if (selectedIndex >= 0 && cacheAffinity != null) {
             reportCacheAffinityDecision(
-                    roleType, survivors.endpoint(selectedIndex).getIp(),
+                    roleType, survivors.endpoint(selectedIndex).getStatus().getLogicalIpPort(),
                     affinityReason);
             if (Logger.isDebugEnabled()) {
                 Logger.debug(
@@ -336,7 +338,7 @@ public class CostBasedPrefillStrategy {
                     ? "CACHE_LEADER"
                     : affinityReason;
             reportCacheAffinityDecision(
-                    roleType, candidates.endpoint(selectedIndex).getIp(), reason);
+                    roleType, candidates.endpoint(selectedIndex).getStatus().getLogicalIpPort(), reason);
             if (Logger.isDebugEnabled()) {
                 Logger.debug(
                         "Prefill LRU cache-affinity decision - role: {}, group: {}, "
@@ -554,7 +556,7 @@ public class CostBasedPrefillStrategy {
             String endpointAddress = routingEntry.address();
             CacheTokenMatch cacheMatch =
                     calculateCacheMatch(
-                            ep, endpointAddress, cacheMatchResult, request, config);
+                            ep, cacheMatchResult, request, config);
             long cacheHit = cacheMatch.effectiveHitTokens();
             long routingCacheMatchTokens = cacheMatch.routingHitTokens();
             RouteProjection.Inputs projectionInputs =
@@ -825,7 +827,6 @@ public class CostBasedPrefillStrategy {
 
     private CacheTokenMatch calculateCacheMatch(
             PrefillEndpoint ep,
-            String endpointAddress,
             CacheMatchResult cacheMatchResult,
             Request request,
             FlexlbConfig config) {
@@ -836,7 +837,7 @@ public class CostBasedPrefillStrategy {
         if (seqLen <= 0L) {
             return CacheTokenMatch.NONE;
         }
-        HostCacheMatch match = cacheMatchResult.hostMatch(endpointAddress);
+        HostCacheMatch match = cacheMatchResult.hostMatch(ep.getStatus());
         if (match == null) {
             return CacheTokenMatch.NONE;
         }
@@ -878,9 +879,10 @@ public class CostBasedPrefillStrategy {
         return new CacheTokenMatch(effectiveHit, routingHit);
     }
 
-    private void reportCacheHitMetrics(RoleType roleType, long hitCacheTokens, long seqLen) {
+    private void reportCacheHitMetrics(
+            RoleType roleType, String ipIndex, long hitCacheTokens, long seqLen) {
         double hitRate = seqLen > 0 ? hitCacheTokens / (double) seqLen : 0.0;
-        engineHealthReporter.reportCacheHitMetrics(roleType, hitCacheTokens, hitRate);
+        engineHealthReporter.reportCacheHitMetrics(roleType, ipIndex, hitCacheTokens, hitRate);
     }
 
     /**
@@ -901,7 +903,7 @@ public class CostBasedPrefillStrategy {
         try {
             engineHealthReporter.reportPrefillSelectedEstimates(
                     roleType,
-                    endpoint.getIp(),
+                    endpoint.getStatus().getLogicalIpPort(),
                     deliveryMode,
                     projectedTtftMs.getAsLong(),
                     executionTimeMs);
@@ -961,6 +963,8 @@ public class CostBasedPrefillStrategy {
             result.setDpRank(status.dpRank());
             result.setDebugInfo(debugInfo);
             result.setSuccess(true);
+            result.setSelectedEngineIndex(
+                    topology.engineIndex(), topology.multiEngineNum());
             WorkerEndpoint.GenerationPin ownedPin = selectedPin;
             selectedPin = null;
             return SelectedRole.prefill(

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/RandomStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/RandomStrategy.java
@@ -47,6 +47,9 @@ public final class RandomStrategy {
                 continue;
             }
             try {
+                if (!workerDirectory.isPhysicalGroupHealthy(pin.endpoint())) {
+                    continue;
+                }
                 WorkerStatus status = pin.endpoint().getStatus();
                 WorkerStatus.TopologySnapshot topology =
                         status.topologySnapshot();
@@ -89,6 +92,8 @@ public final class RandomStrategy {
             result.setHttpPort(topology.port());
             result.setGrpcPort(CommonUtils.toGrpcPort(topology.port()));
             result.setDpRank(engine.dpRank());
+            result.setSelectedEngineIndex(
+                    topology.engineIndex(), topology.multiEngineNum());
 
             WorkerEndpoint.GenerationPin owned = pin;
             pin = null;

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/monitor/EngineHealthReporter.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/monitor/EngineHealthReporter.java
@@ -464,20 +464,30 @@ public class EngineHealthReporter {
         monitor.report(CACHE_STATUS_CHECK_FAIL, metricTags, 1.0);
     }
 
+    public void reportCacheStatusCheckerFail(String modelName,
+                                             WorkerStatus workerStatus,
+                                             BalanceStatusEnum errorEnum) {
+        FlexMetricTags metricTags = FlexMetricTags.of(
+                "model", modelName,
+                "engineIp", workerStatus.getLogicalIpPort(),
+                "code", String.valueOf(errorEnum.getCode()),
+                "role", workerStatus.getRole().getCode());
+        monitor.report(CACHE_STATUS_CHECK_FAIL, metricTags, 1.0);
+    }
+
     public void reportStatusCheckerSuccess(String modelName,
                                            WorkerStatus workerStatus,
                                            WorkerEndpoint ep,
                                            int runningTaskInfoSize,
                                            int finishedTaskListSize) {
 
-        WorkerStatus.TopologySnapshot topology = workerStatus.topologySnapshot();
         WorkerStatus.EngineObservation status =
                 workerStatus.committedEngineObservation();
         WorkerStatus.PollHealth pollHealth = workerStatus.pollHealth();
 
         FlexMetricTags metricTags = FlexMetricTags.of(
                 "model", modelName,
-                "engineIp", topology.ip(),
+                "engineIp", workerStatus.getLogicalIpPort(),
                 "role", status.role().name());
 
         Long availableConcurrency = status.availableConcurrency();
@@ -503,14 +513,13 @@ public class EngineHealthReporter {
             String modelName,
             WorkerStatus workerStatus,
             long successfulPollIntervalUs) {
-        WorkerStatus.TopologySnapshot topology = workerStatus.topologySnapshot();
         WorkerStatus.EngineObservation status =
                 workerStatus.committedEngineObservation();
         CacheStatus cacheStatus = workerStatus.getCacheStatus();
         if (successfulPollIntervalUs > 0L) {
             FlexMetricTags metricTags = FlexMetricTags.of(
                     "model", modelName,
-                    "engineIp", topology.ip(),
+                    "engineIp", workerStatus.getLogicalIpPort(),
                     "role", status.role().name());
             monitor.report(
                     CACHE_STATUS_CHECK_SUCCESS_PERIOD,
@@ -525,7 +534,7 @@ public class EngineHealthReporter {
                     "role", status.role().name());
             FlexMetricTags engineMetricTags = FlexMetricTags.of(
                     "model", modelName,
-                    "engineIp", topology.ip(),
+                    "engineIp", workerStatus.getLogicalIpPort(),
                     "role", status.role().name());
             monitor.report(CACHE_BLOCK_SIZE, roleMetricTags, blockSize);
             reportLocalStandbyBlockSize(engineMetricTags, blockSize);
@@ -538,7 +547,7 @@ public class EngineHealthReporter {
 
         FlexMetricTags kvCacheMetricTags = FlexMetricTags.of(
                 "model", modelName,
-                "engineIp", topology.ip(),
+                "engineIp", workerStatus.getLogicalIpPort(),
                 "role", status.role().name());
 
         monitor.report(CACHE_USED_KV_CACHE_TOKENS, kvCacheMetricTags, usedKvCacheTokens);
@@ -588,7 +597,7 @@ public class EngineHealthReporter {
                     FlexMetricTags serverSelectionTags = FlexMetricTags.of(
                             "role", serverStatus.getRole().name(),
                             "strategy", strategyName(ctx, serverStatus.getRole()),
-                            "engineIp", serverStatus.getServerIp(),
+                            "engineIp", serverStatus.getLogicalIpPort(),
                             "success", String.valueOf(isSuccess),
                             "code", String.valueOf(code)
                     );
@@ -680,8 +689,9 @@ public class EngineHealthReporter {
         monitor.report(org.flexlb.constant.MetricConstant.ENGINE_BALANCING_EVENT_LOOP_GROUP_INFO, FlexMetricTags.of(metricMap), totalPendingTask);
     }
 
-    public void reportCacheHitMetrics(RoleType roleType, long hitTokens, double hitRatio) {
-        cacheMetricsReporter.reportCacheHitMetrics(roleType, hitTokens, hitRatio);
+    public void reportCacheHitMetrics(
+            RoleType roleType, String ipIndex, long hitTokens, double hitRatio) {
+        cacheMetricsReporter.reportCacheHitMetrics(roleType, ipIndex, hitTokens, hitRatio);
     }
 
     /**

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/EngineSyncRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/EngineSyncRunner.java
@@ -12,7 +12,6 @@ import org.flexlb.service.address.WorkerAddressService;
 import org.flexlb.service.grpc.EngineGrpcService;
 import org.flexlb.service.monitor.EngineHealthReporter;
 import org.flexlb.sync.status.WorkerDirectory;
-import org.flexlb.util.CommonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -128,7 +127,9 @@ public class EngineSyncRunner implements Runnable {
         logger.debug("EngineSyncRunner start for model: {}, role: {}", modelName, roleType.toString());
         try {
             long startTimeInUs = System.nanoTime() / 1000;
-            List<WorkerHost> latestEngineWorkerList = workerAddressService.getEngineWorkerList(modelName, roleType);
+            List<WorkerHost> latestEngineWorkerList =
+                    workerAddressService.getEngineWorkerList(
+                            modelName, roleType);
             logger.debug("workerAddressService getEngineWorkerList, model: {}, role: {}, size: {}", modelName, roleType, latestEngineWorkerList.size());
             engineHealthReporter.reportServiceDiscoveryResult(modelName, latestEngineWorkerList.size(), roleType.toString());
             if (CollectionUtils.isEmpty(latestEngineWorkerList)) {
@@ -144,7 +145,7 @@ public class EngineSyncRunner implements Runnable {
 
             // Remove if not in latest engine list
             Set<String> latestValidIpPorts = latestEngineWorkerList.stream()
-                    .map(WorkerHost::getIpPort)
+                    .map(WorkerHost::getLogicalIpPort)
                     .collect(Collectors.toSet());
             logger.debug("Current cached worker size: {}, latest worker list size: {}", cachedWorkerStatuses.size(), latestEngineWorkerList.size());
             for (Map.Entry<String, WorkerStatus> entry: cachedWorkerStatuses.entrySet()) {
@@ -164,14 +165,20 @@ public class EngineSyncRunner implements Runnable {
 
             logger.debug("Submitting status check tasks for {} workers", latestEngineWorkerList.size());
             for (WorkerHost host : latestEngineWorkerList) {
-                String workerIpPort = host.getIpPort();
+                String workerIpPort = host.getLogicalIpPort();
                 String site = host.getSite();
 
                 WorkerStatus workerStatus = getOrCreateWorkerStatus(
                         workerIpPort,
                         site,
                         host.getGroup(),
-                        host.getDeploymentName());
+                        host.getDeploymentName(),
+                        host.getIp(),
+                        host.getHttpPort(),
+                        host.getGrpcPort(),
+                        host.getEngineIndex(),
+                        host.getMultiEngineNum(),
+                        host.getPhysicalGroupKey());
 
                 if (!workerStatus.isActiveGeneration()) {
                     logger.debug(
@@ -213,7 +220,8 @@ public class EngineSyncRunner implements Runnable {
                     try {
                         logger.debug("Submitting GrpcCacheStatusCheckRunner for worker: {}, site: {}", workerIpPort, site);
                         GrpcCacheStatusCheckRunner grpcCacheStatusCheckRunner
-                                = new GrpcCacheStatusCheckRunner(modelName, workerIpPort, site, roleType,
+                                = new GrpcCacheStatusCheckRunner(modelName, workerIpPort,
+                                host.getWorkerStatusPort(), site, roleType,
                                 workerStatus, cachePollLease, workerDirectory,
                                 engineHealthReporter, engineGrpcService,
                                 cacheAwareService, cacheIntervalService,
@@ -317,12 +325,20 @@ public class EngineSyncRunner implements Runnable {
             String workerIpPort,
             String site,
             String group,
-            String deploymentName) {
+            String deploymentName,
+            String ip,
+            int port,
+            int grpcPort,
+            int engineIndex,
+            int multiEngineNum,
+            String physicalGroupKey) {
         while (true) {
             WorkerStatus workerStatus = workerDirectory.currentOrDiscover(
                     roleType, workerIpPort,
                     () -> createWorkerStatus(
-                            workerIpPort, site, group, deploymentName));
+                            workerIpPort, site, group, deploymentName,
+                            ip, port, grpcPort, engineIndex, multiEngineNum,
+                            physicalGroupKey));
 
             EndpointRegistry.DetachedGeneration endpointToRetire = null;
             RoleType generationRole = null;
@@ -341,7 +357,9 @@ public class EngineSyncRunner implements Runnable {
                 String currentGroup = workerStatus.getGroup();
                 boolean roleChanged = currentRole != roleType;
                 boolean groupChanged = !Objects.equals(currentGroup, group);
-                if (!roleChanged && !groupChanged) {
+                boolean physicalGroupChanged = !Objects.equals(
+                        workerStatus.getPhysicalGroupKey(), physicalGroupKey);
+                if (!roleChanged && !groupChanged && !physicalGroupChanged) {
                     // Site changes do not change scheduling ownership. Publish
                     // the discovery labels atomically on the same generation.
                     workerStatus.updateDiscoveryLabels(
@@ -384,22 +402,24 @@ public class EngineSyncRunner implements Runnable {
             String workerIpPort,
             String site,
             String group,
-            String deploymentName) {
-        int separator = workerIpPort.lastIndexOf(':');
-        if (separator <= 0 || separator == workerIpPort.length() - 1) {
-            throw new IllegalArgumentException(
-                    "Invalid worker address: " + workerIpPort);
-        }
-        String ip = workerIpPort.substring(0, separator);
-        int port = Integer.parseInt(workerIpPort.substring(separator + 1));
+            String deploymentName,
+            String ip,
+            int port,
+            int grpcPort,
+            int engineIndex,
+            int multiEngineNum,
+            String physicalGroupKey) {
         WorkerStatus discovered = WorkerStatus.createDiscovered(
                 roleType,
                 group,
                 ip,
                 port,
-                CommonUtils.toGrpcPort(port),
+                grpcPort,
                 site,
-                deploymentName);
+                deploymentName,
+                engineIndex,
+                multiEngineNum,
+                physicalGroupKey);
         logger.info("Created WorkerStatus generation {} for worker: {}",
                 discovered.getGenerationId(), workerIpPort);
         return discovered;

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunner.java
@@ -11,7 +11,6 @@ import org.flexlb.service.grpc.EngineGrpcService;
 import org.flexlb.service.grpc.EngineStatusConverter;
 import org.flexlb.service.monitor.EngineHealthReporter;
 import org.flexlb.sync.status.WorkerDirectory;
-import org.flexlb.util.CommonUtils;
 import org.flexlb.util.IdUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,11 +62,32 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
                                       boolean fullSnapshotDebugMode,
                                       Executor callbackExecutor) {
 
+        this(modelName, ipPort, workerStatus.getGrpcPort(), site, roleType,
+                workerStatus, pollLease, workerDirectory, engineHealthReporter,
+                engineGrpcService, cacheAwareService, cacheIntervalService,
+                requestTimeoutMs, syncCount, syncEngineStatusInterval,
+                fullSnapshotDebugMode, callbackExecutor);
+    }
+
+    public GrpcCacheStatusCheckRunner(String modelName, String ipPort, int workerStatusPort,
+                                      String site, RoleType roleType,
+                                      WorkerStatus workerStatus,
+                                      WorkerStatus.PollLease pollLease,
+                                      WorkerDirectory workerDirectory,
+                                      EngineHealthReporter engineHealthReporter,
+                                      EngineGrpcService engineGrpcService,
+                                      CacheAwareService cacheAwareService,
+                                      DynamicCacheIntervalService cacheIntervalService,
+                                      long requestTimeoutMs,
+                                      LongAdder syncCount,
+                                      Long syncEngineStatusInterval,
+                                      boolean fullSnapshotDebugMode,
+                                      Executor callbackExecutor) {
+
         this.ipPort = ipPort;
-        String[] split = ipPort.split(":");
-        this.ip = split[0];
+        this.ip = workerStatus.getIp();
         this.roleType = roleType;
-        this.grpcPort = CommonUtils.toGrpcPort(Integer.parseInt(split[1]));
+        this.grpcPort = workerStatusPort;
         this.modelName = modelName;
         this.workerStatus = workerStatus;
         this.workerDirectory = java.util.Objects.requireNonNull(
@@ -207,13 +227,13 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
             }
 
             engineHealthReporter.reportCacheStatusCheckRemoteInfo(
-                    modelName, roleType.name(), startTime);
+                    modelName, workerStatus.getLogicalIpPort(), roleType.name(), startTime);
             engineHealthReporter.reportCacheStatusCheckerSuccess(
                     modelName, workerStatus, successfulIntervalUs);
         } catch (Throwable e) {
             log("engine cache status check via gRPC exception, msg: " + e.getMessage(), e);
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE);
         }
     }
 
@@ -254,7 +274,7 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
                         "Cache service returned no update result for {}#{}",
                         ipPort, generationId);
                 engineHealthReporter.reportCacheStatusCheckerFail(
-                        modelName, BalanceStatusEnum.CACHE_UPDATE_FAILED, roleType);
+                        modelName, workerStatus, BalanceStatusEnum.CACHE_UPDATE_FAILED);
                 return null;
             }
             if (!result.isSuccess()) {
@@ -265,15 +285,15 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
                         result.getErrorMessage());
                 engineHealthReporter.reportCacheStatusCheckerFail(
                         modelName,
-                        BalanceStatusEnum.CACHE_UPDATE_FAILED,
-                        roleType);
+                        workerStatus,
+                        BalanceStatusEnum.CACHE_UPDATE_FAILED);
             }
             return result;
         } catch (Exception e) {
             logger.debug("Exception to update worker cache for {}#{}: {}",
                     ipPort, generationId, e.getMessage());
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_UPDATE_FAILED, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_UPDATE_FAILED);
             return null;
         }
     }
@@ -309,10 +329,10 @@ public class GrpcCacheStatusCheckRunner implements Runnable {
         // Report specific error based on exception type
         if (ex.getMessage() != null && ex.getMessage().toLowerCase().contains(DEADLINE_EXCEEDED_MESSAGE.toLowerCase())) {
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_GRPC_TIMEOUT, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_GRPC_TIMEOUT);
         } else {
             engineHealthReporter.reportCacheStatusCheckerFail(
-                    modelName, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE, roleType);
+                    modelName, workerStatus, BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcWorkerStatusRunner.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/runner/GrpcWorkerStatusRunner.java
@@ -10,7 +10,6 @@ import org.flexlb.service.grpc.EngineGrpcService;
 import org.flexlb.service.grpc.EngineStatusConverter;
 import org.flexlb.service.monitor.EngineHealthReporter;
 import org.flexlb.sync.status.WorkerDirectory;
-import org.flexlb.util.CommonUtils;
 import org.flexlb.util.IdUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,8 +56,7 @@ public class GrpcWorkerStatusRunner implements Runnable {
                                   CacheAwareService cacheAwareService,
                                   Executor callbackExecutor) {
         this.ipPort = ipPort;
-        String[] split = ipPort.split(":");
-        this.ip = split[0];
+        this.ip = workerStatus.getIp();
         this.workerStatusPort = workerStatusPort;
         this.modelName = modelName;
         this.workerStatus = workerStatus;
@@ -86,15 +84,14 @@ public class GrpcWorkerStatusRunner implements Runnable {
                                   long syncRequestTimeoutMs,
                                   CacheAwareService cacheAwareService,
                                   Executor callbackExecutor) {
-        this(modelName, ipPort, defaultWorkerStatusPort(ipPort), site, roleType,
+        this(modelName, ipPort, defaultWorkerStatusPort(workerStatus), site, roleType,
                 ignoredGroup, workerStatus, pollLease, workerDirectory,
                 engineHealthReporter, engineGrpcService, syncRequestTimeoutMs,
                 cacheAwareService, callbackExecutor);
     }
 
-    private static int defaultWorkerStatusPort(String ipPort) {
-        String[] split = ipPort.split(":");
-        return CommonUtils.toGrpcPort(Integer.parseInt(split[1]));
+    private static int defaultWorkerStatusPort(WorkerStatus workerStatus) {
+        return workerStatus.getGrpcPort();
     }
 
     @Override
@@ -157,7 +154,8 @@ public class GrpcWorkerStatusRunner implements Runnable {
             if (observation == null) {
                 logger.debug("query engine worker status via gRPC, response body is null");
                 engineHealthReporter.reportStatusCheckerFail(
-                        modelName, BalanceStatusEnum.RESPONSE_NULL, roleType);
+                        modelName, BalanceStatusEnum.RESPONSE_NULL,
+                        workerStatus.getLogicalIpPort(), roleType);
                 return;
             }
             if (!workerDirectory.isCurrentStatus(
@@ -302,7 +300,8 @@ public class GrpcWorkerStatusRunner implements Runnable {
             logger.error("Worker status response handling failed after callback for {}",
                     ipPort, e);
             engineHealthReporter.reportStatusCheckerFail(
-                    modelName, BalanceStatusEnum.UNKNOWN_ERROR, roleType);
+                    modelName, BalanceStatusEnum.UNKNOWN_ERROR,
+                    workerStatus.getLogicalIpPort(), roleType);
         }
     }
 
@@ -384,7 +383,8 @@ public class GrpcWorkerStatusRunner implements Runnable {
             WorkerEndpoint endpoint) {
         try {
             engineHealthReporter.reportStatusCheckRemoteInfo(
-                    modelName, observation.role().name(), startTime);
+                    modelName, workerStatus.getLogicalIpPort(),
+                    observation.role().name(), startTime);
             engineHealthReporter.reportStatusCheckerSuccess(
                     modelName,
                     workerStatus,
@@ -434,10 +434,12 @@ public class GrpcWorkerStatusRunner implements Runnable {
         if (ex.getMessage() != null && ex.getMessage().toLowerCase().contains(DEADLINE_EXCEEDED_MESSAGE.toLowerCase())) {
             logger.debug("gRPC worker status check timeout, msg={}, ipPort: {}, rt: {}", ex.getMessage(), ipPort, System.nanoTime() / 1000 - createTimeUs);
             engineHealthReporter.reportStatusCheckerFail(
-                    modelName, BalanceStatusEnum.WORKER_STATUS_GRPC_TIMEOUT, roleType);
+                    modelName, BalanceStatusEnum.WORKER_STATUS_GRPC_TIMEOUT,
+                    workerStatus.getLogicalIpPort(), roleType);
         } else {
             engineHealthReporter.reportStatusCheckerFail(
-                    modelName, BalanceStatusEnum.WORKER_SERVICE_UNAVAILABLE, roleType);
+                    modelName, BalanceStatusEnum.WORKER_SERVICE_UNAVAILABLE,
+                    workerStatus.getLogicalIpPort(), roleType);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/status/WorkerDirectory.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/sync/status/WorkerDirectory.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -89,7 +90,7 @@ public final class WorkerDirectory implements WorkerStatusProvider {
             WorkerStatus discovered = Objects.requireNonNull(
                     discoveredFactory.get(), "discovered status");
             if (discovered.getRole() != role
-                    || !address.equals(discovered.getIpPort())) {
+                    || !address.equals(discovered.getLogicalIpPort())) {
                 throw new IllegalArgumentException(
                         "Discovered WorkerStatus identity does not match directory key");
             }
@@ -237,7 +238,21 @@ public final class WorkerDirectory implements WorkerStatusProvider {
 
     /** Immutable, non-owning address snapshot for lazy selection. */
     public List<String> endpointAddressSnapshot(RoleType role) {
-        return endpointRegistry.endpointAddressSnapshot(role);
+        List<String> addresses = endpointRegistry.endpointAddressSnapshot(role);
+        if (addresses.isEmpty()) {
+            return addresses;
+        }
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(role);
+        List<String> routable = new ArrayList<>(addresses.size());
+        for (String address : addresses) {
+            WorkerEndpoint endpoint = endpointRegistry.get(role, address);
+            if (isPhysicalGroupHealthy(endpoint, physicalHealth)) {
+                routable.add(address);
+            }
+        }
+        return routable.size() == addresses.size()
+                ? addresses : List.copyOf(routable);
     }
 
     /**
@@ -246,7 +261,22 @@ public final class WorkerDirectory implements WorkerStatusProvider {
      */
     public List<EndpointRegistry.PrefillRoutingEntry> prefillRoutingSnapshot(
             RoleType role) {
-        return endpointRegistry.prefillRoutingSnapshot(role);
+        List<EndpointRegistry.PrefillRoutingEntry> entries =
+                endpointRegistry.prefillRoutingSnapshot(role);
+        if (entries.isEmpty()) {
+            return entries;
+        }
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(role);
+        List<EndpointRegistry.PrefillRoutingEntry> routable =
+                new ArrayList<>(entries.size());
+        for (EndpointRegistry.PrefillRoutingEntry entry : entries) {
+            if (isPhysicalGroupHealthy(entry.endpoint(), physicalHealth)) {
+                routable.add(entry);
+            }
+        }
+        return routable.size() == entries.size()
+                ? entries : List.copyOf(routable);
     }
 
     /** Capture one exact currently published endpoint generation by address. */
@@ -263,18 +293,36 @@ public final class WorkerDirectory implements WorkerStatusProvider {
         // group filter is needed.
         List<DecodeEndpoint.DecodeRoutingView> snapshots =
                 endpointRegistry.decodeRoutingSnapshot();
-        if (group == null || snapshots.isEmpty()) {
+        if (snapshots.isEmpty()) {
             return snapshots;
         }
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(RoleType.DECODE);
         ArrayList<DecodeEndpoint.DecodeRoutingView> matching =
                 new ArrayList<>(snapshots.size());
         for (int index = 0; index < snapshots.size(); index++) {
             DecodeEndpoint.DecodeRoutingView snapshot = snapshots.get(index);
-            if (group.equals(snapshot.topology().group())) {
+            WorkerEndpoint endpoint = endpointRegistry.get(
+                    RoleType.DECODE, snapshot.address());
+            if (isPhysicalGroupHealthy(endpoint, physicalHealth)
+                    && (group == null
+                    || group.equals(snapshot.topology().group()))) {
                 matching.add(snapshot);
             }
         }
-        return List.copyOf(matching);
+        return matching.size() == snapshots.size()
+                ? snapshots : List.copyOf(matching);
+    }
+
+    /**
+     * A logical worker behind a shared frontend is routable only when every
+     * expected sibling is currently published and alive. Single-engine RTP-LLM
+     * workers keep their existing one-worker health behavior.
+     */
+    public boolean isPhysicalGroupHealthy(WorkerEndpoint endpoint) {
+        WorkerStatus worker = endpoint == null ? null : endpoint.getStatus();
+        return worker != null && isPhysicalGroupHealthy(
+                endpoint, physicalGroupHealthSnapshot(worker.getRole()));
     }
 
     /** Pin the exact generation represented by a Decode routing snapshot. */
@@ -289,12 +337,15 @@ public final class WorkerDirectory implements WorkerStatusProvider {
         List<WorkerEndpoint.GenerationPin> captured = endpointRegistry.capture(role);
         List<WorkerEndpoint.GenerationPin> matching =
                 new ArrayList<>(captured.size());
+        Map<String, Boolean> physicalHealth =
+                physicalGroupHealthSnapshot(role);
         try {
             for (int index = 0; index < captured.size(); index++) {
                 WorkerEndpoint.GenerationPin pin = captured.get(index);
                 WorkerStatus.TopologySnapshot topology =
                         pin.endpoint().getStatus().topologySnapshot();
-                if (group != null && !group.equals(topology.group())) {
+                if (!isPhysicalGroupHealthy(pin.endpoint(), physicalHealth)
+                        || group != null && !group.equals(topology.group())) {
                     pin.close();
                     captured.set(index, null);
                     continue;
@@ -329,6 +380,72 @@ public final class WorkerDirectory implements WorkerStatusProvider {
             if (pin != null) {
                 pin.close();
             }
+        }
+    }
+
+    private boolean isPhysicalGroupHealthy(
+            WorkerEndpoint endpoint, Map<String, Boolean> physicalHealth) {
+        WorkerStatus worker = endpoint == null ? null : endpoint.getStatus();
+        return worker != null && worker.isAlive()
+                && (worker.getMultiEngineNum() == 1
+                || physicalHealth.getOrDefault(
+                        worker.getPhysicalGroupKey(), false));
+    }
+
+    private Map<String, Boolean> physicalGroupHealthSnapshot(RoleType role) {
+        if (role == null) {
+            return Map.of();
+        }
+        Map<String, WorkerStatus> statuses = statusesByRole.get(role);
+        if (statuses.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, PhysicalGroupHealth> groups = new HashMap<>();
+        for (Map.Entry<String, WorkerStatus> entry : statuses.entrySet()) {
+            WorkerStatus sibling = entry.getValue();
+            groups.computeIfAbsent(
+                    sibling.getPhysicalGroupKey(), ignored ->
+                            new PhysicalGroupHealth())
+                    .observe(
+                            sibling,
+                            endpointRegistry.get(role, entry.getKey(), sibling)
+                                    != null);
+        }
+        Map<String, Boolean> health = new HashMap<>(groups.size());
+        for (Map.Entry<String, PhysicalGroupHealth> entry : groups.entrySet()) {
+            health.put(entry.getKey(), entry.getValue().healthy());
+        }
+        return health;
+    }
+
+    private static final class PhysicalGroupHealth {
+        private int expected = -1;
+        private boolean[] observedIndexes;
+        private int observedCount;
+        private boolean invalid;
+
+        private void observe(WorkerStatus worker, boolean endpointPublished) {
+            int engineCount = worker.getMultiEngineNum();
+            int engineIndex = worker.getEngineIndex();
+            if (expected == -1) {
+                expected = engineCount;
+                observedIndexes = new boolean[Math.max(0, engineCount)];
+            }
+            if (engineCount != expected
+                    || engineIndex < 0
+                    || engineIndex >= expected
+                    || !worker.isAlive()
+                    || !endpointPublished
+                    || observedIndexes[engineIndex]) {
+                invalid = true;
+                return;
+            }
+            observedIndexes[engineIndex] = true;
+            observedCount++;
+        }
+
+        private boolean healthy() {
+            return !invalid && expected > 0 && observedCount == expected;
         }
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointAdmissionTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointAdmissionTest.java
@@ -110,7 +110,7 @@ class DecodeEndpointAdmissionTest {
         }
         exactEndpoint.releaseReservationExact(speculative);
         verify(availability).capacityChanged(
-                RoleType.DECODE, null, "10.0.0.1:8080");
+                RoleType.DECODE, null, "10.0.0.1:8080@0");
 
         DecodeEndpoint.ReservationHandle published;
         try (WorkerEndpoint.GenerationPin pin =
@@ -121,7 +121,7 @@ class DecodeEndpointAdmissionTest {
         }
         exactEndpoint.releaseReservationExact(published);
         verify(availability, times(2)).capacityChanged(
-                RoleType.DECODE, null, "10.0.0.1:8080");
+                RoleType.DECODE, null, "10.0.0.1:8080@0");
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointLayeredViewTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointLayeredViewTest.java
@@ -117,7 +117,7 @@ class DecodeEndpointLayeredViewTest {
 
         endpoint.reportAdmissionMetrics(reporter);
 
-        String endpointKey = "10.0.0.1:8080";
+        String endpointKey = "10.0.0.1:8080@0";
         org.mockito.Mockito.verify(reporter)
                 .reportDecodeReservedCount(endpointKey, 1);
         org.mockito.Mockito.verify(reporter)

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/DecodeEndpointTest.java
@@ -1,10 +1,14 @@
 package org.flexlb.balance.endpoint;
 
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.flexlb.dao.master.TaskInfo;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.master.WorkerStatusResponse;
 import org.flexlb.dao.route.RoleType;
 import org.flexlb.enums.TaskPhase;
+import org.flexlb.metric.MicrometerFlexMonitor;
+import org.flexlb.service.monitor.BatchSchedulerReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +36,50 @@ class DecodeEndpointTest {
                 RoleType.DECODE, "10.0.0.1", 8080, 8081);
         endpoint = new DecodeEndpoint(
                 status, EndpointTestSupport.noopEventSink());
+    }
+
+    @Test
+    void batchMetricsKeepSiblingEngineReservationsSeparate() {
+        WorkerStatus firstStatus = WorkerStatus.createDiscovered(
+                RoleType.DECODE, null, "10.0.0.1", 8080, 8081,
+                null, null, 0, 2);
+        WorkerStatus siblingStatus = WorkerStatus.createDiscovered(
+                RoleType.DECODE, null, "10.0.0.1", 8080, 8081,
+                null, null, 1, 2);
+        DecodeEndpoint first = new DecodeEndpoint(
+                firstStatus, EndpointTestSupport.noopEventSink());
+        DecodeEndpoint sibling = new DecodeEndpoint(
+                siblingStatus, EndpointTestSupport.noopEventSink());
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        try {
+            BatchSchedulerReporter reporter =
+                    new BatchSchedulerReporter(
+                            new MicrometerFlexMonitor(registry));
+            reporter.init();
+            reserve(first, 100L, 500, 500);
+            reserve(sibling, 200L, 300, 300);
+            reserve(sibling, 201L, 400, 400);
+
+            first.reportBatchMetrics(reporter);
+            sibling.reportBatchMetrics(reporter);
+
+            Gauge firstInflight = registry.find("flexlb.app.flexlb.inflight.request.count")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@0").gauge();
+            Gauge secondInflight = registry.find("flexlb.app.flexlb.inflight.request.count")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@1").gauge();
+            assertNotNull(firstInflight, "engine 0 must expose its own inflight gauge");
+            assertNotNull(secondInflight, "engine 1 must expose its own inflight gauge");
+            assertEquals(1.0, firstInflight.value());
+            assertEquals(2.0, secondInflight.value());
+            assertEquals(500.0, registry.get("flexlb.app.flexlb.decode.inflight.kv.reserved.tokens")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@0").gauge().value());
+            assertEquals(700.0, registry.get("flexlb.app.flexlb.decode.inflight.kv.reserved.tokens")
+                    .tags("role", "DECODE", "engineIp", "10.0.0.1:8080@1").gauge().value());
+        } finally {
+            registry.close();
+            first.close();
+            sibling.close();
+        }
     }
 
     @Test
@@ -122,7 +170,7 @@ class DecodeEndpointTest {
 
     @Test
     void ipPort_format() {
-        assertEquals("10.0.0.1:8080", endpoint.ipPort());
+        assertEquals("10.0.0.1:8080@0", endpoint.ipPort());
     }
 
     // ==================== PR-C: getEngineLoad O(1) + queuedPhaseCount drift ===========
@@ -272,13 +320,21 @@ class DecodeEndpointTest {
 
     private DecodeEndpoint.ReservationHandle reserve(
             long requestId, long hardKv, long expectedKv) {
-        try (WorkerEndpoint.GenerationPin pin = endpoint.tryPinGeneration()) {
+        DecodeEndpoint.ReservationHandle reservation =
+                reserve(endpoint, requestId, hardKv, expectedKv);
+        reservations.put(requestId, reservation);
+        return reservation;
+    }
+
+    private static DecodeEndpoint.ReservationHandle reserve(
+            DecodeEndpoint target,
+            long requestId,
+            long hardKv,
+            long expectedKv) {
+        try (WorkerEndpoint.GenerationPin pin = target.tryPinGeneration()) {
             assertNotNull(pin);
-            DecodeEndpoint.ReservationHandle reservation =
-                    endpoint.reservePinned(
-                            pin, Long.toString(requestId), hardKv, expectedKv, 0);
-            reservations.put(requestId, reservation);
-            return reservation;
+            return target.reservePinned(
+                    pin, Long.toString(requestId), hardKv, expectedKv, 0);
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/PrefillEndpointTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/PrefillEndpointTest.java
@@ -327,15 +327,15 @@ class PrefillEndpointTest {
         registerBatch(endpoint, 9L, 100, List.of(createScheduledRequest(9L, 500, 200)));
         doThrow(new IllegalStateException("metrics unavailable"))
                 .when(endpointReporter)
-                .reportBatchPredictedTimeMs("PREFILL", "127.0.0.1", 100);
+                .reportBatchPredictedTimeMs("PREFILL", "127.0.0.1:8080@0", 100);
 
         TaskInfo finished = taskInfo("9", 9L, null, 0, 125);
         assertDoesNotThrow(() -> calibrate(Map.of("9", finished), Map.of()));
 
         assertEquals(0, endpoint.getInflightBatchCount());
         assertEquals(0, endpoint.admissionPendingRequestCount());
-        verify(endpointReporter).reportBatchActualTimeMs("PREFILL", "127.0.0.1", 125);
-        verify(endpointReporter).reportBatchPredictGapMs("PREFILL", "127.0.0.1", 25);
+        verify(endpointReporter).reportBatchActualTimeMs("PREFILL", "127.0.0.1:8080@0", 125);
+        verify(endpointReporter).reportBatchPredictGapMs("PREFILL", "127.0.0.1:8080@0", 25);
     }
 
     @Test
@@ -1219,10 +1219,10 @@ class PrefillEndpointTest {
             slowEndpoint.reportBatchMetrics(reporter);
 
             // Single-report with priority tag (no global untagged series)
-            verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1", 2);
+            verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1:8080@0", 2);
             // Priority buckets on the same routing.queue.length metric
-            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1", 70, 1);
-            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1", 0, 1);
+            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1:8080@0", 70, 1);
+            verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1:8080@0", 0, 1);
         } finally {
             slowEndpoint.close();
         }
@@ -1233,9 +1233,9 @@ class PrefillEndpointTest {
         BatchSchedulerReporter reporter = mock(BatchSchedulerReporter.class);
         endpoint.reportBatchMetrics(reporter);
 
-        verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1", 0);
+        verify(reporter).reportBatcherQueueSize("PREFILL", "127.0.0.1:8080@0", 0);
         // Empty queue fallback: single priority=0 depth=0 report so tagged panels don't gap
-        verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1", 0, 0);
+        verify(reporter).reportBatcherQueueDepthByPriority("PREFILL", "127.0.0.1:8080@0", 0, 0);
     }
 
     // ---- WorkerEndpoint inherited behavior ----

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/WorkerEndpointTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/endpoint/WorkerEndpointTest.java
@@ -186,7 +186,7 @@ class WorkerEndpointTest {
 
     @Test
     void ipPort_format() {
-        assertEquals("10.0.0.1:8080", endpoint.ipPort());
+        assertEquals("10.0.0.1:8080@0", endpoint.ipPort());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/PdfusionSchedulingTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/PdfusionSchedulingTest.java
@@ -102,8 +102,9 @@ class PdfusionSchedulingTest {
         status.setMaxBatchTokensSize(10000L);
         worker.lock.lock();
         try {
-            endpoints.publishPreparedEndpoint(worker.getIpPort(), worker,
+            endpoints.publishPreparedEndpoint(worker.getLogicalIpPort(), worker,
                     worker.prepareNewStatus(worker.freezeStatusResponse(status)));
+            worker.recordSuccessfulPoll(true);
         } finally {
             worker.lock.unlock();
         }
@@ -130,7 +131,8 @@ class PdfusionSchedulingTest {
                     .map(ServerStatus::getRole).toList());
             assertEquals(0, endpoints.getEndpointCount(RoleType.DECODE));
             assertEquals(0, lifecycle.decodeAcceptanceCount());
-            PrefillEndpoint endpoint = (PrefillEndpoint) endpoints.get(RoleType.PDFUSION, worker.getIpPort());
+            PrefillEndpoint endpoint = (PrefillEndpoint) endpoints.get(
+                    RoleType.PDFUSION, worker.getLogicalIpPort());
             assertEquals(1, endpoint.admissionPendingRequestCount());
             var committedWork = endpoint.captureRouteProjectionInputs().work();
             assertTrue(committedWork.containsRequest(Long.toString(requestId)));

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/RequestLifecycleDeliveryLockContractTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/scheduler/RequestLifecycleDeliveryLockContractTest.java
@@ -9,6 +9,7 @@ import org.flexlb.config.ConfigService;
 import org.flexlb.config.FlexlbConfig;
 import org.flexlb.dao.BalanceContext;
 import org.flexlb.dao.loadbalance.Response;
+import org.flexlb.dao.loadbalance.ServerStatus;
 import org.flexlb.service.monitor.BatchSchedulerReporter;
 import org.flexlb.service.monitor.RequestSchedulerReporter;
 import org.junit.jupiter.api.AfterEach;
@@ -135,6 +136,20 @@ class RequestLifecycleDeliveryLockContractTest {
                     return true;
                 }));
         assertFalse(publicationCalled[0]);
+    }
+
+    @Test
+    void queueAdmissionCopyRetainsLogicalEngineIdentity() {
+        ServerStatus source = new ServerStatus();
+        source.setServerIp("127.0.0.1");
+        source.setHttpPort(8080);
+        source.setSelectedEngineIndex(0, 2);
+
+        ServerStatus copy = RequestRegistry.copyOf(source);
+
+        assertEquals("127.0.0.1:8080@0", copy.getLogicalIpPort());
+        assertEquals(0, copy.getEngineIndex());
+        assertEquals(2, copy.getRoutingMultiEngineNum());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedDecodeStrategyTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +38,20 @@ class CostBasedDecodeStrategyTest {
     void setUp() {
         configService = new ConfigService();
         decodeStatuses = new HashMap<>();
+    }
+
+    @Test
+    void springWiresProductionWorkerDirectoryConstructor() {
+        try (AnnotationConfigApplicationContext context =
+                     new AnnotationConfigApplicationContext()) {
+            context.registerBean(WorkerDirectory.class,
+                    () -> Mockito.mock(WorkerDirectory.class));
+            context.register(CostBasedDecodeStrategy.class);
+            context.refresh();
+
+            Assertions.assertNotNull(
+                    context.getBean(CostBasedDecodeStrategy.class));
+        }
     }
 
     WorkerStatus createWorkerStatus(String ip) {
@@ -72,7 +87,14 @@ class CostBasedDecodeStrategyTest {
     }
 
     private CostBasedDecodeStrategy availableStrategy(EndpointRegistry registry) {
-        return new CostBasedDecodeStrategy(new WorkerDirectory(registry));
+        WorkerDirectory directory = new WorkerDirectory(registry);
+        for (String address : registry.endpointAddressSnapshot(RoleType.DECODE)) {
+            WorkerStatus status = registry.get(RoleType.DECODE, address)
+                    .getStatus();
+            directory.currentOrDiscover(
+                    RoleType.DECODE, status.getLogicalIpPort(), () -> status);
+        }
+        return new CostBasedDecodeStrategy(directory);
     }
 
     private BalanceContext context(long sequenceLength, long requestId) {
@@ -127,6 +149,8 @@ class CostBasedDecodeStrategyTest {
         Mockito.when(racing.captureDecodeGeneration(stale)).thenReturn(null);
         Mockito.when(racing.captureDecodeGeneration(replacement))
                 .thenReturn(replacementPin);
+        Mockito.when(racing.isPhysicalGroupHealthy(Mockito.any()))
+                .thenReturn(true);
 
         PlacementResult<SelectedRole, RoleType> result =
                 new CostBasedDecodeStrategy(racing).select(
@@ -173,6 +197,29 @@ class CostBasedDecodeStrategyTest {
 
         Assertions.assertTrue(status.isSuccess());
         Assertions.assertEquals("127.0.0.1", status.getServerIp());
+    }
+
+    @Test
+    void selectedMultiEngineDecodePreservesLogicalIdentity() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.DECODE, "group-a", "127.0.0.1", 8080, 9090,
+                "test-site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.DECODE, "group-a", "127.0.0.1", 8080, 9090,
+                "test-site", null, 1, 2);
+        setKv(first, 10_000L, 10_000L);
+        setKv(second, 10_000L, 10_000L);
+        decodeStatuses.put(first.getLogicalIpPort(), first);
+        decodeStatuses.put(second.getLogicalIpPort(), second);
+
+        ServerStatus status = selectStatus(
+                availableStrategy(decodeRegistry()),
+                context(1_000L, 1_001L), RoleType.DECODE, "group-a");
+
+        Assertions.assertNotNull(status);
+        Assertions.assertNotNull(status.getEngineIndex());
+        Assertions.assertEquals("127.0.0.1:8080@" + status.getEngineIndex(),
+                status.getLogicalIpPort());
     }
 
     @Test
@@ -233,6 +280,8 @@ class CostBasedDecodeStrategyTest {
                 .thenAnswer(invocation -> actual.captureDecodeGeneration(
                         invocation.getArgument(
                                 0, DecodeEndpoint.DecodeRoutingView.class)));
+        Mockito.when(fullFleet.isPhysicalGroupHealthy(Mockito.any()))
+                .thenReturn(true);
         CostBasedDecodeStrategy costBasedDecodeStrategy =
                 new CostBasedDecodeStrategy(fullFleet);
         BalanceContext balanceContext = context(1, 10_000L);

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/CostBasedPrefillSelectionMetricTest.java
@@ -14,6 +14,7 @@ import org.flexlb.dao.BalanceContext;
 import org.flexlb.dao.SchedulingMetadata;
 import org.flexlb.dao.cache.HostCacheMatch;
 import org.flexlb.dao.loadbalance.Request;
+import org.flexlb.dao.loadbalance.ServerStatus;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.route.RoleType;
 import org.flexlb.service.monitor.EngineHealthReporter;
@@ -107,7 +108,7 @@ class CostBasedPrefillSelectionMetricTest {
             ArgumentCaptor<Long> ttft = ArgumentCaptor.forClass(Long.class);
             ArgumentCaptor<Long> execution = ArgumentCaptor.forClass(Long.class);
             verify(reporter).reportPrefillSelectedEstimates(
-                    Mockito.eq(RoleType.PREFILL), Mockito.eq("10.0.0.1"),
+                    Mockito.eq(RoleType.PREFILL), Mockito.eq("10.0.0.1:8080@0"),
                     Mockito.eq(deliveryMode), ttft.capture(), execution.capture());
             assertEquals(selected.serverStatus().getPrefillTime(), ttft.getValue());
             assertEquals(selected.prefillWorkMs(), execution.getValue());
@@ -127,6 +128,54 @@ class CostBasedPrefillSelectionMetricTest {
     }
 
     @Test
+    void selectedMultiEnginePrefillPreservesLogicalIdentity() {
+        ConfigService localConfigService = mock(ConfigService.class);
+        when(localConfigService.loadBalanceConfig()).thenReturn(config);
+        EndpointRegistry localRegistry = StrategyTestSupport.endpointRegistry(
+                localConfigService);
+        try {
+            WorkerStatus first = WorkerStatus.createDiscovered(
+                    RoleType.PREFILL, null, "10.0.0.8", 8080, 8081,
+                    "test-site", null, 0, 2);
+            WorkerStatus second = WorkerStatus.createDiscovered(
+                    RoleType.PREFILL, null, "10.0.0.8", 8080, 8081,
+                    "test-site", null, 1, 2);
+            StrategyTestSupport.publish(first, StrategyTestSupport.response(
+                    RoleType.PREFILL, true, 1_000_000L, 1_000_000L, 1L));
+            StrategyTestSupport.publish(second, StrategyTestSupport.response(
+                    RoleType.PREFILL, true, 1_000_000L, 1_000_000L, 1L));
+            StrategyTestSupport.publishEndpoint(localRegistry,
+                    RoleType.PREFILL, first.getLogicalIpPort(), first);
+            StrategyTestSupport.publishEndpoint(localRegistry,
+                    RoleType.PREFILL, second.getLogicalIpPort(), second);
+            WorkerDirectory directory = new WorkerDirectory(localRegistry);
+            for (String address : localRegistry.endpointAddressSnapshot(
+                    RoleType.PREFILL)) {
+                WorkerStatus endpointStatus = localRegistry.get(
+                        RoleType.PREFILL, address).getStatus();
+                directory.currentOrDiscover(
+                        RoleType.PREFILL, address, () -> endpointStatus);
+            }
+            CostBasedPrefillStrategy localStrategy =
+                    new CostBasedPrefillStrategy(directory, cache, reporter);
+
+            PlacementResult<SelectedRole, RoleType> result = localStrategy.select(
+                    context, RoleType.PREFILL, null);
+
+            assertEquals(PlacementResult.Status.SUCCESS, result.status());
+            try (SelectedRole selected = result.value()) {
+                ServerStatus selectedStatus = selected.serverStatus();
+                assertTrue(selectedStatus.getEngineIndex() != null);
+                assertEquals("10.0.0.8:8080@"
+                                + selectedStatus.getEngineIndex(),
+                        selectedStatus.getLogicalIpPort());
+            }
+        } finally {
+            localRegistry.close();
+        }
+    }
+
+    @Test
     void cacheLeaderInsideTtftCapOverridesTheBaselineCandidate() {
         configureAffinity(600L, 5.0,
                 RoutingConfig.CandidateChoiceType.BEST_ONLY);
@@ -134,7 +183,7 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertEquals("10.0.0.2", selected.serverStatus().getServerIp());
             verify(reporter).reportCacheAffinityDecision(
-                    RoleType.PREFILL, "10.0.0.2", "CACHE_LEADER");
+                    RoleType.PREFILL, "10.0.0.2:8080@0", "CACHE_LEADER");
         }
     }
 
@@ -157,7 +206,7 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertEquals("10.0.0.2", selected.serverStatus().getServerIp());
             verify(reporter).reportCacheHitMetrics(
-                    RoleType.PREFILL, 200L, 0.2);
+                    RoleType.PREFILL, "10.0.0.2:8080@0", 200L, 0.2);
         }
     }
 
@@ -206,7 +255,7 @@ class CostBasedPrefillSelectionMetricTest {
         try (SelectedRole selected = select()) {
             assertEquals("10.0.0.1", selected.serverStatus().getServerIp());
             verify(reporter).reportCacheAffinityDecision(
-                    RoleType.PREFILL, "10.0.0.1", reason);
+                    RoleType.PREFILL, "10.0.0.1:8080@0", reason);
         }
     }
 
@@ -219,7 +268,7 @@ class CostBasedPrefillSelectionMetricTest {
             assertEquals("10.0.0.2", selected.serverStatus().getServerIp());
         }
         PrefillEndpoint cacheEndpoint = (PrefillEndpoint)
-                registry.get(RoleType.PREFILL, "10.0.0.2:8080");
+                registry.get(RoleType.PREFILL, "10.0.0.2:8080@0");
         cacheEndpoint.getLastSelectedTime().set(Long.MAX_VALUE);
         context.getRequest().setRequestId("20002");
 
@@ -229,7 +278,7 @@ class CostBasedPrefillSelectionMetricTest {
         assertEquals(Long.MAX_VALUE, cacheEndpoint.getLastSelectedTime().get());
         verify(reporter, times(2))
                 .reportCacheAffinityDecision(
-                        RoleType.PREFILL, "10.0.0.2", "CACHE_LEADER");
+                        RoleType.PREFILL, "10.0.0.2:8080@0", "CACHE_LEADER");
     }
 
     private SelectedRole select() {
@@ -269,7 +318,7 @@ class CostBasedPrefillSelectionMetricTest {
     private static CacheMatchResult localCacheMatch(
             String workerIpPort, long matchedBlocks) {
         return new CacheMatchResult(
-                Map.of(workerIpPort, HostCacheMatch.local(matchedBlocks)),
+                Map.of(workerIpPort + "@0", HostCacheMatch.local(matchedBlocks)),
                 CacheMatchSource.LOCAL_SYNC,
                 0L,
                 100L);
@@ -280,6 +329,6 @@ class CostBasedPrefillSelectionMetricTest {
                 RoleType.PREFILL, null, ip, port, port + 1,
                 true, 1_000_000L, 1_000_000L);
         StrategyTestSupport.publishEndpoint(
-                registry, RoleType.PREFILL, ip + ":" + port, status);
+                registry, RoleType.PREFILL, status.getLogicalIpPort(), status);
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/RandomStrategyTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/RandomStrategyTest.java
@@ -69,6 +69,41 @@ class RandomStrategyTest {
     }
 
     @Test
+    void selectedMultiEngineVitPreservesLogicalIdentity() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.VIT, "group-a", "127.0.0.3", 8080, 8081,
+                "test-site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.VIT, "group-a", "127.0.0.3", 8080, 8081,
+                "test-site", null, 1, 2);
+        StrategyTestSupport.publish(first, StrategyTestSupport.response(
+                RoleType.VIT, true, 0L, 0L, 1L));
+        StrategyTestSupport.publish(second, StrategyTestSupport.response(
+                RoleType.VIT, true, 0L, 0L, 1L));
+        StrategyTestSupport.publishEndpoint(endpoints,
+                RoleType.VIT, first.getLogicalIpPort(), first);
+        StrategyTestSupport.publishEndpoint(endpoints,
+                RoleType.VIT, second.getLogicalIpPort(), second);
+        WorkerDirectory directory = new WorkerDirectory(endpoints);
+        for (String address : endpoints.endpointAddressSnapshot(RoleType.VIT)) {
+            WorkerStatus endpointStatus = endpoints.get(
+                    RoleType.VIT, address).getStatus();
+            directory.currentOrDiscover(
+                    RoleType.VIT, address, () -> endpointStatus);
+        }
+        strategy = new RandomStrategy(directory);
+
+        try (SelectedRole selected = strategy.select(
+                context(31L), RoleType.VIT, "group-a")) {
+            assertNotNull(selected);
+            assertNotNull(selected.serverStatus().getEngineIndex());
+            assertEquals("127.0.0.3:8080@"
+                            + selected.serverStatus().getEngineIndex(),
+                    selected.serverStatus().getLogicalIpPort());
+        }
+    }
+
+    @Test
     void skipsOtherGroups() {
         registerVit("127.0.0.4", 8080, "group-a");
         assertNull(strategy.select(

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/StrategyTestSupport.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/balance/strategy/StrategyTestSupport.java
@@ -99,7 +99,11 @@ final class StrategyTestSupport {
                 source.getIp(),
                 source.getPort(),
                 source.getGrpcPort(),
-                source.getSite());
+                source.getSite(),
+                source.getDeploymentName(),
+                source.getEngineIndex(),
+                source.getMultiEngineNum(),
+                source.getPhysicalGroupKey());
         WorkerStatus.StatusObservation observation =
                 status.bindStatusObservation(
                         source.committedEngineObservation(),
@@ -111,8 +115,10 @@ final class StrategyTestSupport {
         try {
             WorkerStatus.PreparedStatus prepared =
                     status.prepareNewStatus(observation);
-            return registry.publishPreparedEndpoint(
+            WorkerEndpoint endpoint = registry.publishPreparedEndpoint(
                     address, status, prepared).endpoint();
+            status.recordSuccessfulPoll(observation.alive());
+            return endpoint;
         } finally {
             status.lock.unlock();
         }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterSelectionMetricTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterSelectionMetricTest.java
@@ -69,10 +69,10 @@ class EngineHealthReporterSelectionMetricTest {
     @Test
     void reportsSelectedPrefillEstimatesWithDeliveryMode() {
         reporter.reportPrefillSelectedEstimates(
-                RoleType.PREFILL, "10.0.0.1", "NON_BATCH", 1_250L, 400L);
+                RoleType.PREFILL, "10.0.0.1:8080@0", "NON_BATCH", 1_250L, 400L);
 
         FlexMetricTags tags = FlexMetricTags.of(
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "delivery_mode", "NON_BATCH");
         verify(monitor).report(PREFILL_SELECTED_ESTIMATED_TTFT_MS, tags, 1_250.0);

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/monitor/EngineHealthReporterTest.java
@@ -13,6 +13,7 @@ import org.flexlb.dao.loadbalance.Response;
 import org.flexlb.dao.loadbalance.ServerStatus;
 import org.flexlb.dao.master.CacheStatus;
 import org.flexlb.dao.master.TaskInfo;
+import org.flexlb.dao.master.WorkerIdentity;
 import org.flexlb.dao.master.WorkerStatus;
 import org.flexlb.dao.master.WorkerStatusResponse;
 import org.flexlb.dao.route.RoleType;
@@ -107,12 +108,12 @@ class EngineHealthReporterTest {
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
                 "code", String.valueOf(failure.getCode()),
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", RoleType.PREFILL.getCode());
 
-        reporter.reportStatusCheckerFail("test-model", failure, "10.0.0.1", RoleType.PREFILL);
+        reporter.reportStatusCheckerFail("test-model", failure, "10.0.0.1:8080@0", RoleType.PREFILL);
         reporter.reportStatusCheckFailureLatency(
-                "test-model", failure, "10.0.0.1", RoleType.PREFILL, 201_234);
+                "test-model", failure, "10.0.0.1:8080@0", RoleType.PREFILL, 201_234);
 
         verify(monitor).report("app.engine.health.check.fail", expectedTags, 1.0);
         verify(monitor).report("app.engine.health.check.fail.total", expectedTags, 1.0);
@@ -156,6 +157,7 @@ class EngineHealthReporterTest {
         ServerStatus serverStatus = new ServerStatus();
         serverStatus.setRole(RoleType.PREFILL);
         serverStatus.setServerIp("10.0.0.1");
+        serverStatus.setHttpPort(8080);
         Response response = new Response();
         response.setSuccess(true);
         response.setCode(200);
@@ -172,17 +174,17 @@ class EngineHealthReporterTest {
         verify(monitor).report("app.engine.balancing.master.select.detail", FlexMetricTags.of(
                 "role", "PREFILL",
                 "strategy", "LEAST_RECENTLY_USED_IN_POOL",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "success", "true",
                 "code", "200"), 1.0);
     }
 
     @Test
     void shouldReportCacheAffinityDecisionBySelectedEngine() {
-        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1", "CACHE_LEADER");
+        reporter.reportCacheAffinityDecision(RoleType.PREFILL, "10.0.0.1:8080@0", "CACHE_LEADER");
 
         verify(cacheMetricsReporter).reportCacheAffinityDecision(
-                RoleType.PREFILL, "10.0.0.1", "CACHE_LEADER");
+                RoleType.PREFILL, "10.0.0.1:8080@0", "CACHE_LEADER");
     }
 
     @Test
@@ -196,11 +198,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportMasterDecisionToWaitingConfirmationLatency() {
         reporter.reportFlexlbObservedMasterDecisionToWaitingConfirmationLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 53);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 53);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.observed.decision.to.waiting.ms",
@@ -218,11 +220,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportWaitingToRunningLatency() {
         reporter.reportFlexlbObservedWaitingToRunningLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 42);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 42);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.observed.waiting.to.running.ms",
@@ -240,11 +242,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportEngineObservedWaitingToRunningLatency() {
         reporter.reportEngineObservedWaitingToRunningLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 42);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 42);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.engine.waiting.to.running.ms",
@@ -262,11 +264,11 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportEngineObservedReceivedToWaitingLatency() {
         reporter.reportEngineObservedReceivedToWaitingLatency(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", 42);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", 42);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.engine.received.to.waiting.ms",
@@ -289,11 +291,11 @@ class EngineHealthReporterTest {
         task.setPrefillNonfinalChunkTokensMax(256);
 
         reporter.reportPrefillWorkerStatusTask(
-                "test-model", "10.0.0.1", "PREFILL", "test-group", task);
+                "test-model", "10.0.0.1:8080@0", "PREFILL", "test-group", task);
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group");
         verify(monitor).report("app.engine.worker.status.input.queue.wait.ms", expectedTags, 100.0);
@@ -329,7 +331,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.engine.health.check.running.task.info.size", expectedTags, 3.0);
         verify(monitor).report("app.engine.health.check.finished.task.list.size", expectedTags, 4.0);
@@ -343,7 +345,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.cache.block.size",
                 FlexMetricTags.of("model", "test-model", "role", "PREFILL"), 64.0);
@@ -354,6 +356,20 @@ class EngineHealthReporterTest {
                 FlexMetricTags.of("model", "test-model", "role", "PREFILL"), 1000.0);
         verify(monitor).report("app.cache.used.kv.cache.ratio", expectedTags, 20.0);
         verify(monitor).report("app.cache.key.size", expectedTags, 7.0);
+    }
+
+    @Test
+    void shouldReportCacheStatusFailuresWithLogicalWorkerIdentity() {
+        WorkerStatus workerStatus = workerStatus("10.0.0.1", RoleType.PREFILL);
+        BalanceStatusEnum failure = BalanceStatusEnum.CACHE_SERVICE_UNAVAILABLE;
+
+        reporter.reportCacheStatusCheckerFail("test-model", workerStatus, failure);
+
+        verify(monitor).report("app.cache.status.check.fail", FlexMetricTags.of(
+                "model", "test-model",
+                "engineIp", "10.0.0.1:8080@0",
+                "code", String.valueOf(failure.getCode()),
+                "role", "PREFILL"), 1.0);
     }
 
     @Test
@@ -377,7 +393,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.cache.local.standby.block.size", expectedTags, 4096.0);
     }
@@ -401,7 +417,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL");
         verify(monitor).report("app.cache.key.size", expectedTags, 7.0);
     }
@@ -409,7 +425,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportCacheHitComparisonTokenMetricsWithStableDimensions() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
@@ -420,7 +437,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -435,7 +452,7 @@ class EngineHealthReporterTest {
         verify(monitor).report("app.cache.hit.comparison.local.standby.predicted.ratio", expectedTags, 0.4);
         assertEquals(Map.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -444,15 +461,15 @@ class EngineHealthReporterTest {
 
     @Test
     void shouldReportSelectedKvcmP2pMatchDetails() {
-        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1", 40, 80, 100, true);
+        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1:8080@0", 40, 80, 100, true);
 
         verify(cacheMetricsReporter).reportKvcmSelectedMatch(
-                RoleType.PREFILL, "10.0.0.1", 40, 80, 100);
+                RoleType.PREFILL, "10.0.0.1:8080@0", 40, 80, 100);
     }
 
     @Test
     void shouldSkipSelectedKvcmP2pMetricsWhenDetailsAreUnavailable() {
-        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1", 0, 0, 0, false);
+        reporter.reportKvcmSelectedMatch(RoleType.PREFILL, "10.0.0.1:8080@0", 0, 0, 0, false);
 
         verify(cacheMetricsReporter, never()).reportKvcmSelectedMatch(
                 org.mockito.ArgumentMatchers.any(),
@@ -465,7 +482,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldNotReportLocalStandbyMetricsWhenPredictionIsUnavailable() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "LOCAL_SYNC", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "LOCAL_SYNC", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),
@@ -476,7 +494,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -509,7 +527,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldReportKvcmLocalAndP2pDeltasWhenAvailable() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 200,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(60, 60),
@@ -522,7 +541,7 @@ class EngineHealthReporterTest {
 
         FlexMetricTags expectedTags = FlexMetricTags.of(
                 "model", "test-model",
-                "engineIp", "10.0.0.1",
+                "engineIp", "10.0.0.1:8080@0",
                 "role", "PREFILL",
                 "group", "test-group",
                 "taskState", "running",
@@ -534,7 +553,8 @@ class EngineHealthReporterTest {
     @Test
     void shouldNotReportRatiosWithoutInputTokens() {
         CacheHitComparisonResult comparison = new CacheHitComparisonResult(
-                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group", "10.0.0.1",
+                "cache_hit_comparison", "request-1", "KVCM", "PREFILL", "test-group",
+                new WorkerIdentity("10.0.0.1", 8080, 0),
                 "running", 0,
                 new CacheHitComparisonResult.Actual(120),
                 new CacheHitComparisonResult.HitComparison(100, 20),

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/EngineSyncRunnerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/EngineSyncRunnerTest.java
@@ -139,7 +139,7 @@ class EngineSyncRunnerTest {
 
     @Test
     void should_start_new_worker_expiration_window_at_discovery_time() {
-        String ipPort = "127.0.0.1:8080";
+        String ipPort = "127.0.0.1:8080@0";
         Mockito.when(workerAddressService.getEngineWorkerList(modelName, RoleType.VIT))
                 .thenReturn(List.of(WorkerHost.of("127.0.0.1", 8080)));
         EngineSyncRunner runner = new EngineSyncRunner(
@@ -158,7 +158,7 @@ class EngineSyncRunnerTest {
 
     @Test
     void executorRejectionReturnsBothExactPollLeases() {
-        String ipPort = "127.0.0.1:8080";
+        String ipPort = "127.0.0.1:8080@0";
         when(workerAddressService.getEngineWorkerList(
                 modelName, RoleType.PREFILL))
                 .thenReturn(List.of(WorkerHost.of("127.0.0.1", 8080)));
@@ -189,7 +189,7 @@ class EngineSyncRunnerTest {
         Mockito.when(configService.loadBalanceConfig()).thenReturn(new FlexlbConfig());
         EndpointRegistry registry = RunnerTestSupport.endpointRegistry(configService);
         WorkerDirectory directory = new WorkerDirectory(registry);
-        String ipPort = "127.0.0.1:8080";
+        String ipPort = "127.0.0.1:8080@0";
         WorkerStatus status = Mockito.spy(RunnerTestSupport.discovered(
                 RoleType.PREFILL, null, "127.0.0.1",
                 8080, 8081, "test-site"));
@@ -252,11 +252,11 @@ class EngineSyncRunnerTest {
             runner.run();
 
             WorkerStatus discovered = directory.statusSnapshot(RoleType.PREFILL)
-                    .get("127.0.0.1:61000");
+                    .get("127.0.0.1:61000@0");
             assertEquals(RoleType.PREFILL, discovered.getRole());
             assertFalse(discovered.pollHealth().reportedAlive(),
                     "service discovery alone must not make a worker routable");
-            assertNull(registry.get(RoleType.PREFILL, "127.0.0.1:61000"),
+            assertNull(registry.get(RoleType.PREFILL, "127.0.0.1:61000@0"),
                     "an endpoint is published only by a committed status response");
             verify(statusCheckExecutor, times(2)).submit(any(Runnable.class));
         } finally {
@@ -288,9 +288,9 @@ class EngineSyncRunnerTest {
                 .thenReturn(List.of(
                         WorkerHost.of(first.getIp(), first.getPort()),
                         WorkerHost.of(second.getIp(), second.getPort())));
-        when(registry.get(RoleType.PREFILL, first.getIpPort(), first))
+        when(registry.get(RoleType.PREFILL, first.getLogicalIpPort(), first))
                 .thenReturn(firstEndpoint);
-        when(registry.get(RoleType.PREFILL, second.getIpPort(), second))
+        when(registry.get(RoleType.PREFILL, second.getLogicalIpPort(), second))
                 .thenReturn(secondEndpoint);
         when(firstEndpoint.getLoadMetric()).thenReturn(OptionalLong.of(10L));
         when(secondEndpoint.getLoadMetric()).thenReturn(OptionalLong.empty());
@@ -319,9 +319,9 @@ class EngineSyncRunnerTest {
                 .thenReturn(List.of(
                         WorkerHost.of(first.getIp(), first.getPort()),
                         WorkerHost.of(second.getIp(), second.getPort())));
-        when(registry.get(RoleType.PREFILL, first.getIpPort(), first))
+        when(registry.get(RoleType.PREFILL, first.getLogicalIpPort(), first))
                 .thenReturn(firstEndpoint);
-        when(registry.get(RoleType.PREFILL, second.getIpPort(), second))
+        when(registry.get(RoleType.PREFILL, second.getLogicalIpPort(), second))
                 .thenReturn(secondEndpoint);
         when(firstEndpoint.getLoadMetric()).thenReturn(OptionalLong.of(10L));
         when(secondEndpoint.getLoadMetric()).thenReturn(OptionalLong.of(30L));
@@ -351,7 +351,7 @@ class EngineSyncRunnerTest {
                 .thenReturn(new FlexlbConfig());
         EndpointRegistry registry = RunnerTestSupport.endpointRegistry(configService);
         WorkerDirectory directory = new WorkerDirectory(registry);
-        String ipPort = "127.0.0.1:61000";
+        String ipPort = "127.0.0.1:61000@0";
         WorkerStatus oldStatus = RunnerTestSupport.discovered(
                 RoleType.PREFILL, oldGroup, "127.0.0.1",
                 61000, 61001, "site-a");
@@ -431,7 +431,7 @@ class EngineSyncRunnerTest {
     private static void discover(
             WorkerDirectory directory, WorkerStatus status) {
         directory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
     }
 
     @Test
@@ -457,7 +457,53 @@ class EngineSyncRunnerTest {
         verify(engineGrpcService).getWorkerStatusAsync(
                 "127.0.0.1", 18081, -1L, syncRequestTimeoutMs, RoleType.PREFILL);
         assertEquals(8081, workerDirectory.statusSnapshot(RoleType.PREFILL)
-                .get("127.0.0.1:8080").getGrpcPort());
+                .get("127.0.0.1:8080@0").getGrpcPort());
+    }
+
+    @Test
+    void singleEngineWorkerWithoutStatusPortUsesGrpcPortForStatusRunner() {
+        WorkerHost host = new WorkerHost("127.0.0.1", 8080);
+        when(workerAddressService.getEngineWorkerList(modelName, RoleType.PREFILL))
+                .thenReturn(List.of(host));
+        when(engineGrpcService.getWorkerStatusAsync(any(), anyInt(), anyLong(), anyLong(), any()))
+                .thenReturn(new java.util.concurrent.CompletableFuture<>());
+
+        engineSyncRunner.run();
+
+        ArgumentCaptor<Runnable> submittedTasks = ArgumentCaptor.forClass(Runnable.class);
+        verify(statusCheckExecutor, times(2)).submit(submittedTasks.capture());
+        submittedTasks.getAllValues().get(0).run();
+        verify(engineGrpcService).getWorkerStatusAsync(
+                "127.0.0.1", 8081, -1L, syncRequestTimeoutMs, RoleType.PREFILL);
+        WorkerStatus status = workerDirectory.statusSnapshot(RoleType.PREFILL)
+                .get("127.0.0.1:8080@0");
+        assertNotNull(status);
+        assertEquals(0, status.getEngineIndex());
+        assertEquals(1, status.getMultiEngineNum());
+    }
+
+    @Test
+    void discoversLogicalWorkerAndUsesItsIndexedStatusPort() {
+        WorkerHost host = new WorkerHost("127.0.0.1", 8080, 8081, 8085,
+                18082, "", "", "", 1, 2);
+        when(workerAddressService.getEngineWorkerList(modelName, RoleType.PREFILL))
+                .thenReturn(List.of(host));
+        when(engineGrpcService.getWorkerStatusAsync(any(), anyInt(), anyLong(), anyLong(), any()))
+                .thenReturn(new java.util.concurrent.CompletableFuture<>());
+
+        engineSyncRunner.run();
+
+        WorkerStatus status = workerDirectory.statusSnapshot(RoleType.PREFILL)
+                .get("127.0.0.1:8080@1");
+        assertNotNull(status);
+        assertEquals(1, status.getEngineIndex());
+        assertEquals(2, status.getMultiEngineNum());
+        assertEquals(host.getPhysicalGroupKey(), status.getPhysicalGroupKey());
+        ArgumentCaptor<Runnable> submittedTasks = ArgumentCaptor.forClass(Runnable.class);
+        verify(statusCheckExecutor, times(2)).submit(submittedTasks.capture());
+        submittedTasks.getAllValues().get(0).run();
+        verify(engineGrpcService).getWorkerStatusAsync(
+                "127.0.0.1", 18082, -1L, syncRequestTimeoutMs, RoleType.PREFILL);
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunnerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcCacheStatusCheckRunnerTest.java
@@ -39,10 +39,10 @@ class GrpcCacheStatusCheckRunnerTest {
     void testGrpcCacheStatusCheckRunner() {
         // Arrange
         String modelName = "test-model";
-        String ipPort = "127.0.0.1:8080";
         String site = "test-site";
 
         WorkerStatus workerStatus = workerStatus();
+        String ipPort = workerStatus.getLogicalIpPort();
         WorkerDirectory directory = directory(workerStatus);
 
         EngineRpcService.CacheStatusPB cacheStatusPB = EngineRpcService.CacheStatusPB.newBuilder()
@@ -76,8 +76,8 @@ class GrpcCacheStatusCheckRunnerTest {
 
     @Test
     void staleGenerationCallbackCannotPublishAddressCache() {
-        String ipPort = "127.0.0.1:8080";
         WorkerStatus oldStatus = workerStatus();
+        String ipPort = oldStatus.getLogicalIpPort();
         WorkerDirectory directory = Mockito.mock(WorkerDirectory.class);
         when(directory.isCurrentStatus(
                 RoleType.PREFILL, ipPort, oldStatus)).thenReturn(false);
@@ -116,7 +116,7 @@ class GrpcCacheStatusCheckRunnerTest {
         WorkerDirectory directory = new WorkerDirectory(
                 Mockito.mock(EndpointRegistry.class));
         directory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
         return directory;
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcWorkerStatusRunnerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/runner/GrpcWorkerStatusRunnerTest.java
@@ -29,10 +29,10 @@ class GrpcWorkerStatusRunnerTest {
 
     @Test
     void newGenerationProjectionRunsOutsideWorkerStatusLock() {
-        String ipPort = "127.0.0.1:8080";
         WorkerStatus status = RunnerTestSupport.discovered(
                 RoleType.DECODE, null, "127.0.0.1",
                 8080, 8081, "test-site");
+        String ipPort = status.getLogicalIpPort();
         WorkerStatus.PollLease pollLease = status.tryBeginStatusPoll();
         assertNotNull(pollLease);
 
@@ -83,10 +83,10 @@ class GrpcWorkerStatusRunnerTest {
 
     @Test
     void sameVersionResponseProjectsExactEndpointActivity() {
-        String ipPort = "127.0.0.1:8080";
         WorkerStatus status = RunnerTestSupport.alive(
                 RoleType.DECODE, null, "127.0.0.1",
                 8080, 8081, "test-site");
+        String ipPort = status.getLogicalIpPort();
         WorkerStatus.PollLease pollLease = status.tryBeginStatusPoll();
         assertNotNull(pollLease);
 
@@ -141,7 +141,7 @@ class GrpcWorkerStatusRunnerTest {
             EndpointRegistry registry, WorkerStatus status) {
         WorkerDirectory directory = new WorkerDirectory(registry);
         directory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status);
+                status.getRole(), status.getLogicalIpPort(), () -> status);
         return directory;
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/schedule/ExpirationCleanerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/schedule/ExpirationCleanerTest.java
@@ -33,9 +33,9 @@ class ExpirationCleanerTest {
         WorkerStatus second = status("127.0.0.2", 8080);
         WorkerDirectory directory = new WorkerDirectory(registry);
         directory.currentOrDiscover(
-                RoleType.PREFILL, first.getIpPort(), () -> first);
+                RoleType.PREFILL, first.getLogicalIpPort(), () -> first);
         directory.currentOrDiscover(
-                RoleType.PREFILL, second.getIpPort(), () -> second);
+                RoleType.PREFILL, second.getLogicalIpPort(), () -> second);
 
         EndpointRegistry.DetachedGeneration firstDetached =
                 mock(EndpointRegistry.DetachedGeneration.class);
@@ -74,8 +74,8 @@ class ExpirationCleanerTest {
             releaseFirstAwait.countDown();
             cleaning.get(5, TimeUnit.SECONDS);
             assertTrue(directory.statusSnapshot(RoleType.PREFILL).isEmpty());
-            verify(cache).removeEngineBlockCache(first.getIpPort());
-            verify(cache).removeEngineBlockCache(second.getIpPort());
+            verify(cache).removeEngineBlockCache(first.getLogicalIpPort());
+            verify(cache).removeEngineBlockCache(second.getLogicalIpPort());
         } finally {
             releaseFirstAwait.countDown();
             executor.shutdownNow();
@@ -88,11 +88,11 @@ class ExpirationCleanerTest {
             WorkerEndpoint endpoint,
             EndpointRegistry.DetachedGeneration detached) {
         when(registry.get(
-                RoleType.PREFILL, status.getIpPort(), status))
+                RoleType.PREFILL, status.getLogicalIpPort(), status))
                 .thenReturn(endpoint);
         when(detached.ownsEndpoint(endpoint)).thenReturn(true);
         when(registry.detachAndBeginRetirement(
-                RoleType.PREFILL, status.getIpPort(), status))
+                RoleType.PREFILL, status.getLogicalIpPort(), status))
                 .thenAnswer(invocation -> {
                     status.beginRetirementAfterEndpointGateClosed();
                     return detached;

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/status/WorkerDirectoryTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/sync/status/WorkerDirectoryTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -41,9 +42,9 @@ class WorkerDirectoryTest {
         WorkerStatus matching = status(RoleType.DECODE, "group1", 8080);
         WorkerStatus filtered = status(RoleType.DECODE, "group2", 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, matching.getIpPort(), matching);
+                RoleType.DECODE, matching.getLogicalIpPort(), matching);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, filtered.getIpPort(), filtered);
+                RoleType.DECODE, filtered.getLogicalIpPort(), filtered);
 
         List<WorkerEndpoint.GenerationPin> result =
                 workerDirectory.captureEndpoints(
@@ -51,7 +52,7 @@ class WorkerDirectoryTest {
         try {
             assertEquals(1, result.size());
             assertSame(matching, result.getFirst().endpoint().getStatus());
-            assertEquals(matching.getIpPort(),
+            assertEquals(matching.getLogicalIpPort(),
                     result.getFirst().endpoint().ipPort());
         } finally {
             closePins(result);
@@ -63,9 +64,9 @@ class WorkerDirectoryTest {
         WorkerStatus first = status(RoleType.PREFILL, "group1", 8080);
         WorkerStatus second = status(RoleType.PREFILL, "group2", 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.PREFILL, first.getIpPort(), first);
+                RoleType.PREFILL, first.getLogicalIpPort(), first);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.PREFILL, second.getIpPort(), second);
+                RoleType.PREFILL, second.getLogicalIpPort(), second);
 
         List<WorkerEndpoint.GenerationPin> result =
                 workerDirectory.captureEndpoints(
@@ -95,14 +96,14 @@ class WorkerDirectoryTest {
     void should_close_filtered_pins_when_no_group_matches() {
         WorkerStatus status = status(RoleType.VIT, "group1", 8080);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.VIT, status.getIpPort(), status);
+                RoleType.VIT, status.getLogicalIpPort(), status);
 
         List<WorkerEndpoint.GenerationPin> result =
                 workerDirectory.captureEndpoints(
                         RoleType.VIT, "nonExistentGroup");
 
         assertTrue(result.isEmpty());
-        assertEquals(List.of(status.getIpPort()),
+        assertEquals(List.of(status.getLogicalIpPort()),
                 workerDirectory.endpointAddresses(
                         RoleType.VIT, null));
     }
@@ -112,15 +113,15 @@ class WorkerDirectoryTest {
         WorkerStatus matching = status(RoleType.DECODE, "groupA", 8080);
         WorkerStatus ungrouped = status(RoleType.DECODE, null, 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, matching.getIpPort(), matching);
+                RoleType.DECODE, matching.getLogicalIpPort(), matching);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, ungrouped.getIpPort(), ungrouped);
+                RoleType.DECODE, ungrouped.getLogicalIpPort(), ungrouped);
 
         List<String> result = workerDirectory.endpointAddresses(
                 RoleType.DECODE, "groupA");
 
-        assertEquals(List.of(matching.getIpPort()), result);
-        assertFalse(result.contains(ungrouped.getIpPort()));
+        assertEquals(List.of(matching.getLogicalIpPort()), result);
+        assertFalse(result.contains(ungrouped.getLogicalIpPort()));
     }
 
     @Test
@@ -128,16 +129,16 @@ class WorkerDirectoryTest {
         WorkerStatus grouped = status(RoleType.DECODE, "groupA", 8080);
         WorkerStatus ungrouped = status(RoleType.DECODE, null, 8081);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, grouped.getIpPort(), grouped);
+                RoleType.DECODE, grouped.getLogicalIpPort(), grouped);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, ungrouped.getIpPort(), ungrouped);
+                RoleType.DECODE, ungrouped.getLogicalIpPort(), ungrouped);
 
         List<String> result = workerDirectory.endpointAddresses(
                 RoleType.DECODE, null);
 
         assertEquals(2, result.size());
-        assertTrue(result.contains(grouped.getIpPort()));
-        assertTrue(result.contains(ungrouped.getIpPort()));
+        assertTrue(result.contains(grouped.getLogicalIpPort()));
+        assertTrue(result.contains(ungrouped.getLogicalIpPort()));
     }
 
     @Test
@@ -147,11 +148,11 @@ class WorkerDirectoryTest {
         discover(matching);
         discover(filtered);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, matching.getIpPort(), matching);
+                RoleType.DECODE, matching.getLogicalIpPort(), matching);
         RunnerTestSupport.publishEndpoint(registry,
-                RoleType.DECODE, filtered.getIpPort(), filtered);
+                RoleType.DECODE, filtered.getLogicalIpPort(), filtered);
 
-        assertEquals(List.of(matching.getIpPort()),
+        assertEquals(List.of(matching.getLogicalIpPort()),
                 workerDirectory.endpointAddresses(
                         RoleType.DECODE, "group1"));
         assertEquals(2,
@@ -164,10 +165,87 @@ class WorkerDirectoryTest {
         assertRoleEndpoint(RoleType.VIT, 8102);
     }
 
+    @Test
+    void storesSiblingEnginesUnderTheirDistinctLogicalAddresses() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 1, 2);
+
+        workerDirectory.currentOrDiscover(
+                RoleType.PREFILL, first.getLogicalIpPort(), () -> first);
+        workerDirectory.currentOrDiscover(
+                RoleType.PREFILL, second.getLogicalIpPort(), () -> second);
+
+        Map<String, WorkerStatus> statuses =
+                workerDirectory.statusSnapshot(RoleType.PREFILL);
+        assertEquals(2, statuses.size());
+        assertSame(first, statuses.get("127.0.0.1:8080@0"));
+        assertSame(second, statuses.get("127.0.0.1:8080@1"));
+    }
+
+    @Test
+    void excludesEverySiblingWhenOneLogicalEngineIsNotAlive() {
+        WorkerStatus first = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 0, 2);
+        WorkerStatus second = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group", "127.0.0.1", 8080, 8081,
+                "site", null, 1, 2);
+        discover(first);
+        discover(second);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, first.getLogicalIpPort(), first);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, second.getLogicalIpPort(), second);
+        RunnerTestSupport.publish(second,
+                RunnerTestSupport.response(second, false, 2L));
+
+        assertTrue(workerDirectory.prefillRoutingSnapshot(RoleType.PREFILL)
+                .isEmpty());
+    }
+
+    @Test
+    void physicalGroupHealthUsesEndpointAndGroupOwnership() {
+        WorkerStatus completeFirst = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-a", "127.0.0.1", 8080, 8081,
+                "site", null, 0, 2, "endpoint-a|group-a|127.0.0.1:8080");
+        WorkerStatus completeSecond = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-a", "127.0.0.1", 8080, 8081,
+                "site", null, 1, 2, "endpoint-a|group-a|127.0.0.1:8080");
+        WorkerStatus incompleteSibling = WorkerStatus.createDiscovered(
+                RoleType.PREFILL, "group-b", "127.0.0.1", 8080, 8081,
+                "site", null, 2, 3, "endpoint-b|group-b|127.0.0.1:8080");
+        discover(completeFirst);
+        discover(completeSecond);
+        discover(incompleteSibling);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, completeFirst.getLogicalIpPort(),
+                completeFirst);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, completeSecond.getLogicalIpPort(),
+                completeSecond);
+        RunnerTestSupport.publishEndpoint(registry,
+                RoleType.PREFILL, incompleteSibling.getLogicalIpPort(),
+                incompleteSibling);
+
+        List<String> routable = workerDirectory.endpointAddresses(
+                RoleType.PREFILL, "group-a");
+
+        assertEquals(2, routable.size());
+        assertEquals(Set.of(
+                completeFirst.getLogicalIpPort(),
+                completeSecond.getLogicalIpPort()), Set.copyOf(routable));
+        assertTrue(workerDirectory.endpointAddresses(
+                RoleType.PREFILL, "group-b").isEmpty());
+    }
+
     private void assertRoleEndpoint(RoleType role, int port) {
         WorkerStatus status = status(role, null, port);
         WorkerEndpoint registered = RunnerTestSupport.publishEndpoint(registry,
-                role, status.getIpPort(), status);
+                role, status.getLogicalIpPort(), status);
 
         List<WorkerEndpoint.GenerationPin> selected =
                 workerDirectory.captureEndpoints(role, null);
@@ -200,9 +278,9 @@ class WorkerDirectoryTest {
         discover(decode);
 
         assertSame(prefill, workerDirectory.statusSnapshot(RoleType.PREFILL)
-                .get(prefill.getIpPort()));
+                .get(prefill.getLogicalIpPort()));
         assertSame(decode, workerDirectory.statusSnapshot(RoleType.DECODE)
-                .get(decode.getIpPort()));
+                .get(decode.getLogicalIpPort()));
         assertEquals(2, workerDirectory.discoveredCount());
         assertEquals(1, workerDirectory.discoveredCount(RoleType.PREFILL));
     }
@@ -212,7 +290,7 @@ class WorkerDirectoryTest {
         WorkerStatus status = status(RoleType.VIT, "group", 8080);
         discover(status);
 
-        assertEquals(Map.of(status.getIpPort(), status),
+        assertEquals(Map.of(status.getLogicalIpPort(), status),
                 workerDirectory.statusSnapshot(RoleType.VIT));
         assertThrows(UnsupportedOperationException.class,
                 () -> workerDirectory.statusSnapshot(RoleType.VIT).clear());
@@ -238,6 +316,6 @@ class WorkerDirectoryTest {
 
     private void discover(WorkerStatus status) {
         assertSame(status, workerDirectory.currentOrDiscover(
-                status.getRole(), status.getIpPort(), () -> status));
+                status.getRole(), status.getLogicalIpPort(), () -> status));
     }
 }


### PR DESCRIPTION
## Summary

- align all seven stable architecture documents with the current RequestScheduler, endpoint-generation, and RequestRegistry ownership model
- document the current gRPC forwarding, worker synchronization, cache-matching, lifecycle, port, and schema-v2 behavior
- remove stale references to the retired scheduling and resource-management design

## Validation

- ./mvnw spotless:check -Pspotless-check