### PR TITLE
feat: support custom output hidden-state stage selection

### DIFF
--- a/docs/examples/custom_output_processor_example.py
+++ b/docs/examples/custom_output_processor_example.py
@@ -31,6 +31,10 @@ last-layer hidden states，过自定义 MLP 打分，打分随生成结果一起
     context 请求最后一个 token 的 hidden state。
   * MLP 权重放在模型 ckpt 里，通过 custom_weight_info() 走现有权重加载链，
     不要在业务代码里自行 torch.load。
+  * hidden_state_stage() 默认 POST_FINAL_NORM（最终归一化后）。若打分头
+    训练时取最后一个 decoder block 的输出，显式返回 PRE_FINAL_NORM。
+    这与 token ID / 位置选择无关，不会改变生成分支的最终归一化。
+    未支持该阶段的模型/后端会启动失败，不能用“后”静默替代“前”。
   * extend_forward 运行在引擎 forward 热路径上（每个 prefill step 一次，
     batched），禁止任何同步操作: .item() / .cpu() / .tolist() /
     torch.cuda.synchronize() / print / logging。输出留在 GPU 上，
@@ -48,6 +52,7 @@ from rtp_llm.model_loader.weight_module import CustomAtomicWeight
 from rtp_llm.models.downstream_modules.custom_module import (
     CustomHandler,
     CustomModule,
+    HiddenStateStage,
     Trigger,
 )
 from rtp_llm.utils.model_weight import CkptWeightInfo
@@ -89,6 +94,11 @@ class ScoreHandler(CustomHandler):
 
     def trigger_mode(self) -> Trigger:
         return Trigger.CONTEXT  # 基类默认值，显式写出便于阅读
+
+    def hidden_state_stage(self) -> HiddenStateStage:
+        # 必须与打分头训练时一致；card_score_head 的最后层 hook 应选
+        # HiddenStateStage.PRE_FINAL_NORM。普通示例保留默认“后”。
+        return HiddenStateStage.POST_FINAL_NORM
 
     def extend_forward(self, **kwargs: Any) -> torch.Tensor:
         # selected_hidden_states: [context_batch, hidden]，每条请求倒数

--- a/rtp_llm/cpp/engine_base/executor_base/PostLayersProcessor.cc
+++ b/rtp_llm/cpp/engine_base/executor_base/PostLayersProcessor.cc
@@ -54,6 +54,7 @@ void PostLayersProcessor::setHandler(py::object handler) {
         handler_args_  = HandlerArgs::Flag{};
         has_handler_   = false;
         wants_context_ = false;
+        uses_pre_final_norm_ = false;
         return;
     }
 
@@ -114,9 +115,19 @@ void PostLayersProcessor::setHandler(py::object handler) {
                                  + "\" is not implemented; only Trigger.CONTEXT is supported");
     }
 
+    // Older duck-typed handlers need not implement the new optional method.
+    const auto stage = py::hasattr(handler_, "hidden_state_stage") ?
+                           py::cast<std::string>(handler_.attr("hidden_state_stage")()) :
+                           std::string("post_final_norm");
+    if (stage != "post_final_norm" && stage != "pre_final_norm") {
+        throw std::runtime_error("unsupported post-layers hidden_state_stage \"" + stage
+                                 + "\"; expected post_final_norm or pre_final_norm");
+    }
+    uses_pre_final_norm_ = stage == "pre_final_norm";
     wants_context_ = true;
     has_handler_   = true;
-    RTP_LLM_LOG_INFO("post-layers handler registered, trigger=%s", trigger.c_str());
+    RTP_LLM_LOG_INFO(
+        "post-layers handler registered, trigger=%s, hidden_state_stage=%s", trigger.c_str(), stage.c_str());
 }
 
 torch::Tensor PostLayersProcessor::invokeHandler(const torch::Tensor& context_rows) const {

--- a/rtp_llm/cpp/engine_base/executor_base/PostLayersProcessor.h
+++ b/rtp_llm/cpp/engine_base/executor_base/PostLayersProcessor.h
@@ -31,6 +31,10 @@ public:
         return has_handler_;
     }
 
+    bool usesPreFinalNorm() const {
+        return uses_pre_final_norm_;
+    }
+
     // True when the handler should run on this step (CONTEXT trigger).
     bool shouldRunOnContext(bool has_context_request) const {
         return has_handler_ && wants_context_ && has_context_request;
@@ -57,6 +61,7 @@ private:
 
     bool              has_handler_   = false;
     bool              wants_context_ = false;
+    bool              uses_pre_final_norm_ = false;
     pybind11::object  handler_;
     HandlerArgs::Flag handler_args_{};
 };

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -477,7 +477,8 @@ torch_ext::BertEmbeddingInputs PyWrappedModel::buildBertEmbeddingInputs(const Gp
 GptModelOutputs PyWrappedModel::callForwardPostLayers(torch::Tensor         hidden_states,
                                                       const GptModelInputs& inputs,
                                                       bool                  skip_final_layernorm,
-                                                      size_t                num_valid_tokens) {
+                                                      size_t                num_valid_tokens,
+                                                      torch::Tensor         pre_final_norm_hidden) {
     RTP_LLM_PROFILE_SCOPE("py_model.callForwardPostLayers");
     size_t num_input_tokens = num_valid_tokens != -1 ? num_valid_tokens : inputs.combo_tokens.size(0);
     return forwardPostLayers(hidden_states,
@@ -488,13 +489,43 @@ GptModelOutputs PyWrappedModel::callForwardPostLayers(torch::Tensor         hidd
                              num_input_tokens,
                              inputs,
                              torch::Tensor(),
-                             skip_final_layernorm);
+                             skip_final_layernorm,
+                             std::move(pre_final_norm_hidden));
+}
+
+torch::Tensor PyWrappedModel::customOutputIndexes(const GptModelInputs& inputs) {
+    const auto decode_batch_size  = inputs.sequence_lengths.size(0);
+    const auto context_batch_size = inputs.input_lengths.size(0) - decode_batch_size;
+    auto       indexes            = inputs.custom_output_indexes;
+    if (!indexes.defined() || indexes.numel() == 0) {
+        // Last-token mode (also used for model warmup's synthetic requests).
+        indexes = inputs.lm_output_indexes.narrow(0, decode_batch_size, context_batch_size);
+    }
+    TORCH_CHECK(indexes.dim() == 1 && indexes.size(0) == context_batch_size,
+                "custom output indexes must contain one row per context request");
+    buffer_holder_.hold_host(indexes);
+    return indexes.to(torch::kCUDA, /*non_blocking=*/true).to(torch::kLong);
 }
 
 void PyWrappedModel::setPostLayersProcessor(const std::shared_ptr<PostLayersProcessor>& processor) {
     post_layers_processor_ = processor;
     if (post_layers_processor_ && post_layers_processor_->hasHandler()) {
         RTP_LLM_CHECK_WITH_INFO(bool(weights_.lm_head), "post-layers handler requires a model with lm_head");
+        if (post_layers_processor_->usesPreFinalNorm()) {
+            // CP changes token layout and requires a separate selected-row
+            // gather protocol. Never silently feed rank-local/wrong-stage rows.
+            TORCH_CHECK(!device_props_.enable_prefill_cp,
+                        "pre_final_norm custom output does not support context parallel yet");
+            if (!int(device_props_.enable_layer_micro_batch)) {
+                py::gil_scoped_acquire gil;
+                TORCH_CHECK(py::hasattr(py_model_, "supports_pre_final_norm")
+                                && py::cast<bool>(py_model_.attr("supports_pre_final_norm")),
+                            "Python model does not support pre_final_norm custom output; "
+                            "implement selected-row capture before its final norm");
+            }
+            // The layer-microbatch path returns pre-norm activations and applies
+            // final norm in forwardPostLayers, so it needs no Python capture.
+        }
         // Eat the handler's lazy initialization (cuBLAS handles, imports)
         // before traffic; a handler that cannot run fails startup here.
         post_layers_processor_->warmup(weights_.lm_head->kernel.size(1),
@@ -846,11 +877,16 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
             py_model_inputs.input_embeddings      = inputs.input_embeddings;
             py_model_inputs.input_embeddings_locs = inputs.input_embeddings_locs;
         }
+        if (post_layers_processor_ && post_layers_processor_->usesPreFinalNorm()
+            && post_layers_processor_->shouldRunOnContext(has_context_request)) {
+            py_model_inputs.pre_final_norm_output_indexes = customOutputIndexes(inputs);
+        }
         PyModelOutputs py_model_outputs;
         torch::Tensor  hidden_states;
 
         // Cast the Python object to PyModelOutputs and extract hidden states
-        if (enable_cuda_graph_ && graph_runner_->canRun(py_model_inputs, graph_state_)) {
+        if (enable_cuda_graph_ && !py_model_inputs.pre_final_norm_output_indexes.defined()
+            && graph_runner_->canRun(py_model_inputs, graph_state_)) {
             py::gil_scoped_acquire gil;
             RTP_LLM_PROFILE_SCOPE("py_model.forward(cuda_graph)");
             DevicePerfWrapper wrapper(enable_device_perf_, "cuda graph python forward");
@@ -888,7 +924,8 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
             size_t num_valid_tokens = context_parallel_processor_->handleOutputs(hidden_states, inputs, cp_params);
             return callForwardPostLayers(hidden_states, inputs, true, num_valid_tokens);
         }
-        return callForwardPostLayers(hidden_states, inputs, true);
+        return callForwardPostLayers(
+            hidden_states, inputs, true, -1, std::move(py_model_outputs.pre_final_norm_hidden_states));
 
     } catch (const py::error_already_set& e) {
         RTP_LLM_LOG_ERROR("Python error during forward call on Python instance: %s", e.what());
@@ -949,7 +986,8 @@ GptModelOutputs PyWrappedModel::forwardPostLayers(torch::Tensor         hidden,
                                                   size_t                token_num,
                                                   const GptModelInputs& inputs,
                                                   torch::Tensor         merged_eagle3_hidden,
-                                                  bool                  skip_final_layernorm) {
+                                                  bool                  skip_final_layernorm,
+                                                  torch::Tensor         pre_final_norm_hidden) {
     DevicePerfWrapper wrapper(enable_device_perf_, "forwardPostLayers");
     if (enable_sp && device_props_.tp_size > 1) {
         auto ag_tensor =
@@ -983,6 +1021,14 @@ GptModelOutputs PyWrappedModel::forwardPostLayers(torch::Tensor         hidden,
         } else {
             hidden = ag_tensor;
         }
+    }
+
+    const bool run_custom = post_layers_processor_ && post_layers_processor_->shouldRunOnContext(has_context_request);
+    const bool use_pre_final_norm = run_custom && post_layers_processor_->usesPreFinalNorm();
+    if (use_pre_final_norm && !skip_final_layernorm) {
+        // Layer microbatches have already been merged into original token order.
+        // Retain only requested rows, before any final normalization takes place.
+        pre_final_norm_hidden = torch::index_select(hidden, 0, customOutputIndexes(inputs));
     }
 
     if (weights_.final_layernorm && !skip_final_layernorm) {
@@ -1048,19 +1094,30 @@ GptModelOutputs PyWrappedModel::forwardPostLayers(torch::Tensor         hidden,
 
         torch::Tensor custom_output;
         std::string   custom_output_error;
-        if (post_layers_processor_ && post_layers_processor_->shouldRunOnContext(has_context_request)) {
-            // lm_output rows: decode rows first, context rows at the tail.
-            torch::Tensor lm_rows = need_all_logits ?
-                                        torch::index_select(hidden, 0, lm_output_indexes_device.to(torch::kLong)) :
-                                        last_hidden;
+        if (run_custom) {
             try {
-                if (inputs.custom_output_indexes.defined() && inputs.custom_output_indexes.numel() > 0) {
-                    buffer_holder_.hold_host(inputs.custom_output_indexes);
-                    auto indexes =
-                        inputs.custom_output_indexes.to(torch::kCUDA, /*non_blocking=*/true).to(torch::kLong);
-                    auto selected = torch::index_select(hidden, 0, indexes);
+                if (use_pre_final_norm) {
+                    // Missing output is a protocol error, never a post-norm fallback.
+                    TORCH_CHECK(pre_final_norm_hidden.defined(),
+                                "model did not return requested pre_final_norm hidden states");
+                    TORCH_CHECK(pre_final_norm_hidden.dim() == 2
+                                    && pre_final_norm_hidden.size(0)
+                                           == inputs.input_lengths.size(0) - inputs.sequence_lengths.size(0)
+                                    && pre_final_norm_hidden.size(1) == hidden.size(1),
+                                "pre_final_norm hidden states must have shape [context_batch, hidden_size]");
+                    TORCH_CHECK(pre_final_norm_hidden.device() == hidden.device()
+                                    && pre_final_norm_hidden.scalar_type()
+                                           == dataTypeToTorchType(description_.data_type),
+                                "pre_final_norm hidden states must retain the model activation device and dtype");
+                    custom_output = post_layers_processor_->runOnContext(pre_final_norm_hidden, 0);
+                } else if (inputs.custom_output_indexes.defined() && inputs.custom_output_indexes.numel() > 0) {
+                    auto selected = torch::index_select(hidden, 0, customOutputIndexes(inputs));
                     custom_output = post_layers_processor_->runOnContext(selected, 0);
                 } else {
+                    // Reuse existing LM rows on the default last-token path.
+                    auto lm_rows = need_all_logits ?
+                                       torch::index_select(hidden, 0, lm_output_indexes_device.to(torch::kLong)) :
+                                       last_hidden;
                     custom_output =
                         post_layers_processor_->runOnContext(lm_rows, inputs.sequence_lengths.size(0));
                 }

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -64,7 +64,11 @@ private:
     GptModelOutputs                 callForwardPostLayers(torch::Tensor         hidden_states,
                                                           const GptModelInputs& inputs,
                                                           bool                  skip_final_layernorm,
-                                                          size_t                num_valid_tokens = -1);
+                                                          size_t                num_valid_tokens      = -1,
+                                                          torch::Tensor         pre_final_norm_hidden = {});
+    // Context-only row indexes shared by Python pre-norm capture and C++
+    // post-layers selection. Existing selector/prefix-cache logic owns positions.
+    torch::Tensor                   customOutputIndexes(const GptModelInputs& inputs);
     torch::Tensor                   tensorHoldHostAndToCuda(const torch::Tensor& tensor);
 
     // Methods absorbed from GptModel
@@ -77,7 +81,8 @@ private:
                                       size_t                token_num,
                                       const GptModelInputs& inputs,
                                       torch::Tensor         merged_eagle3_hidden,
-                                      bool                  skip_final_layernorm = false);
+                                      bool                  skip_final_layernorm  = false,
+                                      torch::Tensor         pre_final_norm_hidden = {});
     GptModelOutputs forwardPostLayersLastHidden(torch::Tensor hidden, const GptModelInputs& inputs);
     MicroBatchPlan  planMicroBatches(const GptModelInputs& inputs);
     std::pair<std::vector<GptModelInputs>, std::vector<TokenSliceInfo>>

--- a/rtp_llm/cpp/models/test/BUILD
+++ b/rtp_llm/cpp/models/test/BUILD
@@ -87,3 +87,33 @@ py_test(
     },
     exec_properties = {"gpu": "H20"},
 )
+
+cc_library(
+    name = "pywrapped_model_custom_output_test_lib",
+    srcs = ["PyWrappedModelCustomOutputTest.cc"],
+    alwayslink = True,
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/models:models",
+        "//rtp_llm/cpp/engine_base/executor_base:post_layers_processor",
+        "//rtp_llm/models_py/bindings:op_defs",
+        "//rtp_llm/models_py/bindings/core:exec_ops_test_lib",
+        "//rtp_llm/models_py/bindings/cuda/ops:cuda_impl",
+        "//rtp_llm/models_py/bindings/cuda/ops:gpu_base",
+    ] + torch_deps(),
+)
+
+cc_binary(
+    name = "th_pywrapped_model_custom_output_test",
+    deps = [":pywrapped_model_custom_output_test_lib"],
+    linkshared = 1,
+)
+
+py_test(
+    name = "pywrapped_model_custom_output_test",
+    srcs = ["pywrapped_model_custom_output_test.py"],
+    data = [":th_pywrapped_model_custom_output_test"],
+    deps = ["//rtp_llm:torch"],
+    env = {"TEST_USING_DEVICE": "CUDA"},
+    exec_properties = {"gpu": "H20"},
+)

--- a/rtp_llm/cpp/models/test/PyWrappedModelCustomOutputTest.cc
+++ b/rtp_llm/cpp/models/test/PyWrappedModelCustomOutputTest.cc
@@ -1,0 +1,71 @@
+#include <mutex>
+#include <pybind11/pybind11.h>
+#include <torch/extension.h>
+
+#include "rtp_llm/cpp/models/PyWrappedModel.h"
+#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+
+namespace py = pybind11;
+
+namespace rtp_llm::test {
+
+// Exercise the real post-layers implementation with tiny deterministic weights,
+// without a checkpoint or attention kernels. The BUILD target enables private
+// access just like the existing PyWrappedModel integration tests.
+py::dict runCustomOutput(py::object                   py_model,
+                         py::object                   handler,
+                         torch::Tensor                hidden,
+                         torch::Tensor                lm_indexes,
+                         std::optional<torch::Tensor> custom_indexes,
+                         int64_t                      decode_batch,
+                         bool                         python_norm,
+                         bool                         all_logits,
+                         std::optional<torch::Tensor> pre_hidden) {
+    static std::once_flag runtime_once;
+    std::call_once(runtime_once, []() { initRuntime(0, false, false, MlaOpsType::AUTO); });
+    const auto width = hidden.size(1);
+    Weights    weights;
+    auto       lm_head      = std::make_shared<DenseWeights>();
+    lm_head->kernel         = torch::eye(width, hidden.options());
+    weights.lm_head         = lm_head;
+    auto norm               = std::make_shared<LayerNormWeights>();
+    norm->gamma             = torch::ones({width}, hidden.options());
+    weights.final_layernorm = norm;
+    GptModelDescription description;
+    description.data_type                    = DataType::TYPE_FP32;
+    description.norm_type                    = NormType::rmsnorm;
+    description.attention_conf.head_num      = 1;
+    description.attention_conf.size_per_head = width;
+    GptModelInitParams params{weights, description, std::nullopt};
+    params.device_resource_config.enable_layer_micro_batch = python_norm ? 0 : 1;
+    PyWrappedModel model(params, std::move(py_model));
+    auto           processor = std::make_shared<PostLayersProcessor>();
+    processor->setHandler(std::move(handler));
+    model.setPostLayersProcessor(processor);
+
+    GptModelInputs inputs;
+    inputs.combo_tokens          = torch::zeros({hidden.size(0)}, torch::kInt32);
+    inputs.input_lengths         = torch::ones({lm_indexes.size(0)}, torch::kInt32);
+    inputs.sequence_lengths      = torch::ones({decode_batch}, torch::kInt32);
+    inputs.lm_output_indexes     = lm_indexes;
+    inputs.custom_output_indexes = custom_indexes.value_or(torch::Tensor());
+    inputs.need_all_logits       = all_logits;
+    auto outputs = model.callForwardPostLayers(hidden, inputs, python_norm, -1, pre_hidden.value_or(torch::Tensor()));
+    py::dict result;
+    result["custom_output"]       = outputs.custom_output;
+    result["custom_output_error"] = outputs.custom_output_error;
+    result["logits"]              = outputs.logits;
+    result["hidden_states"]       = outputs.all_hidden_states;
+    return result;
+}
+
+}  // namespace rtp_llm::test
+
+PYBIND11_MODULE(libth_pywrapped_model_custom_output_test, m) {
+    torch_ext::registerPyOpDefs(m);
+    m.def("run_post_layers", &rtp_llm::test::runCustomOutput);
+    py::class_<rtp_llm::PostLayersProcessor>(m, "PostLayersProcessor")
+        .def(py::init<>())
+        .def("set_handler", &rtp_llm::PostLayersProcessor::setHandler)
+        .def("uses_pre_final_norm", &rtp_llm::PostLayersProcessor::usesPreFinalNorm);
+}

--- a/rtp_llm/cpp/models/test/pywrapped_model_custom_output_test.py
+++ b/rtp_llm/cpp/models/test/pywrapped_model_custom_output_test.py
@@ -1,0 +1,209 @@
+import os
+import unittest
+from enum import Enum
+from unittest import mock
+
+import torch
+
+from rtp_llm.cpp.models.test.libth_pywrapped_model_custom_output_test import (
+    PostLayersProcessor,
+    run_post_layers,
+)
+
+
+class Stage(str, Enum):
+    PRE = "pre_final_norm"
+    POST = "post_final_norm"
+
+
+class LegacyHandler:
+    def extend_forward_args(self):
+        return ["last_hidden_states"]
+
+    def trigger_mode(self):
+        return "context"
+
+    def extend_forward(self, **kwargs):
+        return next(iter(kwargs.values())).clone()
+
+
+class Handler(LegacyHandler):
+    def __init__(self, stage=Stage.POST, selected=False):
+        self.stage = stage
+        self.selected = selected
+
+    def hidden_state_stage(self):
+        return self.stage
+
+    def extend_forward_args(self):
+        return ["selected_hidden_states" if self.selected else "last_hidden_states"]
+
+
+class Model:
+    supports_pre_final_norm = True
+
+    def initialize(self, resources):
+        return True
+
+
+class CustomOutputTestBase(unittest.TestCase):
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        for name in (
+            "CUSTOM_OUTPUT_TRACKED_TOKEN_ID",
+            "CUSTOM_OUTPUT_TOKEN_POSITION",
+            "CUSTOM_OUTPUT_EXPECTED_TOKEN_ID",
+        ):
+            os.environ.pop(name, None)
+
+
+class CustomOutputProtocolTest(CustomOutputTestBase):
+    def test_legacy_handler_defaults_to_post(self):
+        processor = PostLayersProcessor()
+        processor.set_handler(LegacyHandler())
+        self.assertFalse(processor.uses_pre_final_norm())
+
+    def test_enum_string_and_reset(self):
+        processor = PostLayersProcessor()
+        for stage in (Stage.PRE, "pre_final_norm"):
+            processor.set_handler(Handler(stage))
+            self.assertTrue(processor.uses_pre_final_norm())
+        processor.set_handler(None)
+        self.assertFalse(processor.uses_pre_final_norm())
+        processor.set_handler(Handler())
+        self.assertFalse(processor.uses_pre_final_norm())
+
+    def test_invalid_stage_fails_registration(self):
+        with self.assertRaisesRegex(RuntimeError, "unsupported.*hidden_state_stage"):
+            PostLayersProcessor().set_handler(Handler("pre_norm_typo"))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA/ROCm")
+class CustomOutputPostLayersTest(CustomOutputTestBase):
+    def setUp(self):
+        super().setUp()
+        self.hidden = (
+            torch.arange(24, device="cuda", dtype=torch.float32).reshape(6, 4) + 1
+        )
+        self.normalized = self.hidden * torch.rsqrt(
+            self.hidden.square().mean(-1, keepdim=True) + 1e-5
+        )
+
+    def run_case(
+        self, stage, python_norm, selected, all_logits, pre_hidden=None, model=None
+    ):
+        env = {"CUSTOM_OUTPUT_TRACKED_TOKEN_ID": "42"} if selected else {}
+        with mock.patch.dict(os.environ, env):
+            # One decode row, then two variable-length context requests.
+            return run_post_layers(
+                model or Model(),
+                Handler(stage, selected),
+                self.normalized if python_norm else self.hidden,
+                torch.tensor([0, 2, 5], dtype=torch.int32),
+                torch.tensor([1, 4], dtype=torch.int32) if selected else None,
+                1,
+                python_norm,
+                all_logits,
+                pre_hidden,
+            )
+
+    def test_pre_and_post_keep_lm_logits_identical(self):
+        for python_norm in (True, False):
+            for selected in (True, False):
+                for all_logits in (True, False):
+                    with self.subTest(
+                        python_norm=python_norm,
+                        selected=selected,
+                        all_logits=all_logits,
+                    ):
+                        rows = [1, 4] if selected else [2, 5]
+                        pre = self.run_case(
+                            Stage.PRE,
+                            python_norm,
+                            selected,
+                            all_logits,
+                            self.hidden[rows] if python_norm else None,
+                        )
+                        post = self.run_case(
+                            Stage.POST, python_norm, selected, all_logits
+                        )
+                        self.assertEqual(pre["custom_output_error"], "")
+                        self.assertEqual(post["custom_output_error"], "")
+                        torch.testing.assert_close(
+                            pre["custom_output"], self.hidden[rows]
+                        )
+                        torch.testing.assert_close(
+                            post["custom_output"], self.normalized[rows]
+                        )
+                        torch.testing.assert_close(
+                            pre["logits"], post["logits"], rtol=0, atol=0
+                        )
+                        torch.testing.assert_close(
+                            pre["hidden_states"], post["hidden_states"], rtol=0, atol=0
+                        )
+
+    def test_missing_or_malformed_python_capture_never_falls_back(self):
+        for capture in (
+            None,
+            self.hidden[:1],
+            self.hidden[:2, :2],
+            self.hidden[:2].double(),
+        ):
+            with self.subTest(capture=capture):
+                result = self.run_case(Stage.PRE, True, True, False, capture)
+                self.assertIsNone(result["custom_output"])
+                self.assertIn("pre_final_norm", result["custom_output_error"])
+
+    def test_unsupported_python_model_fails_startup(self):
+        model = Model()
+        model.supports_pre_final_norm = False
+        with self.assertRaisesRegex(RuntimeError, "does not support pre_final_norm"):
+            self.run_case(Stage.PRE, True, True, False, model=model)
+
+    def test_decode_does_not_invoke_handler(self):
+        result = run_post_layers(
+            Model(),
+            Handler(Stage.PRE),
+            self.normalized[:1],
+            torch.tensor([0], dtype=torch.int32),
+            None,
+            1,
+            True,
+            False,
+            None,
+        )
+        self.assertIsNone(result["custom_output"])
+        self.assertEqual(result["custom_output_error"], "")
+
+    def test_disabled_handler_and_legacy_post_path_preserve_generation(self):
+        disabled = run_post_layers(
+            Model(),
+            None,
+            self.normalized,
+            torch.tensor([0, 2, 5], dtype=torch.int32),
+            None,
+            1,
+            True,
+            False,
+            None,
+        )
+        legacy = run_post_layers(
+            Model(),
+            LegacyHandler(),
+            self.normalized,
+            torch.tensor([0, 2, 5], dtype=torch.int32),
+            None,
+            1,
+            True,
+            False,
+            None,
+        )
+        self.assertIsNone(disabled["custom_output"])
+        torch.testing.assert_close(legacy["custom_output"], self.normalized[[2, 5]])
+        torch.testing.assert_close(disabled["logits"], legacy["logits"], rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models/downstream_modules/custom_module.py
+++ b/rtp_llm/models/downstream_modules/custom_module.py
@@ -26,6 +26,13 @@ class Trigger(str, Enum):
     CONTEXT = "context"
 
 
+class HiddenStateStage(str, Enum):
+    """Source of generate-path hidden states, independent of token selection."""
+
+    POST_FINAL_NORM = "post_final_norm"
+    PRE_FINAL_NORM = "pre_final_norm"
+
+
 class CustomModule(object):
     renderer: "CustomRenderer"
     handler: "CustomHandler"
@@ -95,6 +102,15 @@ class CustomHandler(object):
     # engine invokes extend_forward. The embedding engine ignores this.
     def trigger_mode(self) -> Trigger:
         return Trigger.CONTEXT
+
+    def hidden_state_stage(self) -> HiddenStateStage:
+        """Match the stage used to train this head; embedding ignores this.
+
+        The default preserves the model's final normalized output. PRE_FINAL_NORM
+        means the input to the final model norm, not the norms inside each block.
+        Unsupported models/backends must reject it rather than substitute data.
+        """
+        return HiddenStateStage.POST_FINAL_NORM
 
     # extended_forward
     # input_lengths: [batch_size]

--- a/rtp_llm/models_py/bindings/OpDefs.cc
+++ b/rtp_llm/models_py/bindings/OpDefs.cc
@@ -266,12 +266,18 @@ void registerPyOpDefs(pybind11::module& m) {
         .def_readwrite(
             "bert_embedding_inputs", &PyModelInputs::bert_embedding_inputs, "BERT embedding inputs structure")
         .def_readwrite("input_embeddings", &PyModelInputs::input_embeddings, "Input embeddings tensors")
-        .def_readwrite("input_embeddings_locs", &PyModelInputs::input_embeddings_locs, "Input embeddings locations");
+        .def_readwrite("input_embeddings_locs", &PyModelInputs::input_embeddings_locs, "Input embeddings locations")
+        .def_readwrite("pre_final_norm_output_indexes",
+                       &PyModelInputs::pre_final_norm_output_indexes,
+                       "Optional device int64 indexes of context rows to retain before the final norm");
 
     pybind11::class_<PyModelOutputs>(m, "PyModelOutputs")
         .def(pybind11::init<>(), "Default constructor")
         .def(pybind11::init<torch::Tensor>(), pybind11::arg("hidden_states"), "Initialize with hidden states tensor")
-        .def_readwrite("hidden_states", &PyModelOutputs::hidden_states, "Hidden states output tensor");
+        .def_readwrite("hidden_states", &PyModelOutputs::hidden_states, "Hidden states output tensor")
+        .def_readwrite("pre_final_norm_hidden_states",
+                       &PyModelOutputs::pre_final_norm_hidden_states,
+                       "Optional selected pre-final-norm rows [context_batch, hidden]");
 }
 
 }  // namespace torch_ext

--- a/rtp_llm/models_py/bindings/OpDefs.h
+++ b/rtp_llm/models_py/bindings/OpDefs.h
@@ -360,6 +360,9 @@ struct PyModelInputs {
     BertEmbeddingInputs                       bert_embedding_inputs;
     std::optional<std::vector<torch::Tensor>> input_embeddings;
     torch::Tensor                             input_embeddings_locs;
+    // Optional device int64 indexes, one per context request. Undefined on
+    // decode/default post-norm paths. Select BEFORE applying the final norm.
+    torch::Tensor pre_final_norm_output_indexes;
 
     bool hasAttentionInputsByTag() const {
         return !attention_inputs_by_tag.empty();
@@ -368,6 +371,9 @@ struct PyModelInputs {
 
 struct PyModelOutputs {
     torch::Tensor hidden_states;
+    // Selected rows only [context_batch, hidden], NOT the full token activation.
+    // hidden_states always keeps its existing semantics for generation.
+    torch::Tensor pre_final_norm_hidden_states;
 
     PyModelOutputs() = default;
 

--- a/rtp_llm/models_py/bindings/py_model_inputs_compat_test.py
+++ b/rtp_llm/models_py/bindings/py_model_inputs_compat_test.py
@@ -95,11 +95,18 @@ class PyModelInputsCompatTest(unittest.TestCase):
         self.assertTrue(inputs.attention_inputs.is_prefill)
         self.assertEqual(3, inputs.attention_inputs.input_lengths.item())
 
-    def test_model_outputs_only_exposes_hidden_states(self) -> None:
+    def test_model_outputs_preserves_constructor_and_optional_capture(self) -> None:
         hidden_states = torch.empty(0)
         outputs = PyModelOutputs(hidden_states)
 
         self.assertEqual(hidden_states.data_ptr(), outputs.hidden_states.data_ptr())
+        self.assertIsNone(outputs.pre_final_norm_hidden_states)
+        self.assertIsNone(PyModelInputs().pre_final_norm_output_indexes)
+        selected = torch.ones(2, 4)
+        outputs.pre_final_norm_hidden_states = selected
+        self.assertEqual(
+            selected.data_ptr(), outputs.pre_final_norm_hidden_states.data_ptr()
+        )
         self.assertFalse(hasattr(outputs, "params_ptr"))
         with self.assertRaises(TypeError):
             PyModelOutputs(hidden_states, {"full": None})

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -25,6 +25,9 @@ from rtp_llm.utils.model_weight import W
 
 
 class GptModelBase(nn.Module):
+    # Opt in only when forward returns selected rows from immediately before
+    # the final norm. Existence of a .norm attribute alone is not sufficient.
+    supports_pre_final_norm = False
 
     def __init__(
         self,
@@ -201,6 +204,20 @@ class GptModelBase(nn.Module):
             raise RuntimeError(
                 f"{type(self).__name__} does not support input_embeddings."
             )
+
+    def final_norm_outputs(
+        self, hidden_states: Tensor, inputs: PyModelInputs
+    ) -> PyModelOutputs:
+        indexes = inputs.pre_final_norm_output_indexes
+        # index_select owns only [context_batch, hidden] storage. Do this before
+        # norm: some kernels may modify their input in place.
+        selected = (
+            torch.index_select(hidden_states, 0, indexes) if indexes is not None else None
+        )
+        outputs = PyModelOutputs(self.norm(hidden_states))
+        if selected is not None:
+            outputs.pre_final_norm_hidden_states = selected
+        return outputs
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         raise NotImplementedError("forward method must be implemented in subclass")

--- a/rtp_llm/models_py/model_desc/qwen3.py
+++ b/rtp_llm/models_py/model_desc/qwen3.py
@@ -80,6 +80,7 @@ class Qwen3DecoderLayer(nn.Module):
 
 
 class Qwen3Model(GptModelBase):
+    supports_pre_final_norm = True
 
     def __init__(
         self,
@@ -135,8 +136,7 @@ class Qwen3Model(GptModelBase):
                 layer_fmha_impl,
                 kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
             )
-        hidden_states = self.norm(hidden_states)
-        return PyModelOutputs(hidden_states)
+        return self.final_norm_outputs(hidden_states, inputs)
 
 
 __all__ = [

--- a/rtp_llm/models_py/model_desc/test/BUILD
+++ b/rtp_llm/models_py/model_desc/test/BUILD
@@ -3,6 +3,12 @@ py_test_deps = [
 ]
 
 py_test(
+    name = "custom_output_hidden_stage_test",
+    srcs = ["custom_output_hidden_stage_test.py"],
+    deps = py_test_deps,
+)
+
+py_test(
     name = "generic_moe_allreduce_test",
     srcs = ["generic_moe_allreduce_test.py"],
     deps = py_test_deps + [

--- a/rtp_llm/models_py/model_desc/test/custom_output_hidden_stage_test.py
+++ b/rtp_llm/models_py/model_desc/test/custom_output_hidden_stage_test.py
@@ -1,0 +1,120 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.model_desc.qwen3 import Qwen3Model
+from rtp_llm.ops.compute_ops import PyModelInputs
+
+
+class AddResidual(torch.nn.Module):
+    def forward(self, hidden, fmha_impl, kv_cache=None):
+        return hidden + 2
+
+
+class InplaceNorm(torch.nn.Module):
+    def forward(self, hidden):
+        return hidden.mul_(0.25)
+
+
+def make_model(dtype=torch.float32):
+    # Exercise the real forward/selection path without attention kernels or a
+    # checkpoint. The norm and the score head use actual torch tensor math.
+    model = Qwen3Model.__new__(Qwen3Model)
+    torch.nn.Module.__init__(model)
+    model.embed_tokens = torch.nn.Embedding(8, 4, dtype=dtype)
+    with torch.no_grad():
+        model.embed_tokens.weight.copy_(torch.arange(32).reshape(8, 4))
+    model.layers = torch.nn.ModuleList([AddResidual()])
+    model.layer_num = 1
+    model.kv_cache = None
+    model.norm = torch.nn.RMSNorm(4, eps=1e-6, dtype=dtype)
+    return model.eval()
+
+
+def make_inputs(indexes=None):
+    inputs = PyModelInputs()
+    inputs.input_ids = torch.tensor([1, 2, 3, 4, 5])
+    if indexes is not None:
+        inputs.pre_final_norm_output_indexes = torch.tensor(indexes, dtype=torch.long)
+    return inputs
+
+
+class CustomOutputHiddenStageTest(unittest.TestCase):
+    def test_models_must_explicitly_opt_in(self):
+        self.assertFalse(GptModelBase.supports_pre_final_norm)
+        self.assertTrue(Qwen3Model.supports_pre_final_norm)
+
+    def test_default_has_no_extra_gather_or_output(self):
+        model = make_model()
+        inputs = make_inputs()
+        expected = model.norm(model.embed_tokens(inputs.input_ids) + 2)
+        with mock.patch.object(
+            torch, "index_select", wraps=torch.index_select
+        ) as gather:
+            outputs = model.forward(inputs, fmha_impl=object())
+        gather.assert_not_called()
+        self.assertIsNone(outputs.pre_final_norm_hidden_states)
+        torch.testing.assert_close(outputs.hidden_states, expected, rtol=0, atol=0)
+
+    def test_selected_rows_match_training_head_without_changing_generation(self):
+        for dtype in (torch.float32, torch.bfloat16):
+            with self.subTest(dtype=dtype), torch.no_grad():
+                model = make_model(dtype)
+                inputs = make_inputs([4, 1])  # preserve request order, not token order
+                before = model.embed_tokens(inputs.input_ids) + 2
+                baseline = model.forward(make_inputs(), fmha_impl=object())
+                outputs = model.forward(inputs, fmha_impl=object())
+                selected = outputs.pre_final_norm_hidden_states
+                self.assertEqual(selected.shape, (2, 4))
+                self.assertEqual(selected.dtype, dtype)
+                # Retained storage must be batch-sized, not a view of all tokens.
+                self.assertEqual(
+                    selected.untyped_storage().nbytes(), 2 * 4 * selected.element_size()
+                )
+                torch.testing.assert_close(selected, before[[4, 1]], rtol=0, atol=0)
+                torch.testing.assert_close(
+                    outputs.hidden_states, baseline.hidden_states, rtol=0, atol=0
+                )
+                head = (
+                    torch.nn.Sequential(
+                        torch.nn.Linear(4, 2), torch.nn.SiLU(), torch.nn.Linear(2, 1)
+                    )
+                    .to(dtype)
+                    .eval()
+                )
+                torch.testing.assert_close(
+                    torch.sigmoid(head(selected).float()),
+                    torch.sigmoid(head(before[[4, 1]]).float()),
+                    rtol=0,
+                    atol=0,
+                )
+                lm_head = torch.arange(12, dtype=dtype).reshape(3, 4)
+                torch.testing.assert_close(
+                    outputs.hidden_states @ lm_head.T,
+                    baseline.hidden_states @ lm_head.T,
+                    rtol=0,
+                    atol=0,
+                )
+
+    def test_capture_precedes_even_an_inplace_norm(self):
+        model = make_model()
+        model.norm = InplaceNorm()
+        inputs = make_inputs([1, 3])
+        before = model.embed_tokens(inputs.input_ids) + 2
+        outputs = model.forward(inputs, fmha_impl=object())
+        torch.testing.assert_close(outputs.pre_final_norm_hidden_states, before[[1, 3]])
+        torch.testing.assert_close(outputs.hidden_states, before * 0.25)
+
+    def test_capture_does_not_leak_into_next_decode_or_default_call(self):
+        model = make_model()
+        first = model.forward(make_inputs([1, 3]), fmha_impl=object())
+        saved = first.pre_final_norm_hidden_states.clone()
+        second = model.forward(make_inputs(), fmha_impl=object())
+        self.assertIsNone(second.pre_final_norm_hidden_states)
+        torch.testing.assert_close(first.pre_final_norm_hidden_states, saved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/ops/librtp_compute_ops/__init__.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/__init__.pyi
@@ -306,6 +306,7 @@ class PyModelInitResources:
     def max_context_batch_size(self) -> int: ...
 
 class PyModelInputs:
+    pre_final_norm_output_indexes: typing.Optional[torch.Tensor]
     @typing.overload
     def __init__(self) -> None: ...
     @typing.overload
@@ -393,6 +394,7 @@ class PyModelInputs:
     def input_embeddings_locs(self, arg0: torch.Tensor) -> None: ...
 
 class PyModelOutputs:
+    pre_final_norm_hidden_states: typing.Optional[torch.Tensor]
     @typing.overload
     def __init__(self) -> None:
         """

--- a/rtp_llm/test/custom_output_processor_test.py
+++ b/rtp_llm/test/custom_output_processor_test.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from rtp_llm.models.downstream_modules.custom_module import (
     CustomHandler,
+    HiddenStateStage,
     Trigger,
 )
 from rtp_llm.models.downstream_modules.utils import create_post_layers_module
@@ -30,6 +31,19 @@ def create_custom_module(config, tokenizer):
 """
 
 class TriggerProtocolTest(unittest.TestCase):
+    def test_default_stage_preserves_post_final_norm(self):
+        self.assertEqual(
+            CustomHandler(None).hidden_state_stage(), HiddenStateStage.POST_FINAL_NORM
+        )
+
+    def test_stage_is_independent_of_token_selection(self):
+        class ScoreHandler(CustomHandler):
+            def hidden_state_stage(self):
+                return HiddenStateStage.PRE_FINAL_NORM
+
+        self.assertEqual(ScoreHandler(None).hidden_state_stage(), "pre_final_norm")
+        self.assertEqual(HiddenStateStage.POST_FINAL_NORM.value, "post_final_norm")
+
     def test_default_trigger_is_context(self):
         handler = CustomHandler(None)
         self.assertEqual(handler.trigger_mode(), Trigger.CONTEXT)


### PR DESCRIPTION
## Summary

- Add `CustomHandler.hidden_state_stage()` with `POST_FINAL_NORM` as the backward-compatible default and explicit `PRE_FINAL_NORM` support.
- Keep token selection independent from the hidden-state stage. Capture only requested rows before final normalization, without changing the generation logits path.
- Wire pre-norm outputs through the Python/C++ bindings and Qwen3; reject unsupported model/backend combinations rather than silently substituting post-norm states.
- Add protocol, binding compatibility, model-forward, and C++ post-layers tests plus a short example update.

## Scope and base branch

This is a **draft, stacked against `bugfix/2026-08`**, so the diff contains only the hidden-state-stage change (18 files, one commit). Its custom-output infrastructure is not yet on `main`; this PR is not the main-branch migration. The inherited compatibility changes are not introduced or endorsed by this diff.

The handler remains **prefill-only (`Trigger.CONTEXT`)**. Per-decode-step invocation, generated-token triggers, and final-step scoring are not implemented in this PR.

## Validation

Built with CUDA 12.9 and ran four Bazel test targets under a GPU lock:

- PASS: `//rtp_llm/models_py/model_desc/test:custom_output_hidden_stage_test` — 5 cases.
- PASS: `//rtp_llm/models_py/bindings:py_model_inputs_compat_test` — 9 cases.
- PASS: `//rtp_llm/test:custom_output_processor_test` — 11 cases.
- BLOCKED at module import: `//rtp_llm/cpp/models/test:pywrapped_model_custom_output_test` — runtime `libibverbs.so.1` lacks `IBVERBS_1.11`; its assertions did not execute. A library-path diagnostic also exposed an unresolved transitive dependency named `visibility=hidden`.

Compilation succeeded after regenerating invalid CUDA dependency cache outputs. `git diff --check` and syntax checks of all nine changed Python/stub files passed.

## Remaining before release

- [ ] Resolve the C++ test runtime dependencies and execute its assertions.
- [ ] Validate real-checkpoint offline/online scores against the comparison CSV; parity is **not verified**.
- [ ] Prepare and revalidate the minimal dependency migration to `main` separately.

No release package or deployment has been produced. Python and C++ bindings must be rebuilt/deployed together.
