### PR TITLE
feat: support FP8 KV cache modes in FlashInfer attention

### DIFF
--- a/3rdparty/flashinfer/build-flashinfer-v0.6.9-direct-scale-wheel.sh
+++ b/3rdparty/flashinfer/build-flashinfer-v0.6.9-direct-scale-wheel.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly FLASHINFER_REPOSITORY="https://github.com/flashinfer-ai/flashinfer.git"
+readonly FLASHINFER_COMMIT="a1aa676196f798435248d9ea205c67674476f473"
+readonly SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly PATCH_FILE="${SCRIPT_DIR}/flashinfer-v0.6.9-direct-per-token-kv-scale.patch"
+
+if (( $# > 1 )); then
+  echo "usage: $0 [wheel-output-directory]" >&2
+  exit 2
+fi
+
+OUTPUT_DIR="${1:-/tmp}"
+PYTHON="${PYTHON:-python3}"
+: "${FLASHINFER_LOCAL_VERSION:=rtp.dynamicfp8.1}"
+export FLASHINFER_LOCAL_VERSION
+
+[[ -f "${PATCH_FILE}" ]] || { echo "missing patch: ${PATCH_FILE}" >&2; exit 1; }
+mkdir -p "${OUTPUT_DIR}"
+OUTPUT_DIR="$(cd "${OUTPUT_DIR}" && pwd -P)"
+
+BUILD_ROOT="$(mktemp -d /tmp/flashinfer-wheel.XXXXXX)"
+trap 'rm -rf "${BUILD_ROOT}"' EXIT
+SOURCE_DIR="${BUILD_ROOT}/flashinfer"
+
+# Keep all build/JIT caches inside the disposable checkout and never install the wheel.
+export PIP_NO_CACHE_DIR=1
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+export PYTHONNOUSERSITE=1
+export XDG_CACHE_HOME="${BUILD_ROOT}/cache"
+export FLASHINFER_WORKSPACE_BASE="${BUILD_ROOT}/flashinfer-workspace"
+export TORCH_EXTENSIONS_DIR="${BUILD_ROOT}/torch-extensions"
+
+git clone --quiet --filter=blob:none "${FLASHINFER_REPOSITORY}" "${SOURCE_DIR}"
+git -C "${SOURCE_DIR}" checkout --quiet --detach "${FLASHINFER_COMMIT}"
+[[ "$(git -C "${SOURCE_DIR}" rev-parse HEAD)" == "${FLASHINFER_COMMIT}" ]] || {
+  echo "unexpected FlashInfer commit" >&2
+  exit 1
+}
+git -C "${SOURCE_DIR}" submodule update --init --recursive
+
+git -C "${SOURCE_DIR}" apply --check "${PATCH_FILE}"
+git -C "${SOURCE_DIR}" apply "${PATCH_FILE}"
+git -C "${SOURCE_DIR}" diff --check -- \
+  include/flashinfer/attention/variant_helper.cuh \
+  include/flashinfer/attention/prefill.cuh
+
+"${PYTHON}" -m pip wheel --no-deps --no-cache-dir --wheel-dir "${OUTPUT_DIR}" "${SOURCE_DIR}"
+echo "FlashInfer wheel written to ${OUTPUT_DIR}"

--- a/3rdparty/flashinfer/flashinfer-v0.6.9-direct-per-token-kv-scale.patch
+++ b/3rdparty/flashinfer/flashinfer-v0.6.9-direct-per-token-kv-scale.patch
@@ -1,0 +1,177 @@
+diff --git a/include/flashinfer/attention/prefill.cuh b/include/flashinfer/attention/prefill.cuh
+index 5db013bb..25e00923 100644
+--- a/include/flashinfer/attention/prefill.cuh
++++ b/include/flashinfer/attention/prefill.cuh
+@@ -687,6 +687,37 @@ __device__ __forceinline__ void compute_qk(
+   *k_smem_offset_r -= KTraits::NUM_MMA_D_QK * sizeof(typename KTraits::DTypeKV);
+ }
+ 
++template <typename KTraits, typename Params>
++__device__ __forceinline__ void apply_per_token_k_scale(
++    const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
++    const uint32_t kv_idx_base,
++    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
++    const uint32_t lane_idx = threadIdx.x, const uint32_t kv_head_idx = blockIdx.z) {
++  if constexpr (KTraits::AttentionVariant::use_per_token_kv_scale) {
++#pragma unroll
++    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
++      float k_scale[4];
++#pragma unroll
++      for (uint32_t scale_idx = 0; scale_idx < 4; ++scale_idx) {
++        const uint32_t kv_idx = kv_idx_base + mma_kv * 16 + 2 * (lane_idx % 4) +
++                                8 * (scale_idx / 2) + scale_idx % 2;
++        k_scale[scale_idx] =
++            variant.KVScale(params, batch_idx, kv_idx, kv_head_idx, /*kv_selector=*/0);
++      }
++#pragma unroll
++      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
++#pragma unroll
++        for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
++          float scaled = float(s_frag[mma_q][mma_kv][reg_id]) *
++                         k_scale[2 * (reg_id / 4) + reg_id % 2];
++          vec_cast<typename KTraits::DTypeQKAccum, float>::cast<1>(
++              &s_frag[mma_q][mma_kv][reg_id], &scaled);
++        }
++      }
++    }
++  }
++}
++
+ template <typename KTraits, typename Params, typename DTypeQKAccum>
+ __device__ __forceinline__ void logits_transform(
+     const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
+@@ -952,8 +983,10 @@ __device__ __forceinline__ void update_mdo_states(
+   }
+ }
+ 
+-template <typename KTraits>
++template <typename KTraits, typename Params>
+ __device__ __forceinline__ void compute_sfm_v(
++    const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
++    const uint32_t kv_idx_base, const uint32_t kv_head_idx,
+     smem_t<KTraits::SWIZZLE_MODE_KV>* v_smem, uint32_t* v_smem_offset_r,
+     typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+     float (*o_frag)[KTraits::NUM_MMA_D_VO][8], float (*d)[2]) {
+@@ -985,6 +1018,38 @@ __device__ __forceinline__ void compute_sfm_v(
+     }
+   }
+ 
++  // Scale the exact probability fragments consumed by PV MMA only after the
++  // unscaled softmax denominator has been accumulated into d.
++  if constexpr (KTraits::AttentionVariant::use_per_token_kv_scale) {
++#pragma unroll
++    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
++      float v_scale[4];
++#pragma unroll
++      for (uint32_t scale_idx = 0; scale_idx < 4; ++scale_idx) {
++        const uint32_t kv_idx = kv_idx_base + mma_kv * 16 + 2 * (threadIdx.x % 4) +
++                                8 * (scale_idx / 2) + scale_idx % 2;
++        v_scale[scale_idx] =
++            variant.KVScale(params, batch_idx, kv_idx, kv_head_idx, /*kv_selector=*/1);
++      }
++#pragma unroll
++      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
++#pragma unroll
++        for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
++          const float scale = v_scale[2 * (reg_id / 4) + reg_id % 2];
++          if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
++            float scaled = float(s_frag_f16[mma_q][mma_kv][reg_id]) * scale;
++            vec_cast<typename KTraits::DTypeQ, float>::cast<1>(
++                &s_frag_f16[mma_q][mma_kv][reg_id], &scaled);
++          } else {
++            float scaled = float(s_frag[mma_q][mma_kv][reg_id]) * scale;
++            vec_cast<typename KTraits::DTypeQKAccum, float>::cast<1>(
++                &s_frag[mma_q][mma_kv][reg_id], &scaled);
++          }
++        }
++      }
++    }
++  }
++
+ #pragma unroll
+   for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+ #pragma unroll
+@@ -1498,6 +1563,8 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
+       compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+       uint32_t kv_idx_base =
+           chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
++      apply_per_token_k_scale<KTraits>(params, variant, /*batch_idx=*/0, kv_idx_base, s_frag,
++                                       lane_idx, kv_head_idx);
+       logits_transform<KTraits>(params, variant, /*batch_idx=*/0, qo_packed_idx_base, kv_idx_base,
+                                 qo_len, kv_len, group_size, s_frag, tid, kv_head_idx);
+ 
+@@ -1518,7 +1585,8 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
+       block.sync();
+ 
+       // compute sfm*v
+-      compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
++      compute_sfm_v<KTraits>(params, variant, /*batch_idx=*/0, kv_idx_base, kv_head_idx, &v_smem,
++                             &v_smem_offset_r, s_frag, o_frag, d);
+ 
+       block.sync();
+       produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+@@ -1937,6 +2005,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
+       compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+       uint32_t kv_idx_base =
+           chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
++      apply_per_token_k_scale<KTraits>(params, variant, /*batch_idx=*/request_idx, kv_idx_base, s_frag,
++                                       lane_idx, kv_head_idx);
+       logits_transform<KTraits>(params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
+                                 kv_idx_base, qo_len, kv_len, group_size, s_frag, tid, kv_head_idx);
+ 
+@@ -1958,7 +2028,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
+       block.sync();
+ 
+       // compute sfm*v
+-      compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
++      compute_sfm_v<KTraits>(params, variant, /*batch_idx=*/request_idx, kv_idx_base, kv_head_idx,
++                             &v_smem, &v_smem_offset_r, s_frag, o_frag, d);
+ 
+       block.sync();
+       produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+@@ -2300,6 +2371,8 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
+       compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+       uint32_t kv_idx_base =
+           chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
++      apply_per_token_k_scale<KTraits>(params, variant, /*batch_idx=*/request_idx, kv_idx_base, s_frag,
++                                       lane_idx, kv_head_idx);
+       logits_transform<KTraits>(params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
+                                 kv_idx_base, qo_len, kv_len, group_size, s_frag, tid, kv_head_idx);
+ 
+@@ -2345,7 +2418,8 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
+       block.sync();
+ 
+       // compute sfm*v
+-      compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
++      compute_sfm_v<KTraits>(params, variant, /*batch_idx=*/request_idx, kv_idx_base, kv_head_idx,
++                             &v_smem, &v_smem_offset_r, s_frag, o_frag, d);
+ 
+       block.sync();
+       page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data,
+diff --git a/include/flashinfer/attention/variant_helper.cuh b/include/flashinfer/attention/variant_helper.cuh
+index bf97db38..03a8482c 100644
+--- a/include/flashinfer/attention/variant_helper.cuh
++++ b/include/flashinfer/attention/variant_helper.cuh
+@@ -74,6 +74,7 @@ DEFINE_HAS_MEMBER(v_scale)
+ 
+ struct AttentionVariantBase {
+   constexpr static bool use_softmax = true;
++  static constexpr bool use_per_token_kv_scale = false;
+   REGISTER_LOGITS_TRANSFORM(params, logits, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx,
+                             { return logits; })
+ 
+@@ -88,6 +89,14 @@ struct AttentionVariantBase {
+     return output * d_rcp * v_scale_val;
+   })
+ 
++  // Per-token KV scale hook. Custom variants can enable it and override this method.
++  // kv_selector is 0 for K and 1 for V.
++  template <typename Params>
++  __device__ __forceinline__ float KVScale(const Params& params, uint32_t batch_idx, uint32_t kv_idx,
++                                           uint32_t kv_head_idx, uint32_t kv_selector) {
++    return 1.f;
++  }
++
+   // Helper to get v_scale from params, returns 1.0f if not present
+   template <typename Params>
+   __device__ __forceinline__ static float get_v_scale(const Params& params) {

--- a/rtp_llm/config/model_config.py
+++ b/rtp_llm/config/model_config.py
@@ -662,23 +662,34 @@ class ModelConfig(CppModelConfig):
                     "ACT_TYPE can be configured manually."
                 )
 
-        # Set attn_config.kv_cache_dtype based on kv_cache_config
+        # Propagate the exact FP8 KV cache mode to attention implementations and
+        # derive the storage dtype without collapsing dynamic mode 2 into a bool.
         if kv_cache_config is not None:
-            if kv_cache_config.fp8_kv_cache:
+            fp8_kv_cache_mode = int(kv_cache_config.fp8_kv_cache)
+            if fp8_kv_cache_mode not in (0, 1, 2):
+                raise ValueError(
+                    "fp8_kv_cache must be one of 0, 1, or 2, "
+                    f"got {fp8_kv_cache_mode}"
+                )
+            self.attn_config.fp8_kv_cache_mode = fp8_kv_cache_mode
+            if fp8_kv_cache_mode in (1, 2):
                 self.attn_config.kv_cache_dtype = KvCacheDataType.FP8
                 logging.info(
-                    "Setting attn_config.kv_cache_dtype to FP8 based on kv_cache_config.fp8_kv_cache"
+                    "Setting attn_config.kv_cache_dtype to FP8 for "
+                    f"fp8_kv_cache mode {fp8_kv_cache_mode}"
                 )
             else:
                 self.attn_config.kv_cache_dtype = KvCacheDataType.BASE
                 logging.info(
-                    "Setting attn_config.kv_cache_dtype to BASE (default, no fp8 kv_cache specified)"
+                    "Setting attn_config.kv_cache_dtype to BASE (fp8_kv_cache mode 0)"
                 )
 
         if quant_config and quant_config.get_method().lower() == "fp8":
             self.attn_config.kv_cache_dtype = KvCacheDataType.FP8
+            if self.attn_config.fp8_kv_cache_mode == 0:
+                self.attn_config.fp8_kv_cache_mode = 1
             logging.info(
-                "Setting attn_config.kv_cache_dtype to FP8 based on quant_config.get_method().lower() == 'fp8'"
+                "Setting legacy FP8 KV cache mode based on quant_config.get_method().lower() == 'fp8'"
             )
 
         # Validate configuration with quant_config

--- a/rtp_llm/config/test/server_config_setup_test.py
+++ b/rtp_llm/config/test/server_config_setup_test.py
@@ -12,7 +12,7 @@ from rtp_llm.config.server_config_setup import (
     set_parallelism_config,
     setup_and_configure_server,
 )
-from rtp_llm.ops import CPRotateMethod, NcclCommConfig, RoleType
+from rtp_llm.ops import CPRotateMethod, KvCacheDataType, NcclCommConfig, RoleType
 from rtp_llm.server.server_args.server_args import setup_args
 
 # clear=True must preserve gpu_lock isolation across Torch lazy initialization.
@@ -103,6 +103,64 @@ class GenerateConfigTest(TestCase):
         self.assertFalse(config.enable_gpu_prefix_tree)
         self.assertFalse(config.enable_prefix_tree_memory_cache)
         self.assertTrue(config.enable_legacy_memory_connector_fallback)
+
+    def test_fp8_kv_cache_modes_parse_and_reject_invalid_values(self):
+        for flag in ("--fp8_kv_cache", "--blockwise_use_fp8_kv_cache"):
+            for mode in (0, 1, 2):
+                with self.subTest(flag=flag, mode=mode), patch.dict(
+                    os.environ, _jit_env(), clear=True
+                ):
+                    config = setup_args([flag, str(mode)]).kv_cache_config
+                    self.assertEqual(config.fp8_kv_cache, mode)
+
+        for mode in (0, 1, 2):
+            with self.subTest(env_mode=mode), patch.dict(
+                os.environ,
+                _jit_env(FP8_KV_CACHE=str(mode)),
+                clear=True,
+            ):
+                config = setup_args(["--model_type", "fake_model"]).kv_cache_config
+                self.assertEqual(config.fp8_kv_cache, mode)
+
+        for args, env in (
+            (["--fp8_kv_cache", "-1"], {}),
+            (["--fp8_kv_cache", "3"], {}),
+            (["--fp8_kv_cache", "invalid"], {}),
+            (["--model_type", "fake_model"], {"FP8_KV_CACHE": "3"}),
+        ):
+            stderr = io.StringIO()
+            with self.subTest(args=args, env=env), patch.dict(
+                os.environ, _jit_env(**env), clear=True
+            ), contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit):
+                setup_args(args)
+            self.assertIn("must be one of 0, 1, or 2", stderr.getvalue())
+
+    @patch(
+        "rtp_llm.config.model_config.QuantizationConfig.load_from_ckpt",
+        return_value=None,
+    )
+    def test_fp8_kv_cache_mode_propagates_to_attention_config(self, _load_from_ckpt):
+        from rtp_llm.config.model_config import ModelConfig
+
+        for mode, expected_dtype in (
+            (0, KvCacheDataType.BASE),
+            (1, KvCacheDataType.FP8),
+            (2, KvCacheDataType.FP8),
+        ):
+            with self.subTest(mode=mode):
+                kv_cache_config = PyEnvConfigs().kv_cache_config
+                kv_cache_config.fp8_kv_cache = mode
+                model_config = ModelConfig()
+
+                model_config.init_precision_config(kv_cache_config, "BF16")
+                attention_config = model_config.getAttentionConfigs(1)
+
+                self.assertEqual(attention_config.fp8_kv_cache_mode, mode)
+                self.assertEqual(attention_config.kv_cache_dtype, expected_dtype)
+
+        kv_cache_config.fp8_kv_cache = 3
+        with self.assertRaisesRegex(ValueError, "one of 0, 1, or 2"):
+            ModelConfig().init_precision_config(kv_cache_config, "BF16")
 
     def test_jit_config(self):
         valid = (

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -35,7 +35,7 @@ struct PrefillCPConfig {
     bool kv_cache_sharded = false;
     // Explicit prefill CP size for decode-side fixed/SWA ring sizing; 0 = unset.
     int64_t prefill_cp_size = 0;
-    bool           is_enabled() const {
+    bool    is_enabled() const {
         return method != CPRotateMethod::DISABLED && method != CPRotateMethod::UNKNOWN
                && method != CPRotateMethod::PREFILL_CP;
     }
@@ -168,6 +168,7 @@ struct KVCacheConfig {
     int64_t                                 memory_cache_disk_sync_timeout_ms = 30000;
     int                                     linear_step                       = 1;  // for linear attention cache reuse
     // Fields merged from PyKvCacheConfig
+    // 0 = disabled, 1 = legacy unit-scale, 2 = dynamic per-token-per-local-KV-head.
     int         fp8_kv_cache              = 0;
     std::string ssm_state_dtype           = "bf16";
     int64_t     kv_cache_mem_mb           = -1;
@@ -189,7 +190,6 @@ struct KVCacheConfig {
     bool    enable_independent_group_eviction       = false;
     int64_t device_cache_min_free_blocks            = 0;
     int     load_cache_retry_times                  = 1;  // Maximum retry attempts for load cache transfer failures
-
 
     // DSV4 fixed-allocation pool block count. 0 means the fixed regions
     // (INDEXER_STATE / CSA_STATE / HCA_STATE / SWA_KV) use the normal
@@ -394,7 +394,7 @@ struct FIFOSchedulerConfig {
     //   "N"   -> 1 prefill : N decode (decode-heavy); "1" = strict alternation.
     //   "1/X" -> X prefill : 1 decode (prefill-heavy).
     //   invalid input falls back to "1".
-    std::string decode_prefill_ratio = "1";
+    std::string decode_prefill_ratio           = "1";
     bool        cp_force_single_prefill        = true;
     int64_t     max_inited_kv_cache_streams    = 0;
     int64_t     max_batch_tokens_without_cache = 0;
@@ -404,9 +404,9 @@ struct FIFOSchedulerConfig {
 struct GrammarConfig {
     bool constrained_json_disable_any_whitespace = false;
     // Service-level xgrammar matcher policy. Requests cannot override it.
-    bool                 terminate_without_stop_token = false;
-    int                  num_workers                  = 8;
-    std::string          tokenizer_info_json;
+    bool        terminate_without_stop_token = false;
+    int         num_workers                  = 8;
+    std::string tokenizer_info_json;
     // Byte cap on xgrammar's internal compiled-grammar cache; <=0 = unlimited.
     int64_t     compiler_cache_bytes = 512 * 1024 * 1024;
     std::string to_string() const;

--- a/rtp_llm/cpp/model_utils/AttentionConfig.cc
+++ b/rtp_llm/cpp/model_utils/AttentionConfig.cc
@@ -33,6 +33,7 @@ std::string AttentionConfigs::DebugAttentionConfigStr() const {
     oss << "  v_head_dim: " << v_head_dim << std::endl;
     oss << "  softmax_extra_scale: " << softmax_extra_scale << std::endl;
     oss << "  kv_cache_dtype: " << kvCacheDataTypeToString(kv_cache_dtype) << std::endl;
+    oss << "  fp8_kv_cache_mode: " << fp8_kv_cache_mode << std::endl;
     oss << "  need_rope_kv_cache: " << need_rope_kv_cache << std::endl;
     oss << rope_config.DebugRopeConfigStr();
     return oss.str();

--- a/rtp_llm/cpp/model_utils/AttentionConfig.h
+++ b/rtp_llm/cpp/model_utils/AttentionConfig.h
@@ -49,7 +49,10 @@ struct AttentionConfigs {
     // softmax config
     float           softmax_extra_scale = 1.0f;
     KvCacheDataType kv_cache_dtype      = KvCacheDataType::BASE;
-    bool            need_rope_kv_cache  = true;
+    // Mirrors KVCacheConfig::fp8_kv_cache for Python attention implementations:
+    // 0 = disabled, 1 = legacy unit-scale, 2 = dynamic per-token-per-local-KV-head.
+    int  fp8_kv_cache_mode  = 0;
+    bool need_rope_kv_cache = true;
 
     // sparse attention config
     bool is_sparse        = false;
@@ -64,12 +67,12 @@ struct AttentionConfigs {
     //   value 128 -> HCA (compress every m'=128 raw tokens, dense MQA)
     std::vector<int> layer_compress_ratios;
     // Output projection: grouped (n_h heads -> g groups -> per-group rank -> hidden_size)
-    size_t o_groups               = 0;
-    size_t o_lora_rank            = 0;
+    size_t o_groups    = 0;
+    size_t o_lora_rank = 0;
     // Sliding-window bypass attention window size (0 disables SWA bypass)
-    int    sliding_window         = 0;
+    int sliding_window = 0;
     // Separate RoPE base for the compressed K branch (V4: rope_theta=10000 main, compress=160000)
-    double compress_rope_theta    = 0.0;
+    double compress_rope_theta = 0.0;
 
     // data type for attention computation
     c10::ScalarType dtype = c10::ScalarType::Half;
@@ -77,7 +80,7 @@ struct AttentionConfigs {
     // maximum sequence length for RoPE cache generation
     size_t max_seq_len = 32768;
 
-    // speculative decoding: tokens generated per cycle (0 = no speculative decoding)
+    // tokens generated per cycle (>1 enables speculative decoding)
     int64_t gen_num_per_cycle = 0;
 
 public:

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1654,6 +1654,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("v_head_dim", &AttentionConfigs::v_head_dim)
         .def_readwrite("softmax_extra_scale", &AttentionConfigs::softmax_extra_scale)
         .def_readwrite("kv_cache_dtype", &AttentionConfigs::kv_cache_dtype)
+        .def_readwrite("fp8_kv_cache_mode", &AttentionConfigs::fp8_kv_cache_mode)
         .def_readwrite("need_rope_kv_cache", &AttentionConfigs::need_rope_kv_cache)
         .def_readwrite("is_sparse", &AttentionConfigs::is_sparse)
         .def_readwrite("indexer_head_dim", &AttentionConfigs::indexer_head_dim)

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -51,7 +51,9 @@ py_library(
         "modules/*.py",
         "modules/**/*.py",
     ]),
-    data = [
+    data = glob([
+        "modules/factory/attention/cuda_impl/flashinfer_direct_scale/include/**/*.cuh",
+    ]) + [
         ":cutlass_moe_config",
         ":rocm_fp8_ptpc_hipb_solutions",
     ],

--- a/rtp_llm/models_py/bindings/cuda/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/BUILD
@@ -165,6 +165,7 @@ cc_library(
         "//rtp_llm/models_py/bindings/cuda/ops:cuda_impl",
         "//rtp_llm/models_py/bindings/core:types_hdr",
         "//rtp_llm/models_py/bindings/cuda/kernels:scaled_fp8_quant",
+        "//rtp_llm/models_py/bindings/cuda/kernels:fp8_kv_cache",
         "//rtp_llm/models_py/bindings/cuda/kernels:cuda_graph_prepare",
         "//rtp_llm/models_py/bindings/common/kernels:kernels_ep_util",
         "//rtp_llm/models_py/bindings/common/kernels:kernels_kv_cache",

--- a/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.cc
+++ b/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.cc
@@ -617,6 +617,120 @@ void FlashInferMlaAttnParams::fillDecodeCudaGraphParams(torch::Tensor sequence_l
     slot_mapping                 = torch::Tensor();
 }
 
+void FlashInferMlaAttnParams::fillDecodeParamsDevice(torch::Tensor sequence_lengths_h,
+                                                     torch::Tensor sequence_lengths_plus_1_d,
+                                                     torch::Tensor kv_cache_block_id_device,
+                                                     int           seq_size_per_block) {
+    sequence_lengths_h = toHostContiguousI32(sequence_lengths_h);
+    RTP_LLM_CHECK_WITH_INFO(sequence_lengths_h.defined() && sequence_lengths_h.dim() == 1,
+                            "fillDecodeParamsDevice expects one-dimensional host sequence lengths");
+    RTP_LLM_CHECK_WITH_INFO(sequence_lengths_plus_1_d.defined() && sequence_lengths_plus_1_d.is_cuda()
+                                && sequence_lengths_plus_1_d.is_contiguous()
+                                && sequence_lengths_plus_1_d.scalar_type() == torch::kInt32,
+                            "fillDecodeParamsDevice expects contiguous CUDA int32 sequence_lengths_plus_1_d");
+    RTP_LLM_CHECK_WITH_INFO(kv_cache_block_id_device.defined() && kv_cache_block_id_device.is_cuda()
+                                && kv_cache_block_id_device.is_contiguous()
+                                && kv_cache_block_id_device.scalar_type() == torch::kInt32
+                                && kv_cache_block_id_device.dim() == 2,
+                            "fillDecodeParamsDevice expects a contiguous two-dimensional CUDA int32 block table");
+    RTP_LLM_CHECK_WITH_INFO(seq_size_per_block > 0, "fillDecodeParamsDevice expects a positive page size");
+
+    const int batch_size           = static_cast<int>(sequence_lengths_h.size(0));
+    const int max_blocks_per_batch = static_cast<int>(kv_cache_block_id_device.size(1));
+    RTP_LLM_CHECK_WITH_INFO(sequence_lengths_plus_1_d.numel() == batch_size,
+                            "fillDecodeParamsDevice sequence length batch mismatch");
+    RTP_LLM_CHECK_WITH_INFO(kv_cache_block_id_device.size(0) >= batch_size,
+                            "fillDecodeParamsDevice block table does not cover the batch");
+
+    const auto sequence_lengths_ptr = sequence_lengths_h.data_ptr<int32_t>();
+    int        page_num             = 0;
+    for (int batch = 0; batch < batch_size; ++batch) {
+        const int seq_len = std::max(sequence_lengths_ptr[batch] + 1, 1);
+        const int pages   = (seq_len + seq_size_per_block - 1) / seq_size_per_block;
+        RTP_LLM_CHECK_WITH_INFO(pages <= max_blocks_per_batch,
+                                "fillDecodeParamsDevice requires %d pages but block table capacity is %d",
+                                pages,
+                                max_blocks_per_batch);
+        page_num += pages;
+    }
+
+    ensureTensorSize(batch_size, batch_size, page_num, 0, batch_size * 4, false);
+
+    auto set_i32_shape = [](torch::Tensor& tensor, std::vector<int64_t> shape) {
+        if (tensor.defined()) {
+            tensor.unsafeGetTensorImpl()->set_sizes_contiguous(shape);
+        }
+    };
+    set_i32_shape(decode_page_indptr_d, {batch_size + 1});
+    set_i32_shape(decode_page_indptr_h, {batch_size + 1});
+    set_i32_shape(prefill_ragged_kv_len_indptr_d, {0});
+    set_i32_shape(prefill_ragged_kv_len_indptr_h, {0});
+    set_i32_shape(qo_indptr_d, {batch_size + 1});
+    set_i32_shape(qo_indptr_h, {batch_size + 1});
+    set_i32_shape(batch_indice_d, {batch_size});
+    set_i32_shape(batch_indice_h, {batch_size});
+    set_i32_shape(positions_d, {batch_size});
+    set_i32_shape(positions_h, {batch_size});
+    set_i32_shape(kvlen_d, {batch_size});
+    set_i32_shape(kvlen_h, {batch_size});
+    set_i32_shape(paged_kv_last_page_len_d, {batch_size});
+    set_i32_shape(paged_kv_last_page_len_h, {batch_size});
+    set_i32_shape(page_indice_d, {page_num});
+    set_i32_shape(page_indice_h, {0});
+    set_i32_shape(reuse_cache_page_indice_d, {0});
+    set_i32_shape(reuse_cache_page_indice_h, {0});
+    set_i32_shape(batch_reuse_info_vec_d, {0, 4});
+    set_i32_shape(batch_reuse_info_vec_h, {0, 4});
+
+    auto decode_page_indptr_ptr     = decode_page_indptr_h.data_ptr<int32_t>();
+    auto paged_kv_last_page_len_ptr = paged_kv_last_page_len_h.data_ptr<int32_t>();
+    auto qo_indptr_ptr              = qo_indptr_h.data_ptr<int32_t>();
+    auto batch_indice_ptr           = batch_indice_h.data_ptr<int32_t>();
+    auto positions_ptr              = positions_h.data_ptr<int32_t>();
+    auto kvlen_ptr                  = kvlen_h.data_ptr<int32_t>();
+    decode_page_indptr_ptr[0]       = 0;
+    qo_indptr_ptr[0]                = 0;
+    int page_offset                 = 0;
+    for (int batch = 0; batch < batch_size; ++batch) {
+        const int seq_len = std::max(sequence_lengths_ptr[batch] + 1, 1);
+        const int pages   = (seq_len + seq_size_per_block - 1) / seq_size_per_block;
+        page_offset += pages;
+        decode_page_indptr_ptr[batch + 1] = page_offset;
+        paged_kv_last_page_len_ptr[batch] = (seq_len - 1) % seq_size_per_block + 1;
+        qo_indptr_ptr[batch + 1]          = batch + 1;
+        batch_indice_ptr[batch]           = batch;
+        positions_ptr[batch]              = seq_len - 1;
+        kvlen_ptr[batch]                  = seq_len;
+    }
+
+    cudaStream_t stream = GET_CURRENT_STREAM();
+    invokePrepareFlashInferDecodeParams(sequence_lengths_plus_1_d.data_ptr<int32_t>(),
+                                        kv_cache_block_id_device.data_ptr<int32_t>(),
+                                        batch_indice_d.data_ptr<int32_t>(),
+                                        page_indice_d.data_ptr<int32_t>(),
+                                        decode_page_indptr_d.data_ptr<int32_t>(),
+                                        paged_kv_last_page_len_d.data_ptr<int32_t>(),
+                                        qo_indptr_d.data_ptr<int32_t>(),
+                                        kvlen_d.data_ptr<int32_t>(),
+                                        positions_d.data_ptr<int32_t>(),
+                                        batch_size,
+                                        max_blocks_per_batch,
+                                        seq_size_per_block,
+                                        stream);
+
+    batch_indice                 = batch_indice_d;
+    page_indice                  = page_indice_d;
+    reuse_cache_page_indice      = torch::Tensor();
+    decode_page_indptr           = decode_page_indptr_d;
+    prefill_ragged_kv_len_indptr = torch::Tensor();
+    paged_kv_last_page_len       = paged_kv_last_page_len_d;
+    qo_indptr                    = qo_indptr_d;
+    kvlen                        = kvlen_d;
+    positions                    = positions_d;
+    batch_reuse_info_vec         = torch::Tensor();
+    slot_mapping                 = torch::Tensor();
+}
+
 void FlashInferMlaAttnParams::fillParamsMhaDevice(torch::Tensor t_prefix_lengths,
                                                   torch::Tensor t_sequence_lengths,
                                                   torch::Tensor t_input_lengths,
@@ -721,6 +835,13 @@ void registerPyFlashInferMlaParams(pybind11::module& m) {
              pybind11::arg("kv_cache_block_id_device"),
              pybind11::arg("seq_size_per_block"),
              "Update FlashInfer decode metadata on device during CUDA graph replay")
+        .def("fill_decode_params_device",
+             &rtp_llm::FlashInferMlaAttnParams::fillDecodeParamsDevice,
+             pybind11::arg("sequence_lengths_h"),
+             pybind11::arg("sequence_lengths_plus_1_d"),
+             pybind11::arg("kv_cache_block_id_device"),
+             pybind11::arg("seq_size_per_block"),
+             "Fill eager decode metadata from host lengths and a device block table")
         .def(
             "fill_params_mha_device",
             [](rtp_llm::FlashInferMlaAttnParams& self,

--- a/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.h
+++ b/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.h
@@ -72,6 +72,11 @@ public:
                                    torch::Tensor kv_cache_block_id_device,
                                    int           seq_size_per_block);
 
+    void fillDecodeParamsDevice(torch::Tensor sequence_lengths_h,
+                                torch::Tensor sequence_lengths_plus_1_d,
+                                torch::Tensor kv_cache_block_id_device,
+                                int           seq_size_per_block);
+
     // Device-only fast path for MHA paged attention. Fills paged-KV metadata
     // plus batch_indice_d/positions_d, reusing fillParams buffers so existing
     // FlashInfer aliases stay valid. MLA-only/reuse fields are not filled.

--- a/rtp_llm/models_py/bindings/cuda/RegisterCudaOps.cc
+++ b/rtp_llm/models_py/bindings/cuda/RegisterCudaOps.cc
@@ -9,6 +9,7 @@
 #endif
 
 #include "rtp_llm/models_py/bindings/cuda/kernels/scaled_fp8_quant.h"
+#include "rtp_llm/models_py/bindings/cuda/kernels/fp8_kv_cache.h"
 #include "rtp_llm/models_py/bindings/common/kernels/moe/ep_utils.h"
 
 namespace rtp_llm {
@@ -29,6 +30,46 @@ void registerPyModuleOps(py::module& rtp_ops_m) {
 
     rtp_ops_m.def(
         "per_token_quant_fp8", &per_token_quant_fp8, py::arg("input"), py::arg("output_q"), py::arg("output_s"));
+
+    rtp_ops_m.def("fused_rope_quantize_and_write_fp8_kv_cache",
+                  &fused_rope_quantize_and_write_fp8_kv_cache,
+                  "Apply RoPE to packed QKV and dynamically quantize/write paged FP8 K/V",
+                  py::arg("qkv"),
+                  py::arg("kv_cache"),
+                  py::arg("kv_scales"),
+                  py::arg("batch_indices"),
+                  py::arg("positions"),
+                  py::arg("page_indptr"),
+                  py::arg("page_indices"),
+                  py::arg("num_q_heads"),
+                  py::arg("num_kv_heads"),
+                  py::arg("kernel_page_size"),
+                  py::arg("rope_config"),
+                  py::arg("cos_sin_cache") = std::nullopt);
+
+    rtp_ops_m.def("quantize_and_write_fp8_kv_cache",
+                  &quantize_and_write_fp8_kv_cache,
+                  "Dynamically quantize post-RoPE K/V and write persistent paged FP8 cache rows",
+                  py::arg("k"),
+                  py::arg("v"),
+                  py::arg("kv_cache"),
+                  py::arg("kv_scales"),
+                  py::arg("target_physical_page_ids"),
+                  py::arg("token_offsets"),
+                  py::arg("physical_page_size"),
+                  py::arg("kernel_page_size"),
+                  py::arg("subdivision"));
+
+    rtp_ops_m.def("gather_and_dequantize_fp8_kv_cache",
+                  &gather_and_dequantize_fp8_kv_cache,
+                  "Gather kernel pages from persistent FP8 KV cache and dequantize with per-row scales",
+                  py::arg("kv_cache"),
+                  py::arg("kv_scales"),
+                  py::arg("source_kernel_page_ids"),
+                  py::arg("output"),
+                  py::arg("physical_page_size"),
+                  py::arg("kernel_page_size"),
+                  py::arg("subdivision"));
 
     // Only available when compiling device code for >= sm100.
 #if defined(ENABLE_FP4)

--- a/rtp_llm/models_py/bindings/cuda/kernels/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/kernels/BUILD
@@ -87,6 +87,23 @@ cc_library(
 )
 
 cc_library(
+    name = "fp8_kv_cache",
+    srcs = ["fp8_kv_cache.cu"],
+    hdrs = ["fp8_kv_cache.h"],
+    deps = [
+        "//rtp_llm/models_py/bindings/common/kernels:attn_utils",
+        "//rtp_llm/models_py/bindings/cuda:cuda_host_utils",
+        "//rtp_llm/cpp/model_utils:model_utils",
+        ":cuda_utils_common",
+        ":scaled_fp8_quant",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart",
+    ] + torch_deps(),
+    copts = cuda_copts(),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "scaled_fp4_quant",
     srcs = ["scaled_fp4_quant.cu"],
     hdrs = ["scaled_fp4_quant.h"],

--- a/rtp_llm/models_py/bindings/cuda/kernels/fp8_kv_cache.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/fp8_kv_cache.cu
@@ -1,0 +1,818 @@
+#include "rtp_llm/models_py/bindings/cuda/kernels/fp8_kv_cache.h"
+
+#include "rtp_llm/models_py/bindings/common/kernels/rotary_position_embedding.h"
+#include "rtp_llm/models_py/bindings/cuda/cuda_host_utils.h"
+#include "rtp_llm/models_py/bindings/cuda/kernels/scaled_fp8_quant_utils.h"
+
+#include <ATen/Functions.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/macros/Macros.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+
+#ifdef ENABLE_FP8
+#include <cuda_fp8.h>
+#endif
+
+namespace rtp_llm {
+namespace {
+
+constexpr int   kThreads = 256;
+constexpr float kFp8Max  = 448.0f;
+
+enum class CacheLayout : int {
+    PhysicalPage = 0,
+    KernelPage   = 1,
+};
+
+struct CacheGeometry {
+    CacheLayout layout;
+    int64_t     physical_pages;
+    int64_t     storage_pages;
+    int64_t     storage_page_size;
+    int64_t     cache_page_stride;
+    int64_t     scale_page_stride;
+};
+
+void check_cuda_contiguous(const at::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void check_same_device(const at::Tensor& reference, const at::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.get_device() == reference.get_device(), name, " must be on the same CUDA device as kv_cache");
+}
+
+void check_page_mapping(int64_t physical_page_size, int64_t kernel_page_size, int64_t subdivision) {
+    TORCH_CHECK(physical_page_size > 0, "physical_page_size must be positive");
+    TORCH_CHECK(kernel_page_size > 0, "kernel_page_size must be positive");
+    TORCH_CHECK(subdivision > 0, "subdivision must be positive");
+    TORCH_CHECK(physical_page_size == kernel_page_size * subdivision,
+                "physical_page_size must equal kernel_page_size * subdivision, got ",
+                physical_page_size,
+                ", ",
+                kernel_page_size,
+                ", and ",
+                subdivision);
+}
+
+CacheGeometry validate_cache_geometry(const at::Tensor& kv_cache,
+                                      const at::Tensor& kv_scales,
+                                      int64_t           num_heads,
+                                      int64_t           head_dim,
+                                      int64_t           physical_page_size,
+                                      int64_t           kernel_page_size,
+                                      int64_t           subdivision) {
+    check_cuda_contiguous(kv_cache, "kv_cache");
+    check_cuda_contiguous(kv_scales, "kv_scales");
+    TORCH_CHECK(kv_cache.scalar_type() == at::ScalarType::Float8_e4m3fn,
+                "kv_cache must have dtype torch.float8_e4m3fn");
+    TORCH_CHECK(kv_scales.scalar_type() == at::ScalarType::Float, "kv_scales must have dtype torch.float32");
+    TORCH_CHECK(kv_scales.dim() == 2, "kv_scales must be a 2D tensor");
+    TORCH_CHECK(kv_cache.dim() == 2 || kv_cache.dim() == 5, "kv_cache must be a packed 2D tensor or a 5D paged tensor");
+    TORCH_CHECK(num_heads > 0 && head_dim > 0, "num_heads and head_dim must be positive");
+    check_page_mapping(physical_page_size, kernel_page_size, subdivision);
+
+    const int64_t physical_scale_stride = 2 * num_heads * physical_page_size;
+    const int64_t kernel_scale_stride   = 2 * num_heads * kernel_page_size;
+
+    CacheGeometry geometry{};
+    if (kv_scales.size(1) == physical_scale_stride) {
+        geometry.layout            = CacheLayout::PhysicalPage;
+        geometry.physical_pages    = kv_scales.size(0);
+        geometry.storage_pages     = geometry.physical_pages;
+        geometry.storage_page_size = physical_page_size;
+    } else {
+        TORCH_CHECK(kv_scales.size(1) == kernel_scale_stride,
+                    "kv_scales.size(1) must be 2 * H * physical_page_size (",
+                    physical_scale_stride,
+                    ") or 2 * H * kernel_page_size (",
+                    kernel_scale_stride,
+                    "), got ",
+                    kv_scales.size(1));
+        TORCH_CHECK(kv_scales.size(0) % subdivision == 0,
+                    "kernel-page kv_scales.size(0) must be divisible by subdivision");
+        geometry.layout            = CacheLayout::KernelPage;
+        geometry.storage_pages     = kv_scales.size(0);
+        geometry.physical_pages    = geometry.storage_pages / subdivision;
+        geometry.storage_page_size = kernel_page_size;
+    }
+    TORCH_CHECK(geometry.physical_pages > 0, "kv_cache must contain at least one physical page");
+
+    const int64_t payload_per_storage_page = 2 * num_heads * geometry.storage_page_size * head_dim;
+    if (kv_cache.dim() == 5) {
+        TORCH_CHECK(kv_cache.size(0) == geometry.storage_pages && kv_cache.size(1) == 2 && kv_cache.size(2) == num_heads
+                        && kv_cache.size(3) == geometry.storage_page_size && kv_cache.size(4) == head_dim,
+                    "5D kv_cache shape does not match the inferred cache layout");
+        geometry.cache_page_stride = payload_per_storage_page;
+    } else {
+        TORCH_CHECK(kv_cache.size(0) == geometry.storage_pages, "packed kv_cache page count does not match kv_scales");
+        TORCH_CHECK(kv_cache.size(1) >= payload_per_storage_page,
+                    "packed kv_cache row is smaller than the required KV payload");
+        geometry.cache_page_stride = kv_cache.size(1);
+    }
+    geometry.scale_page_stride = kv_scales.size(1);
+    return geometry;
+}
+
+#ifndef NDEBUG
+void validate_unique_destinations_async(const at::Tensor& physical_page_ids,
+                                        const at::Tensor& token_offsets,
+                                        int64_t           physical_page_size) {
+    if (physical_page_ids.numel() <= 1) {
+        return;
+    }
+    const auto destinations        = physical_page_ids.to(at::kLong) * physical_page_size + token_offsets.to(at::kLong);
+    const auto sorted_destinations = std::get<0>(destinations.sort());
+    const auto unique_destinations = sorted_destinations.slice(0, 1, sorted_destinations.numel())
+                                         .ne(sorted_destinations.slice(0, 0, sorted_destinations.numel() - 1))
+                                         .all();
+    at::_assert_async(unique_destinations, "FP8 KV cache write destinations must be unique");
+}
+#endif
+
+#ifdef ENABLE_FP8
+
+template<typename T>
+struct FusedVec;
+
+template<>
+struct FusedVec<half> {
+    using Type                = uint32_t;
+    static constexpr int size = 2;
+};
+
+#ifdef ENABLE_BF16
+template<>
+struct FusedVec<__nv_bfloat16> {
+    using Type                = __nv_bfloat162;
+    static constexpr int size = 2;
+};
+#endif
+
+template<typename T, RopeStyle ROPE_STYLE>
+__global__ void fused_rope_quantize_and_write_fp8_kv_cache_kernel(const T* __restrict__ qkv,
+                                                                  T* __restrict__ q_output,
+                                                                  __nv_fp8_e4m3* __restrict__ kv_cache,
+                                                                  float* __restrict__ kv_scales,
+                                                                  const int32_t* __restrict__ batch_indices,
+                                                                  const int32_t* __restrict__ positions,
+                                                                  const int32_t* __restrict__ page_indptr,
+                                                                  const int32_t* __restrict__ page_indices,
+                                                                  int64_t       num_tokens,
+                                                                  int64_t       num_q_heads,
+                                                                  int64_t       num_kv_heads,
+                                                                  int64_t       head_dim,
+                                                                  int64_t       storage_pages,
+                                                                  int64_t       kernel_page_size,
+                                                                  int64_t       cache_page_stride,
+                                                                  int64_t       scale_page_stride,
+                                                                  int64_t       page_indptr_size,
+                                                                  int64_t       page_indices_size,
+                                                                  int64_t       cos_sin_rows,
+                                                                  RopeConfig    rope_config,
+                                                                  const float2* cos_sin_cache) {
+    extern __shared__ __align__(sizeof(float2)) char rope_smem[];
+    __shared__ float                                 maxima[2][WARP_SIZE];
+
+    using Vec              = typename FusedVec<T>::Type;
+    constexpr int vec_size = FusedVec<T>::size;
+
+    const int64_t token_idx    = blockIdx.x;
+    const int64_t head_idx     = blockIdx.y;
+    const int64_t vec_offset   = static_cast<int64_t>(threadIdx.x) * vec_size;
+    const bool    in_head      = vec_offset < head_dim;
+    const bool    owns_kv      = head_idx < num_kv_heads;
+    const int64_t packed_width = (num_q_heads + 2 * num_kv_heads) * head_dim;
+
+    Vec q{};
+    Vec k{};
+    Vec v{};
+    if (in_head) {
+        const int64_t q_offset = token_idx * packed_width + head_idx * head_dim + vec_offset;
+        q                      = *reinterpret_cast<const Vec*>(qkv + q_offset);
+        if (owns_kv) {
+            const int64_t k_offset =
+                token_idx * packed_width + num_q_heads * head_dim + head_idx * head_dim + vec_offset;
+            const int64_t v_offset = k_offset + num_kv_heads * head_dim;
+            k                      = *reinterpret_cast<const Vec*>(qkv + k_offset);
+            v                      = *reinterpret_cast<const Vec*>(qkv + v_offset);
+        }
+    }
+
+    const int32_t position       = positions[token_idx];
+    const bool    valid_position = position >= 0 && (cos_sin_cache == nullptr || position < cos_sin_rows);
+    CUDA_KERNEL_ASSERT_MSG(valid_position, "fused FP8 KV cache RoPE position is out of bounds");
+    if (!valid_position) {
+        return;
+    }
+    apply_rope<T, Vec, ROPE_STYLE>(
+        rope_config, q, reinterpret_cast<T*>(rope_smem), threadIdx.x, position, position + 1, cos_sin_cache);
+    if (owns_kv) {
+        apply_rope<T, Vec, ROPE_STYLE>(
+            rope_config, k, reinterpret_cast<T*>(rope_smem), threadIdx.x, position, position + 1, cos_sin_cache);
+    }
+
+    if (in_head) {
+        const int64_t q_offset                       = (token_idx * num_q_heads + head_idx) * head_dim + vec_offset;
+        *reinterpret_cast<Vec*>(q_output + q_offset) = q;
+    }
+
+    if (!owns_kv) {
+        return;
+    }
+
+    float k_max = 0.0f;
+    float v_max = 0.0f;
+    if (in_head) {
+#pragma unroll
+        for (int i = 0; i < vec_size; ++i) {
+            const float k_value = static_cast<float>(reinterpret_cast<T*>(&k)[i]);
+            const float v_value = static_cast<float>(reinterpret_cast<T*>(&v)[i]);
+            if (isfinite(k_value)) {
+                k_max = fmaxf(k_max, fabsf(k_value));
+            }
+            if (isfinite(v_value)) {
+                v_max = fmaxf(v_max, fabsf(v_value));
+            }
+        }
+    }
+    k_max                = warpReduceMax(k_max);
+    v_max                = warpReduceMax(v_max);
+    const int lane_id    = threadIdx.x % WARP_SIZE;
+    const int warp_id    = threadIdx.x / WARP_SIZE;
+    const int warp_count = blockDim.x / WARP_SIZE;
+    if (lane_id == 0) {
+        maxima[0][warp_id] = k_max;
+        maxima[1][warp_id] = v_max;
+    }
+    __syncthreads();
+    if (warp_id == 0) {
+        k_max = lane_id < warp_count ? maxima[0][lane_id] : 0.0f;
+        v_max = lane_id < warp_count ? maxima[1][lane_id] : 0.0f;
+        k_max = warpReduceMax(k_max);
+        v_max = warpReduceMax(v_max);
+        if (lane_id == 0) {
+            maxima[0][0] = k_max;
+            maxima[1][0] = v_max;
+        }
+    }
+    __syncthreads();
+
+    const int64_t batch_idx   = static_cast<int64_t>(batch_indices[token_idx]);
+    const bool    valid_batch = batch_idx >= 0 && batch_idx + 1 < page_indptr_size;
+    CUDA_KERNEL_ASSERT_MSG(valid_batch, "fused FP8 KV cache batch index is out of bounds");
+    if (!valid_batch || position < 0) {
+        return;
+    }
+    const int64_t page_offset = position / kernel_page_size;
+    const int64_t page_slot   = static_cast<int64_t>(page_indptr[batch_idx]) + page_offset;
+    const bool    valid_slot =
+        page_slot >= 0 && page_slot < page_indices_size && page_slot < static_cast<int64_t>(page_indptr[batch_idx + 1]);
+    CUDA_KERNEL_ASSERT_MSG(valid_slot, "fused FP8 KV cache page slot is out of bounds");
+    if (!valid_slot) {
+        return;
+    }
+    const int64_t storage_page  = static_cast<int64_t>(page_indices[page_slot]);
+    const int64_t storage_token = position % kernel_page_size;
+    const bool    valid_page    = storage_page >= 0 && storage_page < storage_pages;
+    CUDA_KERNEL_ASSERT_MSG(valid_page, "fused FP8 KV cache page id is out of bounds");
+    if (!valid_page) {
+        return;
+    }
+
+    const float k_scale     = maxima[0][0] == 0.0f ? 1.0f : maxima[0][0] / kFp8Max;
+    const float v_scale     = maxima[1][0] == 0.0f ? 1.0f : maxima[1][0] / kFp8Max;
+    const float k_inv_scale = 1.0f / k_scale;
+    const float v_inv_scale = 1.0f / v_scale;
+    if (threadIdx.x == 0) {
+        kv_scales[storage_page * scale_page_stride + head_idx * kernel_page_size + storage_token] = k_scale;
+        kv_scales[storage_page * scale_page_stride + (num_kv_heads + head_idx) * kernel_page_size + storage_token] =
+            v_scale;
+    }
+
+    if (in_head) {
+        const int64_t k_cache_row =
+            storage_page * cache_page_stride + (head_idx * kernel_page_size + storage_token) * head_dim;
+        const int64_t v_cache_row = storage_page * cache_page_stride
+                                    + ((num_kv_heads + head_idx) * kernel_page_size + storage_token) * head_dim;
+#pragma unroll
+        for (int i = 0; i < vec_size; ++i) {
+            const float k_value                    = static_cast<float>(reinterpret_cast<T*>(&k)[i]);
+            const float v_value                    = static_cast<float>(reinterpret_cast<T*>(&v)[i]);
+            const float quantized_k                = isnan(k_value) ? 0.0f :
+                                                     isinf(k_value) ? copysignf(kFp8Max, k_value) :
+                                                                      fmaxf(-kFp8Max, fminf(kFp8Max, k_value * k_inv_scale));
+            const float quantized_v                = isnan(v_value) ? 0.0f :
+                                                     isinf(v_value) ? copysignf(kFp8Max, v_value) :
+                                                                      fmaxf(-kFp8Max, fminf(kFp8Max, v_value * v_inv_scale));
+            kv_cache[k_cache_row + vec_offset + i] = static_cast<__nv_fp8_e4m3>(quantized_k);
+            kv_cache[v_cache_row + vec_offset + i] = static_cast<__nv_fp8_e4m3>(quantized_v);
+        }
+    }
+}
+
+template<typename T, RopeStyle ROPE_STYLE>
+void launch_fused_rope_quantize_and_write(const at::Tensor&    qkv,
+                                          at::Tensor&          q_output,
+                                          at::Tensor&          kv_cache,
+                                          at::Tensor&          kv_scales,
+                                          const at::Tensor&    batch_indices,
+                                          const at::Tensor&    positions,
+                                          const at::Tensor&    page_indptr,
+                                          const at::Tensor&    page_indices,
+                                          int64_t              num_q_heads,
+                                          int64_t              num_kv_heads,
+                                          int64_t              head_dim,
+                                          int64_t              kernel_page_size,
+                                          const CacheGeometry& geometry,
+                                          const RopeConfig&    rope_config,
+                                          const float2*        cos_sin_cache,
+                                          int64_t              cos_sin_rows,
+                                          cudaStream_t         stream) {
+    if (qkv.size(0) == 0) {
+        return;
+    }
+    int threads = 32;
+    while (threads < (head_dim + FusedVec<T>::size - 1) / FusedVec<T>::size) {
+        threads *= 2;
+    }
+    const dim3   grid(qkv.size(0), num_q_heads);
+    const size_t smem_size = ROPE_STYLE == RopeStyle::No ? 0 : 2 * rope_config.dim * sizeof(T);
+    fused_rope_quantize_and_write_fp8_kv_cache_kernel<T, ROPE_STYLE>
+        <<<grid, threads, smem_size, stream>>>(reinterpret_cast<const T*>(qkv.data_ptr()),
+                                               reinterpret_cast<T*>(q_output.data_ptr()),
+                                               reinterpret_cast<__nv_fp8_e4m3*>(kv_cache.data_ptr()),
+                                               kv_scales.data_ptr<float>(),
+                                               batch_indices.data_ptr<int32_t>(),
+                                               positions.data_ptr<int32_t>(),
+                                               page_indptr.data_ptr<int32_t>(),
+                                               page_indices.data_ptr<int32_t>(),
+                                               qkv.size(0),
+                                               num_q_heads,
+                                               num_kv_heads,
+                                               head_dim,
+                                               geometry.storage_pages,
+                                               kernel_page_size,
+                                               geometry.cache_page_stride,
+                                               geometry.scale_page_stride,
+                                               page_indptr.numel(),
+                                               page_indices.numel(),
+                                               cos_sin_rows,
+                                               rope_config,
+                                               cos_sin_cache);
+}
+
+template<typename T, typename IndexT>
+__global__ void quantize_and_write_fp8_kv_cache_kernel(const T* __restrict__ k,
+                                                       const T* __restrict__ v,
+                                                       __nv_fp8_e4m3* __restrict__ kv_cache,
+                                                       float* __restrict__ kv_scales,
+                                                       const IndexT* __restrict__ physical_page_ids,
+                                                       const IndexT* __restrict__ token_offsets,
+                                                       int64_t     num_tokens,
+                                                       int64_t     num_heads,
+                                                       int64_t     head_dim,
+                                                       int64_t     physical_pages,
+                                                       int64_t     physical_page_size,
+                                                       int64_t     kernel_page_size,
+                                                       int64_t     subdivision,
+                                                       int64_t     cache_page_stride,
+                                                       int64_t     scale_page_stride,
+                                                       CacheLayout layout) {
+    const int64_t row = blockIdx.x;
+    const int64_t h   = row % num_heads;
+    const int64_t kv  = (row / num_heads) % 2;
+    const int64_t n   = row / (2 * num_heads);
+    if (n >= num_tokens) {
+        return;
+    }
+
+    const int64_t physical_page = static_cast<int64_t>(physical_page_ids[n]);
+    const int64_t token_offset  = static_cast<int64_t>(token_offsets[n]);
+    const bool    valid_mapping =
+        physical_page >= 0 && physical_page < physical_pages && token_offset >= 0 && token_offset < physical_page_size;
+    CUDA_KERNEL_ASSERT_MSG(valid_mapping, "FP8 KV cache write mapping is out of bounds");
+    if (!valid_mapping) {
+        return;
+    }
+
+    int64_t storage_page  = physical_page;
+    int64_t storage_token = token_offset;
+    if (layout == CacheLayout::KernelPage) {
+        storage_page  = physical_page * subdivision + token_offset / kernel_page_size;
+        storage_token = token_offset % kernel_page_size;
+    }
+
+    const T* input_row = (kv == 0 ? k : v) + (n * num_heads + h) * head_dim;
+
+    __shared__ float maxima[kThreads];
+    float            local_max = 0.0f;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        const float value = static_cast<float>(input_row[d]);
+        if (isfinite(value)) {
+            local_max = fmaxf(local_max, fabsf(value));
+        }
+    }
+    maxima[threadIdx.x] = local_max;
+    __syncthreads();
+    for (int offset = blockDim.x / 2; offset > 0; offset /= 2) {
+        if (threadIdx.x < offset) {
+            maxima[threadIdx.x] = fmaxf(maxima[threadIdx.x], maxima[threadIdx.x + offset]);
+        }
+        __syncthreads();
+    }
+
+    const float scale = maxima[0] == 0.0f ? 1.0f : maxima[0] / kFp8Max;
+    if (threadIdx.x == 0) {
+        const int64_t scale_index =
+            storage_page * scale_page_stride
+            + (kv * num_heads + h) * (layout == CacheLayout::PhysicalPage ? physical_page_size : kernel_page_size)
+            + storage_token;
+        kv_scales[scale_index] = scale;
+    }
+
+    const float   inv_scale = 1.0f / scale;
+    const int64_t cache_row =
+        storage_page * cache_page_stride
+        + ((kv * num_heads + h) * (layout == CacheLayout::PhysicalPage ? physical_page_size : kernel_page_size)
+           + storage_token)
+              * head_dim;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        const float input_value = static_cast<float>(input_row[d]);
+        float       quantized_value;
+        if (isnan(input_value)) {
+            quantized_value = 0.0f;
+        } else if (isinf(input_value)) {
+            quantized_value = copysignf(kFp8Max, input_value);
+        } else {
+            quantized_value = fmaxf(-kFp8Max, fminf(kFp8Max, input_value * inv_scale));
+        }
+        kv_cache[cache_row + d] = static_cast<__nv_fp8_e4m3>(quantized_value);
+    }
+}
+
+template<typename T, typename IndexT>
+__global__ void gather_and_dequantize_fp8_kv_cache_kernel(const __nv_fp8_e4m3* __restrict__ kv_cache,
+                                                          const float* __restrict__ kv_scales,
+                                                          const IndexT* __restrict__ source_kernel_page_ids,
+                                                          T* __restrict__ output,
+                                                          int64_t     rows,
+                                                          int64_t     num_heads,
+                                                          int64_t     head_dim,
+                                                          int64_t     physical_pages,
+                                                          int64_t     physical_page_size,
+                                                          int64_t     kernel_page_size,
+                                                          int64_t     subdivision,
+                                                          int64_t     cache_page_stride,
+                                                          int64_t     scale_page_stride,
+                                                          CacheLayout layout) {
+    const int64_t total = rows * 2 * num_heads * kernel_page_size * head_dim;
+    for (int64_t output_index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; output_index < total;
+         output_index += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+        int64_t       cursor = output_index;
+        const int64_t d      = cursor % head_dim;
+        cursor /= head_dim;
+        const int64_t token = cursor % kernel_page_size;
+        cursor /= kernel_page_size;
+        const int64_t h = cursor % num_heads;
+        cursor /= num_heads;
+        const int64_t kv = cursor % 2;
+        const int64_t r  = cursor / 2;
+
+        const int64_t kernel_page   = static_cast<int64_t>(source_kernel_page_ids[r]);
+        const int64_t physical_page = kernel_page / subdivision;
+        const bool    valid_page    = kernel_page >= 0 && physical_page < physical_pages;
+        CUDA_KERNEL_ASSERT_MSG(valid_page, "FP8 KV cache gather page id is out of bounds");
+        if (!valid_page) {
+            return;
+        }
+
+        const int64_t subpage       = kernel_page % subdivision;
+        const int64_t storage_page  = layout == CacheLayout::PhysicalPage ? physical_page : kernel_page;
+        const int64_t storage_token = layout == CacheLayout::PhysicalPage ? subpage * kernel_page_size + token : token;
+        const int64_t storage_page_size = layout == CacheLayout::PhysicalPage ? physical_page_size : kernel_page_size;
+        const int64_t cache_index       = storage_page * cache_page_stride
+                                    + ((kv * num_heads + h) * storage_page_size + storage_token) * head_dim + d;
+        const int64_t scale_index =
+            storage_page * scale_page_stride + (kv * num_heads + h) * storage_page_size + storage_token;
+        output[output_index] = static_cast<T>(static_cast<float>(kv_cache[cache_index]) * kv_scales[scale_index]);
+    }
+}
+
+template<typename T, typename IndexT>
+void launch_quantize_and_write(const at::Tensor&    k,
+                               const at::Tensor&    v,
+                               at::Tensor&          kv_cache,
+                               at::Tensor&          kv_scales,
+                               const at::Tensor&    physical_page_ids,
+                               const at::Tensor&    token_offsets,
+                               const CacheGeometry& geometry,
+                               int64_t              physical_page_size,
+                               int64_t              kernel_page_size,
+                               int64_t              subdivision,
+                               cudaStream_t         stream) {
+    const int64_t rows = k.size(0) * 2 * k.size(1);
+    if (rows == 0) {
+        return;
+    }
+    quantize_and_write_fp8_kv_cache_kernel<T, IndexT>
+        <<<rows, kThreads, 0, stream>>>(reinterpret_cast<const T*>(k.data_ptr()),
+                                        reinterpret_cast<const T*>(v.data_ptr()),
+                                        reinterpret_cast<__nv_fp8_e4m3*>(kv_cache.data_ptr()),
+                                        kv_scales.data_ptr<float>(),
+                                        physical_page_ids.data_ptr<IndexT>(),
+                                        token_offsets.data_ptr<IndexT>(),
+                                        k.size(0),
+                                        k.size(1),
+                                        k.size(2),
+                                        geometry.physical_pages,
+                                        physical_page_size,
+                                        kernel_page_size,
+                                        subdivision,
+                                        geometry.cache_page_stride,
+                                        geometry.scale_page_stride,
+                                        geometry.layout);
+}
+
+template<typename T, typename IndexT>
+void launch_gather(const at::Tensor&    kv_cache,
+                   const at::Tensor&    kv_scales,
+                   const at::Tensor&    source_kernel_page_ids,
+                   at::Tensor&          output,
+                   const CacheGeometry& geometry,
+                   int64_t              physical_page_size,
+                   int64_t              kernel_page_size,
+                   int64_t              subdivision,
+                   cudaStream_t         stream) {
+    const int64_t total = output.numel();
+    if (total == 0) {
+        return;
+    }
+    const int64_t blocks = std::min<int64_t>((total + kThreads - 1) / kThreads, 4096);
+    gather_and_dequantize_fp8_kv_cache_kernel<T, IndexT>
+        <<<blocks, kThreads, 0, stream>>>(reinterpret_cast<const __nv_fp8_e4m3*>(kv_cache.data_ptr()),
+                                          kv_scales.data_ptr<float>(),
+                                          source_kernel_page_ids.data_ptr<IndexT>(),
+                                          reinterpret_cast<T*>(output.data_ptr()),
+                                          output.size(0),
+                                          output.size(2),
+                                          output.size(4),
+                                          geometry.physical_pages,
+                                          physical_page_size,
+                                          kernel_page_size,
+                                          subdivision,
+                                          geometry.cache_page_stride,
+                                          geometry.scale_page_stride,
+                                          geometry.layout);
+}
+
+#endif  // ENABLE_FP8
+
+}  // namespace
+
+at::Tensor fused_rope_quantize_and_write_fp8_kv_cache(const at::Tensor&                qkv,
+                                                      at::Tensor&                      kv_cache,
+                                                      at::Tensor&                      kv_scales,
+                                                      const at::Tensor&                batch_indices,
+                                                      const at::Tensor&                positions,
+                                                      const at::Tensor&                page_indptr,
+                                                      const at::Tensor&                page_indices,
+                                                      int64_t                          num_q_heads,
+                                                      int64_t                          num_kv_heads,
+                                                      int64_t                          kernel_page_size,
+                                                      const RopeConfig&                rope_config,
+                                                      const std::optional<at::Tensor>& cos_sin_cache) {
+#ifndef ENABLE_FP8
+    TORCH_CHECK(false, "FP8 support is not enabled in this CUDA build");
+#else
+    check_cuda_contiguous(qkv, "qkv");
+    check_cuda_contiguous(batch_indices, "batch_indices");
+    check_cuda_contiguous(positions, "positions");
+    check_cuda_contiguous(page_indptr, "page_indptr");
+    check_cuda_contiguous(page_indices, "page_indices");
+    TORCH_CHECK(qkv.dim() == 2, "qkv must have shape [N, (QH + 2 * KVH) * D]");
+    TORCH_CHECK(qkv.scalar_type() == at::ScalarType::Half || qkv.scalar_type() == at::ScalarType::BFloat16,
+                "qkv must have dtype torch.float16 or torch.bfloat16");
+    TORCH_CHECK(num_q_heads > 0 && num_kv_heads > 0 && num_q_heads >= num_kv_heads,
+                "num_q_heads and num_kv_heads must be positive with num_q_heads >= num_kv_heads");
+    TORCH_CHECK(num_q_heads <= 65535, "num_q_heads exceeds the CUDA grid y dimension limit");
+    const int64_t packed_heads = num_q_heads + 2 * num_kv_heads;
+    TORCH_CHECK(qkv.size(1) % packed_heads == 0, "qkv packed width must be divisible by QH + 2 * KVH");
+    const int64_t head_dim = qkv.size(1) / packed_heads;
+    TORCH_CHECK(head_dim > 0 && head_dim % 2 == 0 && head_dim <= 2 * kThreads,
+                "head_dim must be positive, even, and at most ",
+                2 * kThreads,
+                ", got ",
+                head_dim);
+    TORCH_CHECK(kernel_page_size > 0, "kernel_page_size must be positive");
+    TORCH_CHECK(batch_indices.dim() == 1 && batch_indices.numel() >= qkv.size(0),
+                "batch_indices must contain at least N elements");
+    TORCH_CHECK(positions.dim() == 1 && positions.numel() >= qkv.size(0), "positions must contain at least N elements");
+    TORCH_CHECK(page_indptr.dim() == 1 && page_indptr.numel() >= 2, "page_indptr must contain at least two elements");
+    TORCH_CHECK(page_indices.dim() == 1, "page_indices must be one-dimensional");
+    TORCH_CHECK(batch_indices.scalar_type() == at::ScalarType::Int && positions.scalar_type() == at::ScalarType::Int
+                    && page_indptr.scalar_type() == at::ScalarType::Int
+                    && page_indices.scalar_type() == at::ScalarType::Int,
+                "batch_indices, positions, page_indptr, and page_indices must have dtype torch.int32");
+    TORCH_CHECK(rope_config.style != RopeStyle::Mrope, "fused dynamic FP8 decode does not support MRoPE");
+    if (rope_config.style != RopeStyle::No) {
+        TORCH_CHECK(rope_config.dim > 0 && rope_config.dim <= head_dim && rope_config.dim % 2 == 0,
+                    "rope_config.dim must be positive, even, and no larger than head_dim");
+    }
+
+    check_same_device(kv_cache, qkv, "qkv");
+    check_same_device(kv_cache, kv_scales, "kv_scales");
+    check_same_device(kv_cache, batch_indices, "batch_indices");
+    check_same_device(kv_cache, positions, "positions");
+    check_same_device(kv_cache, page_indptr, "page_indptr");
+    check_same_device(kv_cache, page_indices, "page_indices");
+    const CacheGeometry geometry =
+        validate_cache_geometry(kv_cache, kv_scales, num_kv_heads, head_dim, kernel_page_size, kernel_page_size, 1);
+
+    const float2* cos_sin_ptr  = nullptr;
+    int64_t       cos_sin_rows = 0;
+    if (cos_sin_cache.has_value() && cos_sin_cache->defined() && cos_sin_cache->numel() != 0) {
+        check_cuda_contiguous(*cos_sin_cache, "cos_sin_cache");
+        check_same_device(kv_cache, *cos_sin_cache, "cos_sin_cache");
+        TORCH_CHECK(cos_sin_cache->scalar_type() == at::ScalarType::Float,
+                    "cos_sin_cache must have dtype torch.float32");
+        TORCH_CHECK(cos_sin_cache->dim() == 2 && cos_sin_cache->size(1) == rope_config.dim,
+                    "cos_sin_cache must have shape [max_positions, rope_config.dim]");
+        TORCH_CHECK(rope_config.style == RopeStyle::Base || rope_config.style == RopeStyle::Yarn,
+                    "cos_sin_cache is only supported for Base and Yarn RoPE");
+        cos_sin_ptr  = reinterpret_cast<const float2*>(cos_sin_cache->data_ptr<float>());
+        cos_sin_rows = cos_sin_cache->size(0);
+    }
+
+    const c10::cuda::CUDAGuard device_guard(kv_cache.device());
+    at::Tensor                 q_output = at::empty({qkv.size(0), num_q_heads, head_dim}, qkv.options());
+    const cudaStream_t         stream   = at::cuda::getCurrentCUDAStream(kv_cache.get_device()).stream();
+#define LAUNCH_FUSED(input_type)                                                                                       \
+    FT_ROPE_SWITCH(rope_config.style, ROPE_STYLE, [&] {                                                                \
+        launch_fused_rope_quantize_and_write<input_type, ROPE_STYLE>(qkv,                                              \
+                                                                     q_output,                                         \
+                                                                     kv_cache,                                         \
+                                                                     kv_scales,                                        \
+                                                                     batch_indices,                                    \
+                                                                     positions,                                        \
+                                                                     page_indptr,                                      \
+                                                                     page_indices,                                     \
+                                                                     num_q_heads,                                      \
+                                                                     num_kv_heads,                                     \
+                                                                     head_dim,                                         \
+                                                                     kernel_page_size,                                 \
+                                                                     geometry,                                         \
+                                                                     rope_config,                                      \
+                                                                     cos_sin_ptr,                                      \
+                                                                     cos_sin_rows,                                     \
+                                                                     stream);                                          \
+    })
+    if (qkv.scalar_type() == at::ScalarType::Half) {
+        LAUNCH_FUSED(half);
+    } else {
+#ifdef ENABLE_BF16
+        LAUNCH_FUSED(__nv_bfloat16);
+#else
+        TORCH_CHECK(false, "BF16 support is not enabled in this CUDA build");
+#endif
+    }
+#undef LAUNCH_FUSED
+    check_cuda_error();
+    return q_output;
+#endif
+}
+
+void quantize_and_write_fp8_kv_cache(const at::Tensor& k,
+                                     const at::Tensor& v,
+                                     at::Tensor&       kv_cache,
+                                     at::Tensor&       kv_scales,
+                                     const at::Tensor& target_physical_page_ids,
+                                     const at::Tensor& token_offsets,
+                                     int64_t           physical_page_size,
+                                     int64_t           kernel_page_size,
+                                     int64_t           subdivision) {
+#ifndef ENABLE_FP8
+    TORCH_CHECK(false, "FP8 support is not enabled in this CUDA build");
+#else
+    check_cuda_contiguous(k, "k");
+    check_cuda_contiguous(v, "v");
+    check_cuda_contiguous(target_physical_page_ids, "target_physical_page_ids");
+    check_cuda_contiguous(token_offsets, "token_offsets");
+    TORCH_CHECK(k.dim() == 3, "k must have shape [N, H, D]");
+    TORCH_CHECK(v.sizes() == k.sizes(), "v must have the same [N, H, D] shape as k");
+    TORCH_CHECK(k.scalar_type() == at::ScalarType::Half || k.scalar_type() == at::ScalarType::BFloat16,
+                "k and v must have dtype torch.float16 or torch.bfloat16");
+    TORCH_CHECK(v.scalar_type() == k.scalar_type(), "v must have the same dtype as k");
+    TORCH_CHECK(target_physical_page_ids.dim() == 1 && target_physical_page_ids.numel() == k.size(0),
+                "target_physical_page_ids must have shape [N]");
+    TORCH_CHECK(token_offsets.dim() == 1 && token_offsets.numel() == k.size(0), "token_offsets must have shape [N]");
+    TORCH_CHECK(target_physical_page_ids.scalar_type() == at::ScalarType::Int
+                    || target_physical_page_ids.scalar_type() == at::ScalarType::Long,
+                "target_physical_page_ids must have dtype torch.int32 or torch.int64");
+    TORCH_CHECK(token_offsets.scalar_type() == target_physical_page_ids.scalar_type(),
+                "token_offsets must have the same integer dtype as target_physical_page_ids");
+
+    check_same_device(kv_cache, k, "k");
+    check_same_device(kv_cache, v, "v");
+    check_same_device(kv_cache, kv_scales, "kv_scales");
+    check_same_device(kv_cache, target_physical_page_ids, "target_physical_page_ids");
+    check_same_device(kv_cache, token_offsets, "token_offsets");
+    const CacheGeometry geometry = validate_cache_geometry(
+        kv_cache, kv_scales, k.size(1), k.size(2), physical_page_size, kernel_page_size, subdivision);
+    const c10::cuda::CUDAGuard device_guard(kv_cache.device());
+#ifndef NDEBUG
+    validate_unique_destinations_async(target_physical_page_ids, token_offsets, physical_page_size);
+#endif
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream(kv_cache.get_device()).stream();
+#define LAUNCH_WRITE(input_type, index_type)                                                                           \
+    launch_quantize_and_write<input_type, index_type>(k,                                                               \
+                                                      v,                                                               \
+                                                      kv_cache,                                                        \
+                                                      kv_scales,                                                       \
+                                                      target_physical_page_ids,                                        \
+                                                      token_offsets,                                                   \
+                                                      geometry,                                                        \
+                                                      physical_page_size,                                              \
+                                                      kernel_page_size,                                                \
+                                                      subdivision,                                                     \
+                                                      stream)
+    if (target_physical_page_ids.scalar_type() == at::ScalarType::Int) {
+        if (k.scalar_type() == at::ScalarType::Half) {
+            LAUNCH_WRITE(__half, int32_t);
+        } else {
+            LAUNCH_WRITE(__nv_bfloat16, int32_t);
+        }
+    } else if (k.scalar_type() == at::ScalarType::Half) {
+        LAUNCH_WRITE(__half, int64_t);
+    } else {
+        LAUNCH_WRITE(__nv_bfloat16, int64_t);
+    }
+#undef LAUNCH_WRITE
+    check_cuda_error();
+#endif
+}
+
+void gather_and_dequantize_fp8_kv_cache(const at::Tensor& kv_cache,
+                                        const at::Tensor& kv_scales,
+                                        const at::Tensor& source_kernel_page_ids,
+                                        at::Tensor&       output,
+                                        int64_t           physical_page_size,
+                                        int64_t           kernel_page_size,
+                                        int64_t           subdivision) {
+#ifndef ENABLE_FP8
+    TORCH_CHECK(false, "FP8 support is not enabled in this CUDA build");
+#else
+    check_cuda_contiguous(source_kernel_page_ids, "source_kernel_page_ids");
+    check_cuda_contiguous(output, "output");
+    TORCH_CHECK(source_kernel_page_ids.dim() == 1, "source_kernel_page_ids must have shape [R]");
+    TORCH_CHECK(source_kernel_page_ids.scalar_type() == at::ScalarType::Int
+                    || source_kernel_page_ids.scalar_type() == at::ScalarType::Long,
+                "source_kernel_page_ids must have dtype torch.int32 or torch.int64");
+    TORCH_CHECK(output.dim() == 5, "output must have shape [R, 2, H, kernel_page_size, D]");
+    TORCH_CHECK(output.size(0) == source_kernel_page_ids.numel() && output.size(1) == 2
+                    && output.size(3) == kernel_page_size,
+                "output must have shape [R, 2, H, kernel_page_size, D]");
+    TORCH_CHECK(output.scalar_type() == at::ScalarType::Half || output.scalar_type() == at::ScalarType::BFloat16,
+                "output must have dtype torch.float16 or torch.bfloat16");
+
+    check_same_device(kv_cache, kv_scales, "kv_scales");
+    check_same_device(kv_cache, source_kernel_page_ids, "source_kernel_page_ids");
+    check_same_device(kv_cache, output, "output");
+    const CacheGeometry geometry = validate_cache_geometry(
+        kv_cache, kv_scales, output.size(2), output.size(4), physical_page_size, kernel_page_size, subdivision);
+    const c10::cuda::CUDAGuard device_guard(kv_cache.device());
+    const cudaStream_t         stream = at::cuda::getCurrentCUDAStream(kv_cache.get_device()).stream();
+#define LAUNCH_GATHER(output_type, index_type)                                                                         \
+    launch_gather<output_type, index_type>(kv_cache,                                                                   \
+                                           kv_scales,                                                                  \
+                                           source_kernel_page_ids,                                                     \
+                                           output,                                                                     \
+                                           geometry,                                                                   \
+                                           physical_page_size,                                                         \
+                                           kernel_page_size,                                                           \
+                                           subdivision,                                                                \
+                                           stream)
+    if (source_kernel_page_ids.scalar_type() == at::ScalarType::Int) {
+        if (output.scalar_type() == at::ScalarType::Half) {
+            LAUNCH_GATHER(__half, int32_t);
+        } else {
+            LAUNCH_GATHER(__nv_bfloat16, int32_t);
+        }
+    } else if (output.scalar_type() == at::ScalarType::Half) {
+        LAUNCH_GATHER(__half, int64_t);
+    } else {
+        LAUNCH_GATHER(__nv_bfloat16, int64_t);
+    }
+#undef LAUNCH_GATHER
+    check_cuda_error();
+#endif
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/fp8_kv_cache.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/fp8_kv_cache.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "rtp_llm/cpp/model_utils/RopeConfig.h"
+
+#include <optional>
+#include <torch/extension.h>
+
+namespace rtp_llm {
+
+at::Tensor fused_rope_quantize_and_write_fp8_kv_cache(const at::Tensor&                qkv,
+                                                      at::Tensor&                      kv_cache,
+                                                      at::Tensor&                      kv_scales,
+                                                      const at::Tensor&                batch_indices,
+                                                      const at::Tensor&                positions,
+                                                      const at::Tensor&                page_indptr,
+                                                      const at::Tensor&                page_indices,
+                                                      int64_t                          num_q_heads,
+                                                      int64_t                          num_kv_heads,
+                                                      int64_t                          kernel_page_size,
+                                                      const RopeConfig&                rope_config,
+                                                      const std::optional<at::Tensor>& cos_sin_cache = std::nullopt);
+
+// Quantize post-RoPE K/V one [H, D] row at a time and write it into a
+// persistent paged FP8 cache. target_physical_page_ids and token_offsets are
+// one-dimensional CUDA int32/int64 tensors with one unique entry per input token.
+// NaN maps to zero; infinities saturate under the finite-value row scale.
+void quantize_and_write_fp8_kv_cache(const at::Tensor& k,
+                                     const at::Tensor& v,
+                                     at::Tensor&       kv_cache,
+                                     at::Tensor&       kv_scales,
+                                     const at::Tensor& target_physical_page_ids,
+                                     const at::Tensor& token_offsets,
+                                     int64_t           physical_page_size,
+                                     int64_t           kernel_page_size,
+                                     int64_t           subdivision);
+
+// Gather source kernel pages from a persistent FP8 cache and dequantize them
+// into output [R, 2, H, kernel_page_size, D]. source_kernel_page_ids are
+// physical_page_id * subdivision + subpage_id.
+void gather_and_dequantize_fp8_kv_cache(const at::Tensor& kv_cache,
+                                        const at::Tensor& kv_scales,
+                                        const at::Tensor& source_kernel_page_ids,
+                                        at::Tensor&       output,
+                                        int64_t           physical_page_size,
+                                        int64_t           kernel_page_size,
+                                        int64_t           subdivision);
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/scaled_fp8_quant.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/scaled_fp8_quant.cu
@@ -263,15 +263,16 @@ __global__ void per_token_quant_fp8_kernel(const T* __restrict__ input,
         }
     }
 
-    float warp_max = warpReduceMax(max_value);
+    const float warp_max = warpReduceMax(max_value);
 
-    __shared__ float scale;
-    scale = warp_max / tensorrt_llm::common::FP8_E4M3_MAX;
-    // Broadcast scale
+    // warpReduceMax broadcasts within this warp. Keep the scale warp-local:
+    // sharing one scalar between the eight independent token warps races and
+    // can quantize a token with another token's scale.
+    const float scale = warp_max == 0.0f ? 1.0f : warp_max / tensorrt_llm::common::FP8_E4M3_MAX;
     if (lane_id == 0) {
         token_scale[0] = scale;
     }
-    float scale_inv = (scale == 0.f) ? 0.f : 1.0f / scale;
+    const float scale_inv = 1.0f / scale;
 
     //
     // Pass-2: quantize and write back
@@ -338,7 +339,7 @@ __global__ void per_token_quant_fp8_small_batch_kernel(const T* __restrict__ inp
 
     __shared__ float scale;
     if (tid == 0) {
-        scale               = max_value / tensorrt_llm::common::FP8_E4M3_MAX;
+        scale               = max_value == 0.0f ? 1.0f : max_value / tensorrt_llm::common::FP8_E4M3_MAX;
         output_s[token_idx] = scale;
     }
     __syncthreads();

--- a/rtp_llm/models_py/kernels/cuda/test/BUILD
+++ b/rtp_llm/models_py/kernels/cuda/test/BUILD
@@ -44,6 +44,14 @@ py_test (
 )
 
 py_test (
+    name = "fp8_kv_cache_test",
+    srcs = ["fp8_kv_cache_test.py"],
+    deps = py_test_deps,
+    tags = ["open_skip", "H20"],
+    exec_properties = {'gpu':'H20'},
+)
+
+py_test (
     name = "cutlass_fp4_scaled_mm_test",
     srcs = ["cutlass_fp4_scaled_mm_test.py"],
     deps = py_test_deps,

--- a/rtp_llm/models_py/kernels/cuda/test/fp8_kv_cache_test.py
+++ b/rtp_llm/models_py/kernels/cuda/test/fp8_kv_cache_test.py
@@ -1,0 +1,415 @@
+import unittest
+from unittest import SkipTest
+
+import torch
+
+import rtp_llm.ops  # isort:skip
+from rtp_llm.ops import RopeConfig, RopeStyle  # isort:skip
+from rtp_llm.ops.compute_ops import (  # isort:skip
+    gather_and_dequantize_fp8_kv_cache,
+    quantize_and_write_fp8_kv_cache,
+    rtp_llm_ops,
+)
+
+
+class Fp8KvCacheTest(unittest.TestCase):
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            raise SkipTest("CUDA is not available")
+
+    @staticmethod
+    def _quantize_row(row: torch.Tensor) -> tuple[torch.Tensor, float]:
+        row = row.float()
+        max_abs = row.abs().max().item()
+        scale = 1.0 if max_abs == 0.0 else max_abs / 448.0
+        quantized = (row / scale).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        return quantized, scale
+
+    def _run_layout(self, subdivision: int, layout: str) -> None:
+        torch.manual_seed(2026 + subdivision)
+        physical_pages = 3
+        physical_page_size = 8
+        kernel_page_size = physical_page_size // subdivision
+        heads = 3
+        head_dim = 17
+        input_dtype = torch.float16 if layout == "physical" else torch.bfloat16
+        output_dtype = torch.bfloat16 if layout == "physical" else torch.float16
+
+        target_pages = torch.tensor([2, 0, 2, 1, 0], dtype=torch.int32)
+        token_offsets = torch.tensor([7, 0, 3, 5, 2], dtype=torch.int32)
+        token_count = target_pages.numel()
+
+        # K and V intentionally use different magnitudes. Explicit zeros and
+        # outliers exercise independent row scales and the zero-row contract.
+        k_cpu = (torch.randn(token_count, heads, head_dim) * 0.125).to(input_dtype)
+        v_cpu = (torch.randn(token_count, heads, head_dim) * 24.0).to(input_dtype)
+        k_cpu[1, 1].zero_()
+        v_cpu[3, 2].zero_()
+        k_cpu[2, 0, 5] = 1000.0
+        v_cpu[0, 2, 9] = -2000.0
+
+        if layout == "physical":
+            cache_shape = (physical_pages, 2, heads, physical_page_size, head_dim)
+            scale_shape = (physical_pages, 2 * heads * physical_page_size)
+        else:
+            kernel_pages = physical_pages * subdivision
+            cache_shape = (kernel_pages, 2, heads, kernel_page_size, head_dim)
+            scale_shape = (kernel_pages, 2 * heads * kernel_page_size)
+
+        sentinel_q = 3.0
+        sentinel_scale = 13.0
+        cache = torch.full(cache_shape, sentinel_q, dtype=torch.float32).to(
+            device="cuda", dtype=torch.float8_e4m3fn
+        )
+        scales = torch.full(
+            scale_shape, sentinel_scale, dtype=torch.float32, device="cuda"
+        )
+
+        quantize_and_write_fp8_kv_cache(
+            k_cpu.cuda(),
+            v_cpu.cuda(),
+            cache,
+            scales,
+            target_pages.cuda(),
+            token_offsets.cuda(),
+            physical_page_size,
+            kernel_page_size,
+            subdivision,
+        )
+
+        expected_scales = torch.full(scale_shape, sentinel_scale, dtype=torch.float32)
+        for n in range(token_count):
+            physical_page = int(target_pages[n])
+            physical_token = int(token_offsets[n])
+            if layout == "physical":
+                storage_page = physical_page
+                storage_token = physical_token
+            else:
+                storage_page = (
+                    physical_page * subdivision + physical_token // kernel_page_size
+                )
+                storage_token = physical_token % kernel_page_size
+            scale_view = expected_scales.view(cache_shape[0], 2, heads, cache_shape[3])
+            for kv, source in enumerate((k_cpu, v_cpu)):
+                for head in range(heads):
+                    _, scale = self._quantize_row(source[n, head])
+                    scale_view[storage_page, kv, head, storage_token] = scale
+
+        cache_cpu = cache.cpu()
+        scales_cpu = scales.cpu()
+        torch.testing.assert_close(scales_cpu, expected_scales, rtol=1e-6, atol=1e-7)
+
+        # Gather every kernel page in a deliberately non-monotonic order.
+        source_kernel_pages = torch.tensor(
+            list(reversed(range(physical_pages * subdivision))),
+            dtype=torch.int64,
+            device="cuda",
+        )
+        output = torch.empty(
+            source_kernel_pages.numel(),
+            2,
+            heads,
+            kernel_page_size,
+            head_dim,
+            dtype=output_dtype,
+            device="cuda",
+        )
+        gather_and_dequantize_fp8_kv_cache(
+            cache,
+            scales,
+            source_kernel_pages,
+            output,
+            physical_page_size,
+            kernel_page_size,
+            subdivision,
+        )
+
+        expected_output = torch.empty_like(output, device="cpu")
+        scale_view = scales_cpu.view(cache_shape[0], 2, heads, cache_shape[3])
+        for r, kernel_page_tensor in enumerate(source_kernel_pages.cpu()):
+            kernel_page = int(kernel_page_tensor)
+            if layout == "physical":
+                storage_page = kernel_page // subdivision
+                token_start = (kernel_page % subdivision) * kernel_page_size
+            else:
+                storage_page = kernel_page
+                token_start = 0
+            q = cache_cpu[
+                storage_page, :, :, token_start : token_start + kernel_page_size, :
+            ].float()
+            s = scale_view[
+                storage_page, :, :, token_start : token_start + kernel_page_size
+            ].unsqueeze(-1)
+            expected_output[r] = (q * s).to(output_dtype)
+        tolerance = 8e-3 if output_dtype == torch.bfloat16 else 1e-3
+        torch.testing.assert_close(
+            output.cpu(), expected_output, rtol=tolerance, atol=tolerance
+        )
+
+        # Most rows were never written: both the FP8 sentinel and its scale must
+        # survive, and gather must dequantize them rather than clearing them.
+        self.assertEqual(cache[0, 0, 0, 1, 0].float().item(), sentinel_q)
+        self.assertEqual(
+            scales.view(cache_shape[0], 2, heads, cache_shape[3])[0, 0, 0, 1].item(),
+            sentinel_scale,
+        )
+
+        # Explicit zero rows use scale=1 and round-trip to zero.
+        if layout == "physical":
+            zero_page, zero_token = 0, 0
+        else:
+            zero_page, zero_token = 0, 0
+        self.assertEqual(
+            scales.view(cache_shape[0], 2, heads, cache_shape[3])[
+                zero_page, 0, 1, zero_token
+            ].item(),
+            1.0,
+        )
+        self.assertTrue(
+            torch.count_nonzero(cache[zero_page, 0, 1, zero_token].float()).item() == 0
+        )
+
+        # Validate quantize/dequantize round-trip error at every written row.
+        scales_cpu = scales_cpu.view(cache_shape[0], 2, heads, cache_shape[3])
+        for n in range(token_count):
+            physical_page = int(target_pages[n])
+            physical_token = int(token_offsets[n])
+            if layout == "physical":
+                storage_page, storage_token = physical_page, physical_token
+            else:
+                storage_page = (
+                    physical_page * subdivision + physical_token // kernel_page_size
+                )
+                storage_token = physical_token % kernel_page_size
+            for kv, source in enumerate((k_cpu, v_cpu)):
+                restored = cache_cpu[
+                    storage_page, kv, :, storage_token
+                ].float() * scales_cpu[storage_page, kv, :, storage_token].unsqueeze(-1)
+                torch.testing.assert_close(
+                    restored, source[n].float(), rtol=0.13, atol=0.02
+                )
+
+    def test_nonfinite_values_are_sanitized(self) -> None:
+        k = torch.tensor(
+            [[[float("nan"), float("inf"), -float("inf"), 2.0]]],
+            device="cuda",
+            dtype=torch.float16,
+        )
+        v = torch.tensor(
+            [[[float("nan"), float("inf"), -float("inf"), 4.0]]],
+            device="cuda",
+            dtype=torch.float16,
+        )
+        cache = torch.empty((1, 2, 1, 1, 4), device="cuda", dtype=torch.float8_e4m3fn)
+        scales = torch.empty((1, 2), device="cuda", dtype=torch.float32)
+        page_ids = torch.tensor([0], device="cuda", dtype=torch.int32)
+        offsets = torch.tensor([0], device="cuda", dtype=torch.int32)
+
+        quantize_and_write_fp8_kv_cache(k, v, cache, scales, page_ids, offsets, 1, 1, 1)
+        output = torch.empty((1, 2, 1, 1, 4), device="cuda", dtype=torch.float16)
+        gather_and_dequantize_fp8_kv_cache(cache, scales, page_ids, output, 1, 1, 1)
+
+        self.assertTrue(torch.isfinite(output).all().item())
+        torch.testing.assert_close(
+            output.cpu().float(),
+            torch.tensor([[[[[0.0, 2.0, -2.0, 2.0]]], [[[0.0, 4.0, -4.0, 4.0]]]]]),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_physical_and_existing_kernel_page_layouts(self) -> None:
+        for subdivision in (1, 2, 4):
+            for layout in ("physical", "kernel"):
+                with self.subTest(subdivision=subdivision, layout=layout):
+                    self._run_layout(subdivision, layout)
+
+    @staticmethod
+    def _rope_reference(tensor: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+        dim = tensor.size(-1)
+        inv_freq = torch.exp(
+            -torch.log(torch.tensor(10000.0, device=tensor.device))
+            * torch.arange(0, dim, 2, device=tensor.device, dtype=torch.float32)
+            / dim
+        )
+        angles = positions.float()[:, None] * inv_freq[None, :]
+        cos = angles.cos()[:, None, :]
+        sin = angles.sin()[:, None, :]
+        first = tensor[..., : dim // 2].float()
+        second = tensor[..., dim // 2 :].float()
+        return torch.cat(
+            [first * cos - second * sin, second * cos + first * sin], dim=-1
+        ).to(tensor.dtype)
+
+    def test_fused_decode_prepare_matches_standalone_oracle(self) -> None:
+        for dtype in (torch.float16, torch.bfloat16):
+            for head_dim in (64, 128):
+                for rope_style in (RopeStyle.No, RopeStyle.Base):
+                    with self.subTest(
+                        dtype=dtype, head_dim=head_dim, rope_style=rope_style
+                    ):
+                        torch.manual_seed(17 + head_dim)
+                        num_tokens, q_heads, kv_heads, page_size = 3, 4, 2, 4
+                        qkv = torch.randn(
+                            num_tokens,
+                            (q_heads + 2 * kv_heads) * head_dim,
+                            device="cuda",
+                            dtype=dtype,
+                        )
+                        q_raw, k_raw, v_raw = torch.split(
+                            qkv,
+                            [
+                                q_heads * head_dim,
+                                kv_heads * head_dim,
+                                kv_heads * head_dim,
+                            ],
+                            dim=-1,
+                        )
+                        q_raw = q_raw.reshape(num_tokens, q_heads, head_dim)
+                        k_raw = k_raw.reshape(num_tokens, kv_heads, head_dim)
+                        v_raw = v_raw.reshape(num_tokens, kv_heads, head_dim)
+                        k_raw[0, 0].zero_()
+                        v_raw[1, 1] *= 32
+                        qkv = torch.cat(
+                            [q_raw.flatten(1), k_raw.flatten(1), v_raw.flatten(1)],
+                            dim=-1,
+                        )
+                        batch_indices = torch.tensor(
+                            [0, 1, 1], device="cuda", dtype=torch.int32
+                        )
+                        positions = torch.tensor(
+                            [0, 2, 11], device="cuda", dtype=torch.int32
+                        )
+                        page_indptr = torch.tensor(
+                            [0, 2, 5], device="cuda", dtype=torch.int32
+                        )
+                        page_indices = torch.tensor(
+                            [6, 1, 5, 2, 6], device="cuda", dtype=torch.int32
+                        )
+                        cache = torch.full(
+                            (7, 2, kv_heads, page_size, head_dim),
+                            3.0,
+                            device="cuda",
+                            dtype=torch.float8_e4m3fn,
+                        )
+                        scales = torch.full(
+                            (7, 2 * kv_heads * page_size),
+                            13.0,
+                            device="cuda",
+                            dtype=torch.float32,
+                        )
+                        rope_config = RopeConfig()
+                        rope_config.style = rope_style
+                        rope_config.dim = head_dim
+                        rope_config.base = 10000
+                        q = rtp_llm_ops.fused_rope_quantize_and_write_fp8_kv_cache(
+                            qkv,
+                            cache,
+                            scales,
+                            batch_indices,
+                            positions,
+                            page_indptr,
+                            page_indices,
+                            q_heads,
+                            kv_heads,
+                            page_size,
+                            rope_config,
+                            None,
+                        )
+                        expected_q = (
+                            q_raw
+                            if rope_style == RopeStyle.No
+                            else self._rope_reference(q_raw, positions)
+                        )
+                        expected_k = (
+                            k_raw
+                            if rope_style == RopeStyle.No
+                            else self._rope_reference(k_raw, positions)
+                        )
+                        torch.testing.assert_close(q, expected_q, rtol=2e-3, atol=2e-3)
+
+                        target_pages = torch.tensor(
+                            [6, 5, 6], device="cuda", dtype=torch.int32
+                        )
+                        target_offsets = torch.tensor(
+                            [0, 2, 3], device="cuda", dtype=torch.int32
+                        )
+                        oracle_cache = torch.full_like(cache, 3.0)
+                        oracle_scales = torch.full_like(scales, 13.0)
+                        quantize_and_write_fp8_kv_cache(
+                            expected_k.contiguous(),
+                            v_raw.contiguous(),
+                            oracle_cache,
+                            oracle_scales,
+                            target_pages,
+                            target_offsets,
+                            page_size,
+                            page_size,
+                            1,
+                        )
+                        torch.testing.assert_close(
+                            cache.float(), oracle_cache.float(), rtol=0, atol=0
+                        )
+                        torch.testing.assert_close(
+                            scales, oracle_scales, rtol=1e-6, atol=1e-7
+                        )
+
+    def test_fused_decode_prepare_sanitizes_nonfinite_kv(self) -> None:
+        qkv = torch.tensor(
+            [
+                [
+                    0.0,
+                    1.0,
+                    2.0,
+                    3.0,
+                    float("nan"),
+                    float("inf"),
+                    -float("inf"),
+                    2.0,
+                    float("nan"),
+                    float("inf"),
+                    -float("inf"),
+                    4.0,
+                ]
+            ],
+            device="cuda",
+            dtype=torch.float16,
+        )
+        cache = torch.empty((1, 2, 1, 1, 4), device="cuda", dtype=torch.float8_e4m3fn)
+        scales = torch.empty((1, 2), device="cuda", dtype=torch.float32)
+        zero = torch.tensor([0], device="cuda", dtype=torch.int32)
+        page_indptr = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+        rope_config = RopeConfig()
+        rope_config.style = RopeStyle.No
+
+        q = rtp_llm_ops.fused_rope_quantize_and_write_fp8_kv_cache(
+            qkv,
+            cache,
+            scales,
+            zero,
+            zero,
+            page_indptr,
+            zero,
+            1,
+            1,
+            1,
+            rope_config,
+            None,
+        )
+
+        torch.testing.assert_close(
+            q.cpu().flatten().float(), torch.arange(4, dtype=torch.float32)
+        )
+        torch.testing.assert_close(
+            scales.cpu(), torch.tensor([[2.0 / 448.0, 4.0 / 448.0]])
+        )
+        restored = cache.float() * scales.view(1, 2, 1, 1, 1)
+        torch.testing.assert_close(
+            restored.cpu().flatten(),
+            torch.tensor([0.0, 2.0, -2.0, 2.0, 0.0, 4.0, -4.0, 4.0]),
+            rtol=0,
+            atol=0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/kernels/cuda/test/per_token_scaled_fp8_quant_test.py
+++ b/rtp_llm/models_py/kernels/cuda/test/per_token_scaled_fp8_quant_test.py
@@ -57,6 +57,33 @@ class PerTokenFp8QuantTest(TestCase):
             ):
                 self._run_per_token_fp8_quant_test(*params)
 
+    def test_zero_rows_and_independent_warp_scales(self):
+        # This size forces the eight-warps-per-CTA path. Adjacent tokens have
+        # deliberately different ranges so a CTA-shared scale race is visible.
+        sm_count = torch.cuda.get_device_properties(0).multi_processor_count
+        num_tokens = sm_count * 16
+        hidden_size = 128
+        token_scales = torch.pow(
+            torch.tensor(2.0, device="cuda"),
+            (torch.arange(num_tokens, device="cuda") % 15 - 7).float(),
+        )
+        x = torch.linspace(-1.0, 1.0, hidden_size, device="cuda").repeat(num_tokens, 1)
+        x = (x * token_scales.unsqueeze(1)).to(torch.bfloat16)
+        x[0].zero_()
+        x[9].zero_()
+
+        q_out, scales = self.call_per_token_quant_fp8(x)
+        max_abs = x.float().abs().amax(dim=1, keepdim=True)
+        expected_scales = torch.where(
+            max_abs == 0, torch.ones_like(max_abs), max_abs / 448.0
+        )
+        expected_q = self.torch_scaled_fp8_quant(x, expected_scales)
+
+        torch.testing.assert_close(scales, expected_scales, rtol=1e-6, atol=0)
+        self.assertTrue(torch.equal(q_out.float(), expected_q.float()))
+        self.assertEqual(scales[0].item(), 1.0)
+        self.assertEqual(scales[9].item(), 1.0)
+
 
 if __name__ == "__main__":
     main()

--- a/rtp_llm/models_py/modules/factory/attention/attn_factory.py
+++ b/rtp_llm/models_py/modules/factory/attention/attn_factory.py
@@ -37,6 +37,37 @@ FLASHINFER_TRTLLM_GEN_IMPLS = {
     "FlashInferTRTLLMDecodeImpl",
 }
 
+DYNAMIC_FP8_PREFILL_IMPLS = {
+    "PyFlashinferPrefillImpl",
+    "PyFlashinferPagedPrefillImpl",
+    "PyFlashinferHybridPrefillImpl",
+}
+DYNAMIC_FP8_DECODE_IMPLS = {"PyFlashinferDecodeImpl"}
+
+
+def _validate_dynamic_fp8_config(
+    attn_configs: AttentionConfigs,
+    is_cuda_graph: bool,
+    attn_inputs: Optional[PyAttentionInputs] = None,
+) -> None:
+    """Reject mode-2 configurations before any attention backend is created."""
+    if getattr(attn_configs, "fp8_kv_cache_mode", 0) != 2:
+        return
+    if is_cuda_graph and (
+        attn_inputs is None or getattr(attn_inputs, "is_prefill", True)
+    ):
+        raise ValueError("FP8 KV cache mode 2 supports CUDA graph for decode only")
+    if attn_configs.use_mla:
+        raise ValueError("FP8 KV cache mode 2 supports MHA only; MLA is not supported")
+    if attn_configs.rope_config.style == RopeStyle.Mrope:
+        raise ValueError("FP8 KV cache mode 2 does not support MRoPE")
+    if attn_configs.use_logn_attn:
+        raise ValueError("FP8 KV cache mode 2 does not support use_logn_attn")
+    if getattr(attn_configs, "gen_num_per_cycle", 1) > 1:
+        raise ValueError(
+            "FP8 KV cache mode 2 does not support speculative or multi-token decode"
+        )
+
 
 def get_mla_impl(
     attn_configs: AttentionConfigs,
@@ -48,6 +79,7 @@ def get_mla_impl(
     max_seq_len: int = 0,
     parallelism_config: Optional[ParallelismConfig] = None,
 ) -> MlaImplBase:
+    _validate_dynamic_fp8_config(attn_configs, is_cuda_graph, attn_inputs)
 
     mla_impls = PREFILL_MLA_IMPS if attn_inputs.is_prefill else DECODE_MLA_IMPS
     for impl in mla_impls:
@@ -169,15 +201,28 @@ def get_fmha_impl(
 ) -> FMHAImplBase:
     # Set is_cuda_graph as dynamic attribute on attn_inputs for base class to read
     attn_inputs.is_cuda_graph = is_cuda_graph
+    _validate_dynamic_fp8_config(attn_configs, is_cuda_graph, attn_inputs)
 
+    dynamic_fp8 = getattr(attn_configs, "fp8_kv_cache_mode", 0) == 2
     mha_impls = PREFILL_MHA_IMPS if attn_inputs.is_prefill else DECODE_MHA_IMPS
-    strict_impl_selection = VALIDATE_FMHA_CONFIG is not None and VALIDATE_FMHA_CONFIG(
-        attn_configs, attn_inputs, fmha_config
+    allowed_dynamic_impls = (
+        DYNAMIC_FP8_PREFILL_IMPLS
+        if attn_inputs.is_prefill
+        else DYNAMIC_FP8_DECODE_IMPLS
+    )
+    strict_impl_selection = dynamic_fp8 or (
+        VALIDATE_FMHA_CONFIG is not None
+        and VALIDATE_FMHA_CONFIG(attn_configs, attn_inputs, fmha_config)
     )
 
     for impl in mha_impls:
         # Check if this FMHA implementation is disabled before creating instance
         impl_class_name = impl.__name__
+
+        # Mode 2 has one storage/read contract. Never try a backend that does not
+        # dynamically dequantize the cache before invoking FlashInfer.
+        if dynamic_fp8 and impl_class_name not in allowed_dynamic_impls:
+            continue
 
         # Skip if this FMHA implementation is disabled in config
         if _is_fmha_impl_disabled(impl_class_name, fmha_config):
@@ -199,14 +244,25 @@ def get_fmha_impl(
             # the bug as a performance regression.
             raise
         except Exception as e:
-            # ROCm validation predicts the selected cache layout, so falling back
-            # after construction could select a reader with a different layout.
+            # ROCm validation and dynamic FP8 select a cache layout before
+            # construction. Falling back could select an incompatible reader.
+            if dynamic_fp8:
+                raise RuntimeError(
+                    "failed to instantiate required attention backend "
+                    f"{impl_class_name} for FP8 KV cache mode 2"
+                ) from e
             if strict_impl_selection:
                 raise
             logging.warning(f"Failed to instantiate {impl_class_name}: {e}")
             continue
         if not is_cuda_graph or instance.support_cuda_graph():
             return instance
+    if dynamic_fp8:
+        allowed = ", ".join(sorted(allowed_dynamic_impls))
+        raise ValueError(
+            "FP8 KV cache mode 2 requires a supported native FlashInfer backend; "
+            f"allowed implementations: {allowed}"
+        )
     if (
         attn_configs.rope_config.style == RopeStyle.Mrope
         and not attn_configs.rope_config.mrope_interleaved
@@ -243,6 +299,7 @@ class AttnImplFactory(object):
         attn_configs = model_config.getAttentionConfigs(
             parallelism_config.get_attn_tp_size()
         )
+        _validate_dynamic_fp8_config(attn_configs, is_cuda_graph, attn_inputs)
         attn_inputs.headwise_config = getattr(model_config, "headwise_config", None)
         key_str = "mla" if attn_configs.use_mla else "mha"
         fmha_impl_method = cls.FMHA_IMPL_REGISTRY[key_str]

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/flashinfer_direct_scale/include/flashinfer/attention/prefill.cuh
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/flashinfer_direct_scale/include/flashinfer/attention/prefill.cuh
@@ -1,0 +1,2995 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_PREFILL_CUH_
+#define FLASHINFER_PREFILL_CUH_
+
+#include <cooperative_groups.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <flashinfer/cp_async.cuh>
+#include <flashinfer/fastdiv.cuh>
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+#include <flashinfer/fp16.h>
+#endif
+#include <flashinfer/frag_layout_swizzle.cuh>
+#include <flashinfer/math.cuh>
+#include <flashinfer/mma.cuh>
+#include <flashinfer/page.cuh>
+#include <flashinfer/permuted_smem.cuh>
+#include <flashinfer/pos_enc.cuh>
+#include <flashinfer/utils.cuh>
+#include <flashinfer/attention/cascade.cuh>
+#include <flashinfer/attention/mask.cuh>
+#include <flashinfer/attention/variants.cuh>
+namespace flashinfer {
+
+DEFINE_HAS_MEMBER(maybe_q_rope_offset)
+DEFINE_HAS_MEMBER(maybe_k_rope_offset)
+DEFINE_HAS_MEMBER(maybe_prefix_len_ptr)
+DEFINE_HAS_MEMBER(maybe_token_pos_in_items_ptr)
+DEFINE_HAS_MEMBER(token_pos_in_items_len)
+DEFINE_HAS_MEMBER(maybe_max_item_len_ptr)
+
+namespace cg = cooperative_groups;
+using cp_async::SharedMemFillMode;
+using mma::MMAMode;
+
+constexpr uint32_t WARP_SIZE = 32;
+
+constexpr uint32_t get_num_warps_q(const uint32_t cta_tile_q) {
+    if (cta_tile_q > 16) {
+        return 4;
+    } else {
+        return 1;
+    }
+}
+
+constexpr uint32_t get_num_warps_kv(const uint32_t cta_tile_kv) {
+    return 4 / get_num_warps_q(cta_tile_kv);
+}
+
+constexpr uint32_t get_num_mma_q(const uint32_t cta_tile_q) {
+    if (cta_tile_q > 64) {
+        return 2;
+    } else {
+        return 1;
+    }
+}
+
+template<uint32_t NUM_WARPS_KV,
+         uint32_t CTA_TILE_Q,
+         uint32_t CTA_TILE_KV,
+         uint32_t HEAD_DIM_QK,
+         uint32_t HEAD_DIM_VO,
+         typename DTypeQ,
+         typename DTypeKV,
+         typename DTypeO>
+struct SharedStorageQKVO {
+    union {
+        struct {
+            alignas(16) DTypeQ q_smem[CTA_TILE_Q * HEAD_DIM_QK];
+            alignas(16) DTypeKV k_smem[CTA_TILE_KV * HEAD_DIM_QK];
+            alignas(16) DTypeKV v_smem[CTA_TILE_KV * HEAD_DIM_VO];
+        };
+        struct {  // NOTE(Zihao): synchronize attention states across warps
+            alignas(16) std::conditional_t<NUM_WARPS_KV == 1,
+                                           float[1],
+                                           float[NUM_WARPS_KV * CTA_TILE_Q * HEAD_DIM_VO]> cta_sync_o_smem;
+            alignas(16)
+                std::conditional_t<NUM_WARPS_KV == 1, float2[1], float2[NUM_WARPS_KV * CTA_TILE_Q]> cta_sync_md_smem;
+        };
+        alignas(16) DTypeO smem_o[CTA_TILE_Q * HEAD_DIM_VO];
+    };
+};
+
+template<MaskMode        MASK_MODE_,
+         uint32_t        CTA_TILE_Q_,
+         uint32_t        NUM_MMA_Q_,
+         uint32_t        NUM_MMA_KV_,
+         uint32_t        NUM_MMA_D_QK_,
+         uint32_t        NUM_MMA_D_VO_,
+         uint32_t        NUM_WARPS_Q_,
+         uint32_t        NUM_WARPS_KV_,
+         PosEncodingMode POS_ENCODING_MODE_,
+         typename DTypeQ_,
+         typename DTypeKV_,
+         typename DTypeO_,
+         typename DTypeQKAccum_,
+         typename IdType_,
+         typename AttentionVariant_>
+struct KernelTraits {
+    static constexpr uint32_t NUM_STAGES      = 1;  // used for BatchAttention Template
+    static constexpr MaskMode MASK_MODE       = MASK_MODE_;
+    static constexpr uint32_t NUM_MMA_Q       = NUM_MMA_Q_;
+    static constexpr uint32_t NUM_MMA_KV      = NUM_MMA_KV_;
+    static constexpr uint32_t NUM_MMA_D_QK    = NUM_MMA_D_QK_;
+    static constexpr uint32_t NUM_MMA_D_VO    = NUM_MMA_D_VO_;
+    static constexpr uint32_t NUM_WARPS_Q     = NUM_WARPS_Q_;
+    static constexpr uint32_t NUM_WARPS_KV    = NUM_WARPS_KV_;
+    static constexpr uint32_t NUM_THREADS     = NUM_WARPS_Q * NUM_WARPS_KV * WARP_SIZE;
+    static constexpr uint32_t NUM_WARPS       = NUM_WARPS_Q * NUM_WARPS_KV;
+    static constexpr uint32_t HEAD_DIM_QK     = NUM_MMA_D_QK * 16;
+    static constexpr uint32_t HEAD_DIM_VO     = NUM_MMA_D_VO * 16;
+    static constexpr uint32_t UPCAST_STRIDE_Q = HEAD_DIM_QK / upcast_size<DTypeQ_>();
+    static constexpr uint32_t UPCAST_STRIDE_K = HEAD_DIM_QK / upcast_size<DTypeKV_>();
+    static constexpr uint32_t UPCAST_STRIDE_V = HEAD_DIM_VO / upcast_size<DTypeKV_>();
+    static constexpr uint32_t UPCAST_STRIDE_O = HEAD_DIM_VO / upcast_size<DTypeO_>();
+    static constexpr uint32_t CTA_TILE_Q      = CTA_TILE_Q_;
+    static constexpr uint32_t CTA_TILE_KV     = NUM_MMA_KV * NUM_WARPS_KV * 16;
+
+    static constexpr SwizzleMode SWIZZLE_MODE_Q = SwizzleMode::k128B;
+    static constexpr SwizzleMode SWIZZLE_MODE_KV =
+        (sizeof(DTypeKV_) == 1 && HEAD_DIM_VO == 64) ? SwizzleMode::k64B : SwizzleMode::k128B;
+    static constexpr uint32_t        KV_THR_LAYOUT_ROW = SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 8;
+    static constexpr uint32_t        KV_THR_LAYOUT_COL = SWIZZLE_MODE_KV == SwizzleMode::k128B ? 8 : 4;
+    static constexpr PosEncodingMode POS_ENCODING_MODE = POS_ENCODING_MODE_;
+    using DTypeQ                                       = DTypeQ_;
+    using DTypeKV                                      = DTypeKV_;
+    using DTypeO                                       = DTypeO_;
+    using DTypeQKAccum                                 = DTypeQKAccum_;
+    using IdType                                       = IdType_;
+    using AttentionVariant                             = AttentionVariant_;
+
+    static constexpr bool IsInvalid() {
+        return ((NUM_MMA_D_VO < 4) || (NUM_MMA_D_VO == 4 && NUM_MMA_KV % 2 == 1)
+                || (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && NUM_MMA_D_VO > 4
+                    && NUM_MMA_D_VO % (2 * NUM_WARPS_Q) != 0)
+                || (NUM_MMA_Q * (8 * NUM_MMA_D_VO + 2 * sizeof(DTypeQKAccum) * NUM_MMA_KV) >= 256)
+                || (sizeof(DTypeKV) == 1 && NUM_MMA_KV * 2 % NUM_WARPS_Q != 0)
+                || (sizeof(DTypeKV) == 1 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
+    }
+
+    using SharedStorage =
+        SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>;
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+    template<typename DT>
+    static constexpr DT getNegInf() {
+        if constexpr (std::is_same<DT, __half>::value) {
+            return std::bit_cast<half>(fp16_ieee_from_fp32_value(-math::inf));
+        } else {
+            return static_cast<DTypeQKAccum>(-math::inf);
+        }
+    }
+
+    static constexpr DTypeQKAccum MaskFillValue =
+        AttentionVariant::use_softmax ? getNegInf<DTypeQKAccum>() : DTypeQKAccum(0.f);
+#else
+    static_assert(!std::is_same<DTypeQKAccum, __half>::value,
+                  "Set -DFP16_QK_REDUCTION_SUPPORTED and install boost_math "
+                  "then recompile to support fp16 reduction");
+    static constexpr DTypeQKAccum MaskFillValue =
+        AttentionVariant::use_softmax ? DTypeQKAccum(-math::inf) : DTypeQKAccum(0.f);
+#endif
+};
+
+namespace {
+
+template<typename KTraits>
+__device__ __forceinline__ uint32_t get_warp_idx_q(const uint32_t tid_y = threadIdx.y) {
+    if constexpr (KTraits::NUM_WARPS_Q == 1) {
+        return 0;
+    } else {
+        return tid_y;
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ uint32_t get_warp_idx_kv(const uint32_t tid_z = threadIdx.z) {
+    if constexpr (KTraits::NUM_WARPS_KV == 1) {
+        return 0;
+    } else {
+        return tid_z;
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ uint32_t get_warp_idx(const uint32_t tid_y = threadIdx.y,
+                                                 const uint32_t tid_z = threadIdx.z) {
+    return get_warp_idx_kv<KTraits>(tid_z) * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid_y);
+}
+
+/*!
+ * \brief Apply Llama style rotary embedding to two 16x16 fragments.
+ * \tparam T The data type of the input fragments.
+ * \param x_first_half First fragment x[offset:offset+16, j*16:(j+1)*16]
+ * \param x_second_half Second fragment x[offset:offset*16, j*16+d/2:(j+1)*16+d/2]
+ * \param rope_freq Rope frequency
+ * \param offset The offset of the first row in both fragments.
+ * \note The sin/cos computation is slow, especially for A100 GPUs which has low
+ *   non tensor-ops flops, will optimize in the future.
+ */
+template<typename T>
+__device__ __forceinline__ void
+k_frag_apply_llama_rope(T* x_first_half, T* x_second_half, const float* rope_freq, const uint32_t kv_offset) {
+    static_assert(sizeof(T) == 2);
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+        float cos, sin, tmp;
+        // 0 1 | 2 3
+        // ---------
+        // 4 5 | 6 7
+        uint32_t i = reg_id / 4, j = (reg_id % 4) / 2;
+        __sincosf(float(kv_offset + 8 * i) * rope_freq[2 * j + reg_id % 2], &sin, &cos);
+        tmp                   = x_first_half[reg_id];
+        x_first_half[reg_id]  = (tmp * cos - (float)x_second_half[reg_id] * sin);
+        x_second_half[reg_id] = ((float)x_second_half[reg_id] * cos + tmp * sin);
+    }
+}
+
+template<typename T>
+__device__ __forceinline__ void q_frag_apply_llama_rope(T*                 x_first_half,
+                                                        T*                 x_second_half,
+                                                        const float*       rope_freq,
+                                                        const uint32_t     qo_packed_offset,
+                                                        const uint_fastdiv group_size) {
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+        float cos, sin, tmp;
+        // 0 1 | 4 5
+        // ---------
+        // 2 3 | 6 7
+        uint32_t i = ((reg_id % 4) / 2), j = (reg_id / 4);
+        __sincosf(float((qo_packed_offset + 8 * i) / group_size) * rope_freq[2 * j + reg_id % 2], &sin, &cos);
+        tmp                   = x_first_half[reg_id];
+        x_first_half[reg_id]  = (tmp * cos - (float)x_second_half[reg_id] * sin);
+        x_second_half[reg_id] = ((float)x_second_half[reg_id] * cos + tmp * sin);
+    }
+}
+
+template<typename T, typename IdType>
+__device__ __forceinline__ void q_frag_apply_llama_rope_with_pos(T*                 x_first_half,
+                                                                 T*                 x_second_half,
+                                                                 const float*       rope_freq,
+                                                                 const uint32_t     qo_packed_offset,
+                                                                 const uint_fastdiv group_size,
+                                                                 const IdType*      q_rope_offset) {
+    float pos[2] = {static_cast<float>(q_rope_offset[qo_packed_offset / group_size]),
+                    static_cast<float>(q_rope_offset[(qo_packed_offset + 8) / group_size])};
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+        float cos, sin, tmp;
+        // 0 1 | 4 5
+        // ---------
+        // 2 3 | 6 7
+        uint32_t i = ((reg_id % 4) / 2), j = (reg_id / 4);
+        __sincosf(pos[i] * rope_freq[2 * j + reg_id % 2], &sin, &cos);
+        tmp                   = x_first_half[reg_id];
+        x_first_half[reg_id]  = (tmp * cos - (float)x_second_half[reg_id] * sin);
+        x_second_half[reg_id] = ((float)x_second_half[reg_id] * cos + tmp * sin);
+    }
+}
+
+/*!
+ * \brief Produce k/v fragments from global memory to shared memory.
+ * \tparam fill_mode The fill mode of the shared memory.
+ * \tparam NUM_MMA_D_VO The number of fragments in y dimension.
+ * \tparam NUM_MMA_KV The number of fragments in z dimension.
+ * \tparam num_warps The number of warps in the threadblock.
+ * \tparam T The data type of the input tensor.
+ * \param smem The shared memory to store kv fragments.
+ * \param gptr The global memory pointer.
+ * \param kv_idx_base The base kv index.
+ * \param kv_len The length of kv tensor.
+ */
+template<bool produce_v, SharedMemFillMode fill_mode, typename KTraits>
+__device__ __forceinline__ void produce_kv(smem_t<KTraits::SWIZZLE_MODE_KV> smem,
+                                           uint32_t*                        smem_offset,
+                                           typename KTraits::DTypeKV**      gptr,
+                                           const uint32_t                   stride_n,
+                                           const uint32_t                   kv_idx_base,
+                                           const uint32_t                   kv_len,
+                                           const dim3                       tid = threadIdx) {
+    // NOTE: for fp8, this function doesn't work for head_dim = 64 at the moment
+    using DTypeKV                    = typename KTraits::DTypeKV;
+    constexpr uint32_t CTA_TILE_KV   = KTraits::CTA_TILE_KV;
+    constexpr uint32_t NUM_WARPS     = KTraits::NUM_WARPS;
+    constexpr uint32_t NUM_WARPS_Q   = KTraits::NUM_WARPS_Q;
+    constexpr uint32_t NUM_MMA_D     = produce_v ? KTraits::NUM_MMA_D_VO : KTraits::NUM_MMA_D_QK;
+    constexpr uint32_t NUM_MMA_KV    = KTraits::NUM_MMA_KV;
+    constexpr uint32_t UPCAST_STRIDE = produce_v ? KTraits::UPCAST_STRIDE_V : KTraits::UPCAST_STRIDE_K;
+    const uint32_t     warp_idx = get_warp_idx<KTraits>(tid.y, tid.z), lane_idx = tid.x;
+
+    if constexpr (KTraits::SWIZZLE_MODE_KV == SwizzleMode::k128B) {
+        uint32_t kv_idx = kv_idx_base + warp_idx * 4 + lane_idx / 8;
+        // NOTE: NUM_MMA_KV * 4 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 4 / num_warps
+        static_assert(NUM_MMA_KV * 4 % NUM_WARPS_Q == 0);
+#pragma unroll
+        for (uint32_t i = 0; i < NUM_MMA_KV * 4 / NUM_WARPS_Q; ++i) {
+#pragma unroll
+            for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(DTypeKV)); ++j) {
+                smem.template load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
+                *smem_offset = smem.template advance_offset_by_column<8>(*smem_offset, j);
+                *gptr += 8 * upcast_size<DTypeKV>();
+            }
+            kv_idx += NUM_WARPS * 4;
+            *smem_offset = smem.template advance_offset_by_row<NUM_WARPS * 4, UPCAST_STRIDE>(*smem_offset)
+                           - sizeof(DTypeKV) * NUM_MMA_D;
+            *gptr += NUM_WARPS * 4 * stride_n - sizeof(DTypeKV) * NUM_MMA_D * upcast_size<DTypeKV>();
+        }
+        *smem_offset -= CTA_TILE_KV * UPCAST_STRIDE;
+    } else {
+        uint32_t kv_idx = kv_idx_base + warp_idx * 8 + lane_idx / 4;
+        // NOTE: NUM_MMA_KV * 2 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 2 / num_warps
+        static_assert(NUM_MMA_KV * 2 % NUM_WARPS_Q == 0);
+#pragma unroll
+        for (uint32_t i = 0; i < NUM_MMA_KV * 2 / NUM_WARPS_Q; ++i) {
+            smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
+            *smem_offset = smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_STRIDE>(*smem_offset);
+            kv_idx += NUM_WARPS * 8;
+            *gptr += NUM_WARPS * 8 * stride_n;
+        }
+        *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
+    }
+}
+
+template<bool produce_v, typename KTraits>
+__device__ __forceinline__ void page_produce_kv(typename KTraits::SharedStorage* smem_storage,
+                                                uint32_t*                        smem_offset,
+                                                typename KTraits::DTypeKV*       kv_ptr,
+                                                const uint32_t                   kv_idx_base,
+                                                const size_t*                    thr_local_kv_offset,
+                                                const uint32_t                   kv_len,
+                                                const uint32_t                   warp_idx,
+                                                const uint32_t                   lane_idx) {
+    // NOTE: for fp8, this function doesn't work for head_dim = 64 at the moment
+    smem_t<KTraits::SWIZZLE_MODE_KV> smem(produce_v ? smem_storage->v_smem : smem_storage->k_smem);
+    using DType                               = typename KTraits::DTypeKV;
+    using IdType                              = typename KTraits::IdType;
+    constexpr SharedMemFillMode fill_mode     = produce_v ? SharedMemFillMode::kFillZero : SharedMemFillMode::kNoFill;
+    constexpr uint32_t          NUM_WARPS     = KTraits::NUM_WARPS;
+    constexpr uint32_t          NUM_WARPS_Q   = KTraits::NUM_WARPS_Q;
+    constexpr uint32_t          NUM_MMA_KV    = KTraits::NUM_MMA_KV;
+    constexpr uint32_t          NUM_MMA_D     = produce_v ? KTraits::NUM_MMA_D_VO : KTraits::NUM_MMA_D_QK;
+    constexpr uint32_t          UPCAST_STRIDE = produce_v ? KTraits::UPCAST_STRIDE_V : KTraits::UPCAST_STRIDE_K;
+    if constexpr (KTraits::SWIZZLE_MODE_KV == SwizzleMode::k128B) {
+        uint32_t kv_idx = kv_idx_base + warp_idx * 4 + lane_idx / 8;
+        // NOTE: NUM_MMA_KV * 4 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 4 / num_warps
+        static_assert(NUM_MMA_KV * 4 % NUM_WARPS_Q == 0);
+#pragma unroll
+        for (uint32_t i = 0; i < NUM_MMA_KV * 4 / NUM_WARPS_Q; ++i) {
+            DType* gptr = kv_ptr + thr_local_kv_offset[i];
+#pragma unroll
+            for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(DType)); ++j) {
+                smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+                *smem_offset = smem.template advance_offset_by_column<8>(*smem_offset, j);
+                gptr += 8 * upcast_size<DType>();
+            }
+            kv_idx += NUM_WARPS * 4;
+            *smem_offset = smem.template advance_offset_by_row<NUM_WARPS * 4, UPCAST_STRIDE>(*smem_offset)
+                           - sizeof(DType) * NUM_MMA_D;
+        }
+        *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
+    } else {
+        uint32_t kv_idx = kv_idx_base + warp_idx * 8 + lane_idx / 4;
+        // NOTE: NUM_MMA_KV * 2 / NUM_WARPS_Q = NUM_WARPS_KV * NUM_MMA_KV * 2 / num_warps
+        static_assert(NUM_MMA_KV * 2 % NUM_WARPS_Q == 0);
+#pragma unroll
+        for (uint32_t i = 0; i < NUM_MMA_KV * 2 / NUM_WARPS_Q; ++i) {
+            DType* gptr = kv_ptr + thr_local_kv_offset[i];
+            smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+            kv_idx += NUM_WARPS * 8;
+            *smem_offset = smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_STRIDE>(*smem_offset);
+        }
+        *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void init_rope_freq(float (*rope_freq)[4],
+                                               const float    rope_rcp_scale,
+                                               const float    rope_rcp_theta,
+                                               const uint32_t tid_x = threadIdx.x) {
+    constexpr uint32_t HEAD_DIM = KTraits::NUM_MMA_D_QK * 16;
+    const uint32_t     lane_idx = tid_x;
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO / 2; ++mma_d) {
+#pragma unroll
+        for (uint32_t j = 0; j < 4; ++j) {
+            rope_freq[mma_d][j] =
+                rope_rcp_scale
+                * __powf(rope_rcp_theta,
+                         float(2 * ((mma_d * 16 + (j / 2) * 8 + (lane_idx % 4) * 2 + (j % 2)) % (HEAD_DIM / 2)))
+                             / float(HEAD_DIM));
+        }
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void init_states(typename KTraits::AttentionVariant variant,
+                                            float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                            typename KTraits::DTypeQKAccum (*m)[2],
+                                            float (*d)[2]) {
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+#pragma unroll
+            for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                o_frag[mma_q][mma_d][reg_id] = 0.f;
+            }
+        }
+    }
+
+    if constexpr (variant.use_softmax) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+            for (uint32_t j = 0; j < 2; ++j) {
+                m[mma_q][j] = typename KTraits::DTypeQKAccum(-math::inf);
+                d[mma_q][j] = 1.f;
+            }
+        }
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void load_q_global_smem(uint32_t                         packed_offset,
+                                                   const uint32_t                   qo_upper_bound,
+                                                   typename KTraits::DTypeQ*        q_ptr_base,
+                                                   const uint32_t                   q_stride_n,
+                                                   const uint32_t                   q_stride_h,
+                                                   const uint_fastdiv               group_size,
+                                                   smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem,
+                                                   const dim3                       tid = threadIdx) {
+    using DTypeQ                       = typename KTraits::DTypeQ;
+    constexpr uint32_t UPCAST_STRIDE_Q = KTraits::UPCAST_STRIDE_Q;
+    const uint32_t     lane_idx = tid.x, warp_idx_x = get_warp_idx_q<KTraits>(tid.y);
+
+    if (get_warp_idx_kv<KTraits>(tid.z) == 0) {
+        uint32_t q_smem_offset_w = q_smem->template get_permuted_offset<UPCAST_STRIDE_Q>(
+            warp_idx_x * KTraits::NUM_MMA_Q * 16 + lane_idx / 8, lane_idx % 8);
+
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+            for (uint32_t j = 0; j < 2 * 2; ++j) {
+                uint32_t q, r;
+                group_size.divmod(packed_offset + lane_idx / 8 + mma_q * 16 + j * 4, q, r);
+                const uint32_t q_idx = q;
+                DTypeQ* q_ptr = q_ptr_base + q * q_stride_n + r * q_stride_h + (lane_idx % 8) * upcast_size<DTypeQ>();
+#pragma unroll
+                for (uint32_t mma_do = 0; mma_do < KTraits::NUM_MMA_D_QK / 4; ++mma_do) {
+                    // load q fragment from gmem to smem
+                    q_smem->template load_128b_async<SharedMemFillMode::kNoFill>(
+                        q_smem_offset_w, q_ptr, q_idx < qo_upper_bound);
+                    q_smem_offset_w = q_smem->template advance_offset_by_column<8>(q_smem_offset_w, mma_do);
+                    q_ptr += 8 * upcast_size<DTypeQ>();
+                }
+                q_smem_offset_w = q_smem->template advance_offset_by_row<4, UPCAST_STRIDE_Q>(q_smem_offset_w)
+                                  - 2 * KTraits::NUM_MMA_D_QK;
+            }
+        }
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void q_smem_inplace_apply_rotary(const uint32_t                   q_packed_idx,
+                                                            const uint32_t                   qo_len,
+                                                            const uint32_t                   kv_len,
+                                                            const uint_fastdiv               group_size,
+                                                            smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem,
+                                                            uint32_t*                        q_smem_offset_r,
+                                                            float (*rope_freq)[4],
+                                                            const dim3 tid = threadIdx) {
+    if (get_warp_idx_kv<KTraits>(tid.z) == 0) {
+        constexpr uint32_t UPCAST_STRIDE_Q = KTraits::UPCAST_STRIDE_Q;
+        const uint32_t     lane_idx        = tid.x;
+        uint32_t           q_frag_local[2][4];
+        static_assert(KTraits::NUM_MMA_D_QK % 4 == 0, "NUM_MMA_D_QK must be a multiple of 4");
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+            uint32_t q_smem_offset_r_first_half = *q_smem_offset_r;
+#pragma unroll
+            for (uint32_t mma_di = 0; mma_di < KTraits::NUM_MMA_D_QK / 2; ++mma_di) {
+                q_smem->ldmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
+                uint32_t q_smem_offset_r_last_half =
+                    q_smem->template advance_offset_by_column<KTraits::NUM_MMA_D_QK>(q_smem_offset_r_first_half, 0);
+                q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
+                q_frag_apply_llama_rope<typename KTraits::DTypeQ>((typename KTraits::DTypeQ*)q_frag_local[0],
+                                                                  (typename KTraits::DTypeQ*)q_frag_local[1],
+                                                                  rope_freq[mma_di],
+                                                                  q_packed_idx + kv_len * group_size
+                                                                      - qo_len * group_size + mma_q * 16 + lane_idx / 4,
+                                                                  group_size);
+                q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
+                q_smem->stmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
+                q_smem_offset_r_first_half =
+                    q_smem->template advance_offset_by_column<2>(q_smem_offset_r_first_half, mma_di);
+            }
+            *q_smem_offset_r += 16 * UPCAST_STRIDE_Q;
+        }
+        *q_smem_offset_r -= KTraits::NUM_MMA_Q * 16 * UPCAST_STRIDE_Q;
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void q_smem_inplace_apply_rotary_with_pos(const uint32_t                   q_packed_idx_base,
+                                                                     const typename KTraits::IdType*  q_rope_offset,
+                                                                     smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem,
+                                                                     const uint_fastdiv               group_size,
+                                                                     uint32_t*                        q_smem_offset_r,
+                                                                     float (*rope_freq)[4],
+                                                                     const dim3 tid = threadIdx) {
+    if (get_warp_idx_kv<KTraits>(tid.z) == 0) {
+        constexpr uint32_t UPCAST_STRIDE_Q = KTraits::UPCAST_STRIDE_Q;
+        const uint32_t     lane_idx        = tid.x;
+        uint32_t           q_frag_local[2][4];
+        static_assert(KTraits::NUM_MMA_D_QK % 4 == 0, "NUM_MMA_D_QK must be a multiple of 4");
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+            uint32_t q_smem_offset_r_first_half = *q_smem_offset_r;
+#pragma unroll
+            for (uint32_t mma_di = 0; mma_di < KTraits::NUM_MMA_D_QK / 2; ++mma_di) {
+                q_smem->ldmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
+                uint32_t q_smem_offset_r_last_half =
+                    q_smem->template advance_offset_by_column<KTraits::NUM_MMA_D_QK>(q_smem_offset_r_first_half, 0);
+                q_smem->ldmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
+                q_frag_apply_llama_rope_with_pos<typename KTraits::DTypeQ, typename KTraits::IdType>(
+                    (typename KTraits::DTypeQ*)q_frag_local[0],
+                    (typename KTraits::DTypeQ*)q_frag_local[1],
+                    rope_freq[mma_di],
+                    q_packed_idx_base + mma_q * 16 + lane_idx / 4,
+                    group_size,
+                    q_rope_offset);
+                q_smem->stmatrix_m8n8x4(q_smem_offset_r_last_half, q_frag_local[1]);
+                q_smem->stmatrix_m8n8x4(q_smem_offset_r_first_half, q_frag_local[0]);
+                q_smem_offset_r_first_half =
+                    q_smem->template advance_offset_by_column<2>(q_smem_offset_r_first_half, mma_di);
+            }
+            *q_smem_offset_r += 16 * UPCAST_STRIDE_Q;
+        }
+        *q_smem_offset_r -= KTraits::NUM_MMA_Q * 16 * UPCAST_STRIDE_Q;
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void k_smem_inplace_apply_rotary(const uint32_t                    kv_idx_base,
+                                                            smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem,
+                                                            uint32_t*                         k_smem_offset_r,
+                                                            float (*rope_freq)[4],
+                                                            const dim3 tid = threadIdx) {
+    using DTypeKV = typename KTraits::DTypeKV;
+    static_assert(sizeof(DTypeKV) == 2);
+    constexpr uint32_t UPCAST_STRIDE_K = KTraits::UPCAST_STRIDE_K;
+    uint32_t           k_frag_local[2][4];
+    const uint32_t     lane_idx = tid.x;
+    if constexpr (KTraits::NUM_MMA_D_QK == 4 && KTraits::NUM_WARPS_Q == 4) {
+        static_assert(KTraits::NUM_WARPS_KV == 1);
+        const uint32_t warp_idx = get_warp_idx_q<KTraits>(tid.y);
+        // horizontal-axis: y
+        // vertical-axis: z
+        //         | 1-16       | 16-32      | 32-48      | 48-64      |
+        // | 1-16  | warp_idx=0 | warp_idx=1 | warp_idx=0 | warp_idx=1 |
+        // | 16-32 | warp_idx=2 | warp_idx=3 | warp_idx=2 | warp_idx=3 |
+        static_assert(KTraits::NUM_MMA_KV % 2 == 0, "when NUM_MMA_D_QK == 4, NUM_MMA_KV must be a multiple of 2");
+        uint32_t kv_idx  = kv_idx_base + (warp_idx / 2) * 16 + lane_idx / 4;
+        *k_smem_offset_r = (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) + (warp_idx / 2) * 16 * UPCAST_STRIDE_K;
+#pragma unroll
+        for (uint32_t i = 0; i < KTraits::NUM_MMA_KV / 2; ++i) {
+            uint32_t k_smem_offset_r_first_half = *k_smem_offset_r;
+            uint32_t mma_di                     = (warp_idx % 2);
+            k_smem->ldmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
+            uint32_t k_smem_offset_r_last_half =
+                k_smem->template advance_offset_by_column<4>(k_smem_offset_r_first_half, 0);
+            k_smem->ldmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
+            k_frag_apply_llama_rope<DTypeKV>(
+                (DTypeKV*)k_frag_local[0], (DTypeKV*)k_frag_local[1], rope_freq[mma_di], kv_idx);
+            k_smem->stmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
+            k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
+            *k_smem_offset_r += 32 * UPCAST_STRIDE_K;
+            kv_idx += 32;
+        }
+        *k_smem_offset_r =
+            (*k_smem_offset_r ^ (0x2 * (warp_idx % 2))) - ((warp_idx / 2) + KTraits::NUM_MMA_KV) * 16 * UPCAST_STRIDE_K;
+    } else {
+        const uint32_t warp_idx_x = get_warp_idx_q<KTraits>(tid.y), warp_idx_z = get_warp_idx_kv<KTraits>(tid.z);
+        static_assert(KTraits::NUM_MMA_D_QK % (2 * KTraits::NUM_WARPS_Q) == 0);
+        // horizontal axis: y
+        // vertical axis: z
+        // | (warp_idx_z, warp_idx_x)       | 1-16   | 16-32  | 32-48  | 48-64  | ...
+        // | 1-16*NUM_MMA_KV                | (0, 0) | (0, 1) | (0, 2) | (0, 3) | ...
+        // | 16*NUM_MMA_KV-32*NUM_MMA_KV    | (1, 0) | (1, 1) | (1, 2) | (1, 3) | ...
+        // ...
+        uint32_t kv_idx  = kv_idx_base + (warp_idx_z * KTraits::NUM_MMA_KV * 16) + lane_idx / 4;
+        *k_smem_offset_r = *k_smem_offset_r ^ (0x2 * warp_idx_x);
+#pragma unroll
+        for (uint32_t i = 0; i < KTraits::NUM_MMA_KV; ++i) {
+            uint32_t k_smem_offset_r_first_half = *k_smem_offset_r;
+#pragma unroll
+            for (uint32_t j = 0; j < KTraits::NUM_MMA_D_QK / (2 * KTraits::NUM_WARPS_Q); ++j) {
+                uint32_t mma_di = warp_idx_x + j * KTraits::NUM_WARPS_Q;
+                k_smem->ldmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
+                uint32_t k_smem_offset_r_last_half =
+                    k_smem->template advance_offset_by_column<KTraits::NUM_MMA_D_QK>(k_smem_offset_r_first_half, 0);
+                k_smem->ldmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
+                k_frag_apply_llama_rope<DTypeKV>(
+                    (DTypeKV*)k_frag_local[0], (DTypeKV*)k_frag_local[1], rope_freq[mma_di], kv_idx);
+                k_smem->stmatrix_m8n8x4(k_smem_offset_r_last_half, k_frag_local[1]);
+                k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
+                k_smem_offset_r_first_half = k_smem->template advance_offset_by_column<2 * KTraits::NUM_WARPS_Q>(
+                    k_smem_offset_r_first_half, mma_di);
+            }
+            *k_smem_offset_r += 16 * UPCAST_STRIDE_K;
+            kv_idx += 16;
+        }
+        *k_smem_offset_r = (*k_smem_offset_r ^ (0x2 * warp_idx_x)) - KTraits::NUM_MMA_KV * 16 * UPCAST_STRIDE_K;
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void compute_qk(smem_t<KTraits::SWIZZLE_MODE_Q>*  q_smem,
+                                           uint32_t*                         q_smem_offset_r,
+                                           smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem,
+                                           uint32_t*                         k_smem_offset_r,
+                                           typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8]) {
+    constexpr uint32_t UPCAST_STRIDE_Q = KTraits::UPCAST_STRIDE_Q;
+    constexpr uint32_t UPCAST_STRIDE_K = KTraits::UPCAST_STRIDE_K;
+    uint32_t           a_frag[KTraits::NUM_MMA_Q][4], b_frag[4];
+    // compute q*k^T
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_QK; ++mma_d) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+            q_smem->ldmatrix_m8n8x4(*q_smem_offset_r, a_frag[mma_q]);
+            *q_smem_offset_r = q_smem->template advance_offset_by_row<16, UPCAST_STRIDE_Q>(*q_smem_offset_r);
+        }
+
+        *q_smem_offset_r = q_smem->template advance_offset_by_column<2>(*q_smem_offset_r, mma_d)
+                           - KTraits::NUM_MMA_Q * 16 * UPCAST_STRIDE_Q;
+
+#pragma unroll
+        for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+            if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
+                uint32_t b_frag_f8[2];
+                if (mma_d % 2 == 0) {
+                    k_smem->ldmatrix_m8n8x4_left_half(*k_smem_offset_r, b_frag_f8);
+                } else {
+                    k_smem->ldmatrix_m8n8x4_right_half(*k_smem_offset_r, b_frag_f8);
+                }
+                b_frag_f8[0] = frag_layout_swizzle_16b_to_8b(b_frag_f8[0]);
+                b_frag_f8[1] = frag_layout_swizzle_16b_to_8b(b_frag_f8[1]);
+                vec_cast<typename KTraits::DTypeQ, typename KTraits::DTypeKV>::cast<8>(
+                    (typename KTraits::DTypeQ*)b_frag, (typename KTraits::DTypeKV*)b_frag_f8);
+            } else {
+                k_smem->ldmatrix_m8n8x4(*k_smem_offset_r, b_frag);
+            }
+            *k_smem_offset_r = k_smem->template advance_offset_by_row<16, UPCAST_STRIDE_K>(*k_smem_offset_r);
+
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+                if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
+                    if (mma_d == 0) {
+                        mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ, MMAMode::kInit>(
+                            s_frag[mma_q][mma_kv], a_frag[mma_q], b_frag);
+                    } else {
+                        mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ>(
+                            s_frag[mma_q][mma_kv], a_frag[mma_q], b_frag);
+                    }
+                } else if (std::is_same_v<typename KTraits::DTypeQKAccum, half>) {
+                    if (mma_d == 0) {
+                        mma::mma_sync_m16n16k16_row_col_f16f16f16<MMAMode::kInit>(
+                            (uint32_t*)s_frag[mma_q][mma_kv], a_frag[mma_q], b_frag);
+                    } else {
+                        mma::mma_sync_m16n16k16_row_col_f16f16f16(
+                            (uint32_t*)s_frag[mma_q][mma_kv], a_frag[mma_q], b_frag);
+                    }
+                }
+            }
+        }
+        if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
+            if (mma_d % 2 == 1) {
+                *k_smem_offset_r = k_smem->template advance_offset_by_column<2>(*k_smem_offset_r, mma_d / 2);
+            }
+            *k_smem_offset_r -= KTraits::NUM_MMA_KV * 16 * UPCAST_STRIDE_K;
+        } else {
+            *k_smem_offset_r = k_smem->template advance_offset_by_column<2>(*k_smem_offset_r, mma_d)
+                               - KTraits::NUM_MMA_KV * 16 * UPCAST_STRIDE_K;
+        }
+    }
+    *q_smem_offset_r -= KTraits::NUM_MMA_D_QK * 2;
+    *k_smem_offset_r -= KTraits::NUM_MMA_D_QK * sizeof(typename KTraits::DTypeKV);
+}
+
+template<typename KTraits, typename Params>
+__device__ __forceinline__ void
+apply_per_token_k_scale(const Params&                      params,
+                        typename KTraits::AttentionVariant variant,
+                        const uint32_t                     batch_idx,
+                        const uint32_t                     kv_idx_base,
+                        typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+                        const uint32_t lane_idx    = threadIdx.x,
+                        const uint32_t kv_head_idx = blockIdx.z) {
+    if constexpr (KTraits::AttentionVariant::use_per_token_kv_scale) {
+#pragma unroll
+        for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+            float k_scale[4];
+#pragma unroll
+            for (uint32_t scale_idx = 0; scale_idx < 4; ++scale_idx) {
+                const uint32_t kv_idx =
+                    kv_idx_base + mma_kv * 16 + 2 * (lane_idx % 4) + 8 * (scale_idx / 2) + scale_idx % 2;
+                k_scale[scale_idx] = variant.KVScale(params, batch_idx, kv_idx, kv_head_idx, /*kv_selector=*/0);
+            }
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                    float scaled = float(s_frag[mma_q][mma_kv][reg_id]) * k_scale[2 * (reg_id / 4) + reg_id % 2];
+                    vec_cast<typename KTraits::DTypeQKAccum, float>::cast<1>(&s_frag[mma_q][mma_kv][reg_id], &scaled);
+                }
+            }
+        }
+    }
+}
+
+template<typename KTraits, typename Params, typename DTypeQKAccum>
+__device__ __forceinline__ void logits_transform(const Params&                      params,
+                                                 typename KTraits::AttentionVariant variant,
+                                                 const uint32_t                     batch_idx,
+                                                 const uint32_t                     qo_packed_idx_base,
+                                                 const uint32_t                     kv_idx_base,
+                                                 const uint32_t                     qo_len,
+                                                 const uint32_t                     kv_len,
+                                                 const uint_fastdiv                 group_size,
+                                                 DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+                                                 const dim3     tid         = threadIdx,
+                                                 const uint32_t kv_head_idx = blockIdx.z) {
+    const uint32_t lane_idx = tid.x;
+    uint32_t       q[KTraits::NUM_MMA_Q][2], r[KTraits::NUM_MMA_Q][2];
+    float          logits = 0., logitsTransformed = 0.;
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t j = 0; j < 2; ++j) {
+            group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / 4 + 8 * j, q[mma_q][j], r[mma_q][j]);
+        }
+    }
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+#pragma unroll
+            for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                const uint32_t q_idx  = q[mma_q][(reg_id % 4) / 2],
+                               kv_idx = kv_idx_base + mma_kv * 16 + 2 * (lane_idx % 4) + 8 * (reg_id / 4) + reg_id % 2;
+                const uint32_t qo_head_idx = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
+
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+                if constexpr (std::is_same<DTypeQKAccum, __half>::value) {
+                    logits = std::bit_cast<float>(fp16_ieee_to_fp32_value(s_frag[mma_q][mma_kv][reg_id]));
+                } else if constexpr (!std::is_same<DTypeQKAccum, __half>::value) {
+                    logits = s_frag[mma_q][mma_kv][reg_id];
+                }
+#else
+                static_assert(!std::is_same<DTypeQKAccum, __half>::value,
+                              "Set -DFP16_QK_REDUCTION_SUPPORTED and install boost_math "
+                              "then recompile to support fp16 reduction");
+                logits = s_frag[mma_q][mma_kv][reg_id];
+#endif
+                logitsTransformed =
+                    variant.LogitsTransform(params, logits, batch_idx, q_idx, kv_idx, qo_head_idx, kv_head_idx);
+#ifdef FP16_QK_REDUCTION_SUPPORTED
+                if constexpr (std::is_same<DTypeQKAccum, __half>::value) {
+                    s_frag[mma_q][mma_kv][reg_id] = std::bit_cast<half>(fp16_ieee_from_fp32_value(logitsTransformed));
+                } else if constexpr (!std::is_same<DTypeQKAccum, __half>::value) {
+                    s_frag[mma_q][mma_kv][reg_id] = logitsTransformed;
+                }
+#else
+                s_frag[mma_q][mma_kv][reg_id] = logitsTransformed;
+#endif
+            }
+        }
+    }
+}
+
+template<typename KTraits, typename Params>
+__device__ __forceinline__ void logits_mask(const Params&                      params,
+                                            typename KTraits::AttentionVariant variant,
+                                            const uint32_t                     batch_idx,
+                                            const uint32_t                     qo_packed_idx_base,
+                                            const uint32_t                     kv_idx_base,
+                                            const uint32_t                     qo_len,
+                                            const uint32_t                     kv_len,
+                                            const uint32_t                     chunk_end,
+                                            const uint_fastdiv                 group_size,
+                                            typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+                                            const dim3     tid         = threadIdx,
+                                            const uint32_t kv_head_idx = blockIdx.z) {
+    const uint32_t     lane_idx   = tid.x;
+    constexpr uint32_t NUM_MMA_Q  = KTraits::NUM_MMA_Q;
+    constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+    using DTypeQKAccum            = typename KTraits::DTypeQKAccum;
+    constexpr MaskMode MASK_MODE  = KTraits::MASK_MODE;
+    uint32_t           q[NUM_MMA_Q][2], r[NUM_MMA_Q][2];
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t j = 0; j < 2; ++j) {
+            group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / 4 + 8 * j, q[mma_q][j], r[mma_q][j]);
+        }
+    }
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+#pragma unroll
+            for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                const uint32_t q_idx  = q[mma_q][(reg_id % 4) / 2],
+                               kv_idx = kv_idx_base + mma_kv * 16 + 2 * (lane_idx % 4) + 8 * (reg_id / 4) + reg_id % 2;
+                const uint32_t qo_head_idx = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
+                const bool     mask = (!(MASK_MODE == MaskMode::kCausal || MASK_MODE == MaskMode::kMultiItemScoring ?
+                                             (kv_idx + qo_len > kv_len + q_idx || (kv_idx >= chunk_end)) :
+                                             kv_idx >= chunk_end))
+                                  && variant.LogitsMask(params, batch_idx, q_idx, kv_idx, qo_head_idx, kv_head_idx);
+                s_frag[mma_q][mma_kv][reg_id] = (mask) ? s_frag[mma_q][mma_kv][reg_id] : (KTraits::MaskFillValue);
+            }
+        }
+    }
+}
+
+template<typename KTraits, typename Params>
+__device__ __forceinline__ void
+logits_mask_multi_item_scoring(const Params&                      params,
+                               typename KTraits::AttentionVariant variant,
+                               const uint32_t                     batch_idx,
+                               const uint32_t                     qo_packed_idx_base,
+                               const uint32_t                     kv_idx_base,
+                               const uint32_t                     qo_len,
+                               const uint32_t                     kv_len,
+                               const uint32_t                     window_left,
+                               const uint32_t                     chunk_end,
+                               const uint_fastdiv                 group_size,
+                               typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+                               // new arguments for compact description of mask
+                               const uint32_t prefix_len,
+                               uint16_t*      token_pos_in_items,
+                               const uint32_t lane_idx    = threadIdx.x,
+                               const uint32_t kv_head_idx = blockIdx.z) {
+    constexpr uint32_t NUM_MMA_Q  = KTraits::NUM_MMA_Q;
+    constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+    using DTypeQKAccum            = typename KTraits::DTypeQKAccum;
+    uint32_t q[NUM_MMA_Q][2], r[NUM_MMA_Q][2];
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t j = 0; j < 2; ++j) {
+            group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / 4 + 8 * j, q[mma_q][j], r[mma_q][j]);
+        }
+    }
+    // prefetching global memory to registers
+    uint16_t token_pos_in_items_regs[NUM_MMA_Q][(4 / 2)];
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t eff_reg_id = 0; eff_reg_id < (4 / 2); ++eff_reg_id) {
+            const uint32_t q_idx = q[mma_q][eff_reg_id];
+            // use __ldca to hint compiler to cache in L1 for further reuse by other tiles
+            const int idx_in_original_seq = q_idx + kv_len - qo_len;
+            if (idx_in_original_seq >= prefix_len & idx_in_original_seq < kv_len) {
+                token_pos_in_items_regs[mma_q][eff_reg_id] =
+                    __ldca(token_pos_in_items + idx_in_original_seq - prefix_len);
+            }
+        }
+    }
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+#pragma unroll
+            for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                const uint32_t q_idx  = q[mma_q][(reg_id % 4) / 2],
+                               kv_idx = kv_idx_base + mma_kv * 16 + 2 * (lane_idx % 4) + 8 * (reg_id / 4) + reg_id % 2;
+                const uint32_t qo_head_idx         = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
+                const uint32_t idx_in_original_seq = q_idx + kv_len - qo_len;
+                const bool     out_of_boundary =
+                    kv_idx > idx_in_original_seq || (kv_idx >= chunk_end) || kv_idx + window_left < idx_in_original_seq;
+                const bool is_prefix = idx_in_original_seq < prefix_len;
+                if (out_of_boundary || is_prefix) {
+                    s_frag[mma_q][mma_kv][reg_id] =
+                        out_of_boundary ? (KTraits::MaskFillValue) : s_frag[mma_q][mma_kv][reg_id];
+                } else {
+                    s_frag[mma_q][mma_kv][reg_id] =
+                        (kv_idx < prefix_len
+                         | (idx_in_original_seq < kv_idx + token_pos_in_items_regs[mma_q][((reg_id % 4) / 2)])) ?
+                            s_frag[mma_q][mma_kv][reg_id] :
+                            (KTraits::MaskFillValue);
+                }
+            }
+        }
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void update_mdo_states(typename KTraits::AttentionVariant variant,
+                                                  typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+                                                  float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                                  typename KTraits::DTypeQKAccum (*m)[2],
+                                                  float (*d)[2]) {
+    using DTypeQKAccum         = typename KTraits::DTypeQKAccum;
+    using AttentionVariant     = typename KTraits::AttentionVariant;
+    constexpr bool use_softmax = AttentionVariant::use_softmax;
+
+    if constexpr (use_softmax) {
+        const float sm_scale = variant.sm_scale_log2;
+        if constexpr (std::is_same_v<DTypeQKAccum, float>) {
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                for (uint32_t j = 0; j < 2; ++j) {
+                    float m_prev = m[mma_q][j];
+#pragma unroll
+                    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+                        float m_local = max(max(s_frag[mma_q][mma_kv][j * 2 + 0], s_frag[mma_q][mma_kv][j * 2 + 1]),
+                                            max(s_frag[mma_q][mma_kv][j * 2 + 4], s_frag[mma_q][mma_kv][j * 2 + 5]));
+                        m[mma_q][j]   = max(m[mma_q][j], m_local);
+                    }
+                    m[mma_q][j] = max(m[mma_q][j], math::shfl_xor_sync(m[mma_q][j], 0x2));
+                    m[mma_q][j] = max(m[mma_q][j], math::shfl_xor_sync(m[mma_q][j], 0x1));
+
+                    float o_scale = math::ptx_exp2(m_prev * sm_scale - m[mma_q][j] * sm_scale);
+                    d[mma_q][j] *= o_scale;
+#pragma unroll
+                    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+                        o_frag[mma_q][mma_d][j * 2 + 0] *= o_scale;
+                        o_frag[mma_q][mma_d][j * 2 + 1] *= o_scale;
+                        o_frag[mma_q][mma_d][j * 2 + 4] *= o_scale;
+                        o_frag[mma_q][mma_d][j * 2 + 5] *= o_scale;
+                    }
+#pragma unroll
+                    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+                        s_frag[mma_q][mma_kv][j * 2 + 0] =
+                            math::ptx_exp2(s_frag[mma_q][mma_kv][j * 2 + 0] * sm_scale - m[mma_q][j] * sm_scale);
+                        s_frag[mma_q][mma_kv][j * 2 + 1] =
+                            math::ptx_exp2(s_frag[mma_q][mma_kv][j * 2 + 1] * sm_scale - m[mma_q][j] * sm_scale);
+                        s_frag[mma_q][mma_kv][j * 2 + 4] =
+                            math::ptx_exp2(s_frag[mma_q][mma_kv][j * 2 + 4] * sm_scale - m[mma_q][j] * sm_scale);
+                        s_frag[mma_q][mma_kv][j * 2 + 5] =
+                            math::ptx_exp2(s_frag[mma_q][mma_kv][j * 2 + 5] * sm_scale - m[mma_q][j] * sm_scale);
+                    }
+                }
+            }
+        } else if constexpr (std::is_same_v<DTypeQKAccum, half>) {
+            const half2 sm_scale = __float2half2_rn(variant.sm_scale_log2);
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+                half m_prev[2];
+#pragma unroll
+                for (uint32_t j = 0; j < 2; ++j) {
+                    m_prev[j] = m[mma_q][j];
+#pragma unroll
+                    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+                        half2 m_local =
+                            __hmax2(*(half2*)&s_frag[mma_q][mma_kv][j * 2], *(half2*)&s_frag[mma_q][mma_kv][j * 2 + 4]);
+                        m[mma_q][j] = __hmax(m[mma_q][j], __hmax(m_local.x, m_local.y));
+                    }
+                }
+                *(half2*)&m[mma_q] = __hmax2(*(half2*)&m[mma_q], math::shfl_xor_sync(*(half2*)&m[mma_q], 0x2));
+                *(half2*)&m[mma_q] = __hmax2(*(half2*)&m[mma_q], math::shfl_xor_sync(*(half2*)&m[mma_q], 0x1));
+#pragma unroll
+                for (uint32_t j = 0; j < 2; ++j) {
+                    float o_scale = math::ptx_exp2(float(m_prev[j] * sm_scale.x - m[mma_q][j] * sm_scale.x));
+                    d[mma_q][j] *= o_scale;
+#pragma unroll
+                    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+                        o_frag[mma_q][mma_d][j * 2 + 0] *= o_scale;
+                        o_frag[mma_q][mma_d][j * 2 + 1] *= o_scale;
+                        o_frag[mma_q][mma_d][j * 2 + 4] *= o_scale;
+                        o_frag[mma_q][mma_d][j * 2 + 5] *= o_scale;
+                    }
+                    half2 m2 = make_half2(m[mma_q][j], m[mma_q][j]);
+#pragma unroll
+                    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+                        *(half2*)&s_frag[mma_q][mma_kv][j * 2] =
+                            math::ptx_exp2(*(half2*)&s_frag[mma_q][mma_kv][j * 2] * sm_scale - m2 * sm_scale);
+                        *(half2*)&s_frag[mma_q][mma_kv][j * 2 + 4] =
+                            math::ptx_exp2(*(half2*)&s_frag[mma_q][mma_kv][j * 2 + 4] * sm_scale - m2 * sm_scale);
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<typename KTraits, typename Params>
+__device__ __forceinline__ void compute_sfm_v(const Params&                      params,
+                                              typename KTraits::AttentionVariant variant,
+                                              const uint32_t                     batch_idx,
+                                              const uint32_t                     kv_idx_base,
+                                              const uint32_t                     kv_head_idx,
+                                              smem_t<KTraits::SWIZZLE_MODE_KV>*  v_smem,
+                                              uint32_t*                          v_smem_offset_r,
+                                              typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+                                              float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                              float (*d)[2]) {
+    constexpr uint32_t UPCAST_STRIDE_V = KTraits::UPCAST_STRIDE_V;
+
+    typename KTraits::DTypeQ s_frag_f16[KTraits::NUM_MMA_Q][KTraits::NUM_MMA_KV][8];
+    if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+            for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+                vec_cast<typename KTraits::DTypeQ, float>::cast<8>(s_frag_f16[mma_q][mma_kv], s_frag[mma_q][mma_kv]);
+            }
+        }
+    }
+
+    if constexpr (KTraits::AttentionVariant::use_softmax) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+            for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+                if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
+                    mma::m16k16_rowsum_f16f16f32(d[mma_q], s_frag_f16[mma_q][mma_kv]);
+                } else {
+                    mma::m16k16_rowsum_f16f16f32(d[mma_q], s_frag[mma_q][mma_kv]);
+                }
+            }
+        }
+    }
+
+    // Scale the exact probability fragments consumed by PV MMA only after the
+    // unscaled softmax denominator has been accumulated into d.
+    if constexpr (KTraits::AttentionVariant::use_per_token_kv_scale) {
+#pragma unroll
+        for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+            float v_scale[4];
+#pragma unroll
+            for (uint32_t scale_idx = 0; scale_idx < 4; ++scale_idx) {
+                const uint32_t kv_idx =
+                    kv_idx_base + mma_kv * 16 + 2 * (threadIdx.x % 4) + 8 * (scale_idx / 2) + scale_idx % 2;
+                v_scale[scale_idx] = variant.KVScale(params, batch_idx, kv_idx, kv_head_idx, /*kv_selector=*/1);
+            }
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                    const float scale = v_scale[2 * (reg_id / 4) + reg_id % 2];
+                    if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
+                        float scaled = float(s_frag_f16[mma_q][mma_kv][reg_id]) * scale;
+                        vec_cast<typename KTraits::DTypeQ, float>::cast<1>(&s_frag_f16[mma_q][mma_kv][reg_id], &scaled);
+                    } else {
+                        float scaled = float(s_frag[mma_q][mma_kv][reg_id]) * scale;
+                        vec_cast<typename KTraits::DTypeQKAccum, float>::cast<1>(&s_frag[mma_q][mma_kv][reg_id],
+                                                                                 &scaled);
+                    }
+                }
+            }
+        }
+    }
+
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+#pragma unroll
+        for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+            uint32_t b_frag[4];
+            if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
+                uint32_t b_frag_f8[2];
+                if (mma_d % 2 == 0) {
+                    v_smem->ldmatrix_m8n8x4_trans_left_half(*v_smem_offset_r, b_frag_f8);
+                } else {
+                    v_smem->ldmatrix_m8n8x4_trans_right_half(*v_smem_offset_r, b_frag_f8);
+                }
+                b_frag_f8[0] = frag_layout_swizzle_16b_to_8b_trans(b_frag_f8[0]);
+                b_frag_f8[1] = frag_layout_swizzle_16b_to_8b_trans(b_frag_f8[1]);
+                vec_cast<typename KTraits::DTypeQ, typename KTraits::DTypeKV>::cast<8>(
+                    (typename KTraits::DTypeQ*)b_frag, (typename KTraits::DTypeKV*)b_frag_f8);
+                swap(b_frag[1], b_frag[2]);
+            } else {
+                v_smem->ldmatrix_m8n8x4_trans(*v_smem_offset_r, b_frag);
+            }
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+                if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
+                    mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ>(
+                        o_frag[mma_q][mma_d], (uint32_t*)s_frag_f16[mma_q][mma_kv], b_frag);
+                } else {
+                    mma::mma_sync_m16n16k16_row_col_f16f16f32<typename KTraits::DTypeQ>(
+                        o_frag[mma_q][mma_d], (uint32_t*)s_frag[mma_q][mma_kv], b_frag);
+                }
+            }
+            if constexpr (sizeof(typename KTraits::DTypeKV) == 1) {
+                if (mma_d % 2 == 1) {
+                    *v_smem_offset_r = v_smem->template advance_offset_by_column<2>(*v_smem_offset_r, mma_d / 2);
+                }
+            } else {
+                *v_smem_offset_r = v_smem->template advance_offset_by_column<2>(*v_smem_offset_r, mma_d);
+            }
+        }
+        *v_smem_offset_r = v_smem->template advance_offset_by_row<16, UPCAST_STRIDE_V>(*v_smem_offset_r)
+                           - sizeof(typename KTraits::DTypeKV) * KTraits::NUM_MMA_D_VO;
+    }
+    *v_smem_offset_r -= 16 * KTraits::NUM_MMA_KV * UPCAST_STRIDE_V;
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void finalize_m(typename KTraits::AttentionVariant variant,
+                                           typename KTraits::DTypeQKAccum (*m)[2]) {
+    if constexpr (variant.use_softmax) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+            for (uint32_t j = 0; j < 2; ++j) {
+                if (m[mma_q][j] != typename KTraits::DTypeQKAccum(-math::inf)) {
+                    m[mma_q][j] *= variant.sm_scale_log2;
+                }
+            }
+        }
+    }
+}
+
+template<typename KTraits, typename Params>
+__device__ __forceinline__ void transform_output(const Params&                      params,
+                                                 typename KTraits::AttentionVariant variant,
+                                                 float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                                 typename KTraits::DTypeQKAccum (*m)[2],
+                                                 float (*d)[2],
+                                                 const uint32_t     batch_idx,
+                                                 const uint32_t     kv_tile_idx,
+                                                 const uint32_t     qo_packed_idx_base,
+                                                 const uint32_t     warp_idx,
+                                                 const uint32_t     lane_idx,
+                                                 uint32_t           kv_head_idx,
+                                                 const uint_fastdiv group_size) {
+    uint32_t q[KTraits::NUM_MMA_Q][2], r[KTraits::NUM_MMA_Q][2];
+    float    scale[KTraits::NUM_MMA_Q][2];
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t j = 0; j < 2; ++j) {
+            group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / 4 + 8 * j, q[mma_q][j], r[mma_q][j]);
+            uint32_t qo_head_idx = kv_head_idx * group_size + r[mma_q][j];
+            // Update the m and d when attention sinks are used.
+            variant.update_m_d(params, kv_tile_idx, qo_head_idx, m[mma_q][j], d[mma_q][j], scale[mma_q][j]);
+        }
+    }
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+        for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+#pragma unroll
+            for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                const uint32_t qo_idx        = q[mma_q][(reg_id % 4) / 2];
+                const uint32_t qo_head_idx   = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
+                o_frag[mma_q][mma_d][reg_id] = variant.OutputTransform(params,
+                                                                       o_frag[mma_q][mma_d][reg_id],
+                                                                       batch_idx,
+                                                                       qo_idx,
+                                                                       qo_head_idx,
+                                                                       m[mma_q][(reg_id % 4) / 2],
+                                                                       d[mma_q][(reg_id % 4) / 2],
+                                                                       scale[mma_q][(reg_id % 4) / 2]);
+            }
+        }
+    }
+}
+
+/*!
+ * \brief Synchronize the states of the MDO kernel across the threadblock along threadIdx.z.
+ */
+template<typename KTraits>
+__device__ __forceinline__ void threadblock_sync_mdo_states(float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                                            typename KTraits::SharedStorage* smem_storage,
+                                                            typename KTraits::DTypeQKAccum (*m)[2],
+                                                            float (*d)[2],
+                                                            const uint32_t warp_idx,
+                                                            const uint32_t lane_idx,
+                                                            const dim3     tid = threadIdx) {
+    // only necessary when blockDim.z > 1
+    if constexpr (KTraits::NUM_WARPS_KV > 1) {
+        float*  smem_o  = smem_storage->cta_sync_o_smem;
+        float2* smem_md = smem_storage->cta_sync_md_smem;
+        // o: [num_warps, NUM_MMA_Q, NUM_MMA_D_VO, WARP_SIZE(32), 8]
+        // md: [num_warps, NUM_MMA_Q, 16, 2 (m/d)]
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+            for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+                vec_t<float, 8>::memcpy(
+                    smem_o
+                        + (((warp_idx * KTraits::NUM_MMA_Q + mma_q) * KTraits::NUM_MMA_D_VO + mma_d) * WARP_SIZE
+                           + lane_idx)
+                              * 8,
+                    o_frag[mma_q][mma_d]);
+            }
+        }
+
+        if constexpr (KTraits::AttentionVariant::use_softmax) {
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                for (uint32_t j = 0; j < 2; ++j) {
+                    smem_md[((warp_idx * KTraits::NUM_MMA_Q + mma_q) * 2 + j) * 8 + lane_idx / 4] =
+                        make_float2(float(m[mma_q][j]), d[mma_q][j]);
+                }
+            }
+
+            // synchronize m,d first
+            __syncthreads();
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+                float o_scale[2][KTraits::NUM_WARPS_KV];
+#pragma unroll
+                for (uint32_t j = 0; j < 2; ++j) {
+                    float m_new = -math::inf, d_new = 1.f;
+#pragma unroll
+                    for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
+                        float2 md =
+                            smem_md[(((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) * KTraits::NUM_MMA_Q
+                                      + mma_q)
+                                         * 2
+                                     + j)
+                                        * 8
+                                    + lane_idx / 4];
+                        float m_prev = m_new, d_prev = d_new;
+                        m_new = max(m_new, md.x);
+                        d_new = d_prev * math::ptx_exp2(m_prev - m_new) + md.y * math::ptx_exp2(md.x - m_new);
+                    }
+
+#pragma unroll
+                    for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
+                        float2 md =
+                            smem_md[(((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) * KTraits::NUM_MMA_Q
+                                      + mma_q)
+                                         * 2
+                                     + j)
+                                        * 8
+                                    + lane_idx / 4];
+                        float mi      = md.x;
+                        o_scale[j][i] = math::ptx_exp2(float(mi - m_new));
+                    }
+                    m[mma_q][j] = typename KTraits::DTypeQKAccum(m_new);
+                    d[mma_q][j] = d_new;
+                }
+
+#pragma unroll
+                for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+                    vec_t<float, 8> o_new;
+                    o_new.fill(0.f);
+#pragma unroll
+                    for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
+                        vec_t<float, 8> oi;
+                        oi.load(smem_o
+                                + ((((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) * KTraits::NUM_MMA_Q
+                                     + mma_q)
+                                        * KTraits::NUM_MMA_D_VO
+                                    + mma_d)
+                                       * WARP_SIZE
+                                   + lane_idx)
+                                      * 8);
+
+#pragma unroll
+                        for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                            o_new[reg_id] += oi[reg_id] * o_scale[(reg_id % 4) / 2][i];
+                        }
+                    }
+                    o_new.store(o_frag[mma_q][mma_d]);
+                }
+            }
+        } else {
+            // synchronize m,d first
+            __syncthreads();
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+                    vec_t<float, 8> o_new;
+                    o_new.fill(0.f);
+#pragma unroll
+                    for (uint32_t i = 0; i < KTraits::NUM_WARPS_KV; ++i) {
+                        vec_t<float, 8> oi;
+                        oi.load(smem_o
+                                + ((((i * KTraits::NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) * KTraits::NUM_MMA_Q
+                                     + mma_q)
+                                        * KTraits::NUM_MMA_D_VO
+                                    + mma_d)
+                                       * WARP_SIZE
+                                   + lane_idx)
+                                      * 8);
+#pragma unroll
+                        for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+                            o_new[reg_id] += oi[reg_id];
+                        }
+                    }
+                    o_new.store(o_frag[mma_q][mma_d]);
+                }
+            }
+        }
+    }
+}
+
+template<typename KTraits>
+__device__ __forceinline__ void write_o_reg_gmem(float (*o_frag)[KTraits::NUM_MMA_D_VO][8],
+                                                 smem_t<KTraits::SWIZZLE_MODE_Q>* o_smem,
+                                                 typename KTraits::DTypeO*        o_ptr_base,
+                                                 const uint32_t                   o_packed_idx_base,
+                                                 const uint32_t                   qo_upper_bound,
+                                                 const uint32_t                   o_stride_n,
+                                                 const uint32_t                   o_stride_h,
+                                                 const uint_fastdiv               group_size,
+                                                 const dim3                       tid = threadIdx) {
+    using DTypeO                       = typename KTraits::DTypeO;
+    constexpr uint32_t UPCAST_STRIDE_O = KTraits::UPCAST_STRIDE_O;
+    const uint32_t     warp_idx_x      = get_warp_idx_q<KTraits>(tid.y);
+    const uint32_t     lane_idx        = tid.x;
+
+    if constexpr (sizeof(DTypeO) == 4) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+            for (uint32_t j = 0; j < 2; ++j) {
+                uint32_t q, r;
+                group_size.divmod(o_packed_idx_base + lane_idx / 4 + mma_q * 16 + j * 8, q, r);
+                const uint32_t o_idx = q;
+#pragma unroll
+                for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+                    if (o_idx < qo_upper_bound) {
+                        *reinterpret_cast<float2*>(o_ptr_base + q * o_stride_n + r * o_stride_h + mma_d * 16
+                                                   + (lane_idx % 4) * 2) =
+                            *reinterpret_cast<float2*>(&o_frag[mma_q][mma_d][j * 2]);
+                        *reinterpret_cast<float2*>(o_ptr_base + q * o_stride_n + r * o_stride_h + mma_d * 16 + 8
+                                                   + (lane_idx % 4) * 2) =
+                            *reinterpret_cast<float2*>(&o_frag[mma_q][mma_d][4 + j * 2]);
+                    }
+                }
+            }
+        }
+    } else {
+        if (get_warp_idx_kv<KTraits>(tid.z) == 0) {
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
+                    uint32_t o_frag_f16[8 / 2];
+                    vec_cast<DTypeO, float>::cast<8>((DTypeO*)o_frag_f16, o_frag[mma_q][mma_d]);
+
+#ifdef FLASHINFER_STMATRIX_M8N8X4_ENABLED
+                    uint32_t o_smem_offset_w = o_smem->template get_permuted_offset<UPCAST_STRIDE_O>(
+                        (warp_idx_x * KTraits::NUM_MMA_Q + mma_q) * 16 + lane_idx % 16, mma_d * 2 + lane_idx / 16);
+                    o_smem->stmatrix_m8n8x4(o_smem_offset_w, o_frag_f16);
+#else
+                    uint32_t o_smem_offset_w = o_smem->template get_permuted_offset<UPCAST_STRIDE_O>(
+                        (warp_idx_x * KTraits::NUM_MMA_Q + mma_q) * 16 + lane_idx / 4, mma_d * 2);
+                    ((uint32_t*)(o_smem->base + o_smem_offset_w))[lane_idx % 4]                       = o_frag_f16[0];
+                    ((uint32_t*)(o_smem->base + o_smem_offset_w + 8 * UPCAST_STRIDE_O))[lane_idx % 4] = o_frag_f16[1];
+                    ((uint32_t*)(o_smem->base + (o_smem_offset_w ^ 0x1)))[lane_idx % 4]               = o_frag_f16[2];
+                    ((uint32_t*)(o_smem->base + (o_smem_offset_w ^ 0x1) + 8 * UPCAST_STRIDE_O))[lane_idx % 4] =
+                        o_frag_f16[3];
+#endif
+                }
+            }
+
+            uint32_t o_smem_offset_w = o_smem->template get_permuted_offset<UPCAST_STRIDE_O>(
+                warp_idx_x * KTraits::NUM_MMA_Q * 16 + lane_idx / 8, lane_idx % 8);
+
+#pragma unroll
+            for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                for (uint32_t j = 0; j < 2 * 2; ++j) {
+                    uint32_t q, r;
+                    group_size.divmod(o_packed_idx_base + lane_idx / 8 + mma_q * 16 + j * 4, q, r);
+                    const uint32_t o_idx = q;
+                    DTypeO*        o_ptr =
+                        o_ptr_base + q * o_stride_n + r * o_stride_h + (lane_idx % 8) * upcast_size<DTypeO>();
+#pragma unroll
+                    for (uint32_t mma_do = 0; mma_do < KTraits::NUM_MMA_D_VO / 4; ++mma_do) {
+                        if (o_idx < qo_upper_bound) {
+                            o_smem->store_128b(o_smem_offset_w, o_ptr);
+                        }
+                        o_ptr += 8 * upcast_size<DTypeO>();
+                        o_smem_offset_w = o_smem->template advance_offset_by_column<8>(o_smem_offset_w, mma_do);
+                    }
+                    o_smem_offset_w = o_smem->template advance_offset_by_row<4, UPCAST_STRIDE_O>(o_smem_offset_w)
+                                      - 2 * KTraits::NUM_MMA_D_VO;
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+/*!
+ * \brief FlashAttention prefill CUDA kernel for a single request.
+ * \tparam partition_kv Whether to split kv_len into chunks.
+ * \tparam mask_mode The mask mode used in the attention operation.
+ * \tparam POS_ENCODING_MODE The positional encoding mode.
+ * \tparam NUM_MMA_Q The number of fragments in x dimension.
+ * \tparam NUM_MMA_D_VO The number of fragments in y dimension.
+ * \tparam NUM_MMA_KV The number of fragments in z dimension.
+ * \tparam num_warps The number of warps in the threadblock.
+ * \tparam DTypeQ The data type of the query tensor.
+ * \tparam DTypeKV The data type of the key/value tensor.
+ * \tparam DTypeO The data type of the output tensor.
+ * \param q The query tensor.
+ * \param k The key tensor.
+ * \param v The value tensor.
+ * \param o The output tensor.
+ * \param tmp The temporary buffer (used when partition_kv is true).
+ * \param lse The logsumexp value.
+ * \param rope_rcp_scale 1/(rope_scale), where rope_scale is the scaling
+ *   factor used in RoPE interpolation.
+ * \param rope_rcp_theta 1/(rope_theta), where rope_theta is the theta
+ *   used in RoPE.
+ */
+template<typename KTraits, typename Params>
+__device__ __forceinline__ void SinglePrefillWithKVCacheDevice(const Params                     params,
+                                                               typename KTraits::SharedStorage& smem_storage,
+                                                               const dim3                       tid       = threadIdx,
+                                                               const uint32_t                   bx        = blockIdx.x,
+                                                               const uint32_t                   chunk_idx = blockIdx.y,
+                                                               const uint32_t kv_head_idx                 = blockIdx.z,
+                                                               const uint32_t num_chunks                  = gridDim.y,
+                                                               const uint32_t num_kv_heads                = gridDim.z) {
+    using DTypeQ = typename Params::DTypeQ;
+#if (__CUDA_ARCH__ < 800)
+    if constexpr (std::is_same_v<DTypeQ, nv_bfloat16>) {
+        FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
+    } else {
+#endif
+        using DTypeKV                                            = typename Params::DTypeKV;
+        using DTypeO                                             = typename Params::DTypeO;
+        using DTypeQKAccum                                       = typename KTraits::DTypeQKAccum;
+        using AttentionVariant                                   = typename KTraits::AttentionVariant;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_Q         = KTraits::NUM_MMA_Q;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_KV        = KTraits::NUM_MMA_KV;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_D_QK      = KTraits::NUM_MMA_D_QK;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_D_VO      = KTraits::NUM_MMA_D_VO;
+        [[maybe_unused]] constexpr uint32_t    HEAD_DIM_QK       = KTraits::HEAD_DIM_QK;
+        [[maybe_unused]] constexpr uint32_t    HEAD_DIM_VO       = KTraits::HEAD_DIM_VO;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_Q   = KTraits::UPCAST_STRIDE_Q;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_K   = KTraits::UPCAST_STRIDE_K;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_V   = KTraits::UPCAST_STRIDE_V;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_O   = KTraits::UPCAST_STRIDE_O;
+        [[maybe_unused]] constexpr uint32_t    CTA_TILE_Q        = KTraits::CTA_TILE_Q;
+        [[maybe_unused]] constexpr uint32_t    CTA_TILE_KV       = KTraits::CTA_TILE_KV;
+        [[maybe_unused]] constexpr uint32_t    NUM_WARPS_Q       = KTraits::NUM_WARPS_Q;
+        [[maybe_unused]] constexpr uint32_t    NUM_WARPS_KV      = KTraits::NUM_WARPS_KV;
+        [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_Q    = KTraits::SWIZZLE_MODE_Q;
+        [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_KV   = KTraits::SWIZZLE_MODE_KV;
+        [[maybe_unused]] constexpr uint32_t    KV_THR_LAYOUT_ROW = KTraits::KV_THR_LAYOUT_ROW;
+        [[maybe_unused]] constexpr uint32_t    KV_THR_LAYOUT_COL = KTraits::KV_THR_LAYOUT_COL;
+        [[maybe_unused]] constexpr MaskMode    MASK_MODE         = KTraits::MASK_MODE;
+
+        DTypeQ*             q            = params.q;
+        DTypeKV*            k            = params.k;
+        DTypeKV*            v            = params.v;
+        DTypeO*             o            = params.o;
+        float*              lse          = params.lse;
+        const uint32_t      qo_len       = params.qo_len;
+        const uint32_t      kv_len       = params.kv_len;
+        const bool          partition_kv = params.partition_kv;
+        const uint32_t      q_stride_n   = params.q_stride_n;
+        const uint32_t      q_stride_h   = params.q_stride_h;
+        const uint32_t      k_stride_n   = params.k_stride_n;
+        const uint32_t      k_stride_h   = params.k_stride_h;
+        const uint32_t      v_stride_n   = params.v_stride_n;
+        const uint32_t      v_stride_h   = params.v_stride_h;
+        const uint_fastdiv& group_size   = params.group_size;
+
+        static_assert(sizeof(DTypeQ) == 2);
+        const uint32_t lane_idx = tid.x, warp_idx = get_warp_idx<KTraits>(tid.y, tid.z);
+        const uint32_t num_qo_heads = num_kv_heads * group_size;
+
+        const uint32_t max_chunk_size = partition_kv ? ceil_div(kv_len, num_chunks) : kv_len;
+        const uint32_t chunk_start    = partition_kv ? chunk_idx * max_chunk_size : 0;
+        const uint32_t chunk_end      = partition_kv ? min((chunk_idx + 1) * max_chunk_size, kv_len) : kv_len;
+        const uint32_t chunk_size     = chunk_end - chunk_start;
+
+        auto             block = cg::this_thread_block();
+        auto             smem  = reinterpret_cast<uint8_t*>(&smem_storage);
+        AttentionVariant variant(params, /*batch_idx=*/0, smem);
+        const uint32_t   window_left = variant.window_left;
+
+        DTypeQKAccum      s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
+        alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
+        DTypeQKAccum      m[NUM_MMA_Q][2];
+        float             d[NUM_MMA_Q][2];
+        float             rope_freq[NUM_MMA_D_QK / 2][4];
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+            const float rope_rcp_scale = params.rope_rcp_scale;
+            const float rope_rcp_theta = params.rope_rcp_theta;
+            init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+        }
+        init_states<KTraits>(variant, o_frag, m, d);
+
+        // cooperative fetch q fragment from gmem to reg
+        const uint32_t qo_packed_idx_base = (bx * NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) * NUM_MMA_Q * 16;
+        smem_t<SWIZZLE_MODE_Q> qo_smem(smem_storage.q_smem);
+        const uint32_t         o_stride_n = num_qo_heads * HEAD_DIM_VO, o_stride_h = HEAD_DIM_VO;
+        DTypeQ*                q_ptr_base = q + (kv_head_idx * group_size) * q_stride_h;
+        DTypeO* o_ptr_base = partition_kv ? o + chunk_idx * o_stride_n + (kv_head_idx * group_size) * o_stride_h :
+                                            o + (kv_head_idx * group_size) * o_stride_h;
+
+        uint32_t q_smem_offset_r = qo_smem.template get_permuted_offset<UPCAST_STRIDE_Q>(
+            get_warp_idx_q<KTraits>(tid.y) * NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
+        load_q_global_smem<KTraits>(
+            qo_packed_idx_base, qo_len, q_ptr_base, q_stride_n, q_stride_h, group_size, &qo_smem, tid);
+
+        cp_async::commit_group();
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+            cp_async::wait_group<0>();
+            block.sync();
+            q_smem_inplace_apply_rotary<KTraits>(
+                qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq, tid);
+            block.sync();
+        }
+
+        smem_t<SWIZZLE_MODE_KV> k_smem(smem_storage.k_smem), v_smem(smem_storage.v_smem);
+
+        const uint32_t num_iterations =
+            ceil_div(MASK_MODE == MaskMode::kCausal ?
+                         min(chunk_size,
+                             sub_if_greater_or_zero(kv_len - qo_len + ceil_div(((bx + 1) * CTA_TILE_Q), group_size),
+                                                    chunk_start)) :
+                         chunk_size,
+                     CTA_TILE_KV);
+
+        const uint32_t window_iteration =
+            ceil_div(sub_if_greater_or_zero(kv_len + ceil_div((bx + 1) * CTA_TILE_Q, group_size),
+                                            qo_len + window_left + chunk_start),
+                     CTA_TILE_KV);
+
+        const uint32_t mask_iteration =
+            (MASK_MODE == MaskMode::kCausal ?
+                 min(chunk_size,
+                     sub_if_greater_or_zero(kv_len + ceil_div((bx * CTA_TILE_Q), group_size) - qo_len, chunk_start)) :
+                 chunk_size)
+            / CTA_TILE_KV;
+
+        DTypeKV* k_ptr = k + (chunk_start + warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL) * k_stride_n
+                         + kv_head_idx * k_stride_h + (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>();
+        DTypeKV* v_ptr = v + (chunk_start + warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL) * v_stride_n
+                         + kv_head_idx * v_stride_h + (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>();
+
+        uint32_t k_smem_offset_r = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
+                     get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + 8 * (lane_idx / 16) + lane_idx % 8,
+                     (lane_idx % 16) / 8),
+                 v_smem_offset_r = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+                     get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + lane_idx % 16, lane_idx / 16),
+                 k_smem_offset_w = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
+                     warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL, lane_idx % KV_THR_LAYOUT_COL),
+                 v_smem_offset_w = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+                     warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL, lane_idx % KV_THR_LAYOUT_COL);
+        produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(
+            k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, 0, chunk_size, tid);
+        cp_async::commit_group();
+        produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+            v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, 0, chunk_size, tid);
+        cp_async::commit_group();
+
+#pragma unroll 1
+        for (uint32_t iter = 0; iter < num_iterations; ++iter) {
+            cp_async::wait_group<1>();
+            block.sync();
+
+            if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+                k_smem_inplace_apply_rotary<KTraits>(
+                    chunk_start + iter * CTA_TILE_KV, &k_smem, &k_smem_offset_r, rope_freq, tid);
+                block.sync();
+            }
+
+            // compute attention score
+            compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+            uint32_t kv_idx_base =
+                chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
+            apply_per_token_k_scale<KTraits>(
+                params, variant, /*batch_idx=*/0, kv_idx_base, s_frag, lane_idx, kv_head_idx);
+            logits_transform<KTraits>(params,
+                                      variant,
+                                      /*batch_idx=*/0,
+                                      qo_packed_idx_base,
+                                      kv_idx_base,
+                                      qo_len,
+                                      kv_len,
+                                      group_size,
+                                      s_frag,
+                                      tid,
+                                      kv_head_idx);
+
+            // apply mask
+            if (MASK_MODE == MaskMode::kCustom || (iter >= mask_iteration || iter < window_iteration)) {
+                logits_mask<KTraits>(params,
+                                     variant,
+                                     /*batch_idx=*/0,
+                                     qo_packed_idx_base,
+                                     kv_idx_base,
+                                     qo_len,
+                                     kv_len,
+                                     chunk_end,
+                                     group_size,
+                                     s_frag,
+                                     tid,
+                                     kv_head_idx);
+            }
+
+            // compute m,d states in online softmax
+            update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
+
+            block.sync();
+            produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(
+                k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size, tid);
+            cp_async::commit_group();
+            cp_async::wait_group<1>();
+            block.sync();
+
+            // compute sfm*v
+            compute_sfm_v<KTraits>(params,
+                                   variant,
+                                   /*batch_idx=*/0,
+                                   kv_idx_base,
+                                   kv_head_idx,
+                                   &v_smem,
+                                   &v_smem_offset_r,
+                                   s_frag,
+                                   o_frag,
+                                   d);
+
+            block.sync();
+            produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+                v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size, tid);
+            cp_async::commit_group();
+        }
+        cp_async::wait_group<0>();
+        block.sync();
+
+        finalize_m<KTraits>(variant, m);
+
+        // threadblock synchronization
+        threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
+
+        // transform output
+        transform_output<KTraits, Params>(params,
+                                          variant,
+                                          o_frag,
+                                          m,
+                                          d,
+                                          /*batch_idx=*/0,
+                                          chunk_idx,
+                                          qo_packed_idx_base,
+                                          warp_idx,
+                                          lane_idx,
+                                          kv_head_idx,
+                                          group_size);
+
+        // write back
+        write_o_reg_gmem<KTraits>(o_frag,
+                                  &qo_smem,
+                                  o_ptr_base,
+                                  qo_packed_idx_base,
+                                  qo_len,
+                                  /*o_stride_n=*/
+                                  partition_kv ? num_chunks * o_stride_n : o_stride_n,
+                                  /*o_stride_h=*/o_stride_h,
+                                  group_size,
+                                  tid);
+
+        // write lse
+        if constexpr (variant.use_softmax) {
+            if (lse != nullptr || partition_kv) {
+                if (get_warp_idx_kv<KTraits>(tid.z) == 0) {
+#pragma unroll
+                    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                        for (uint32_t j = 0; j < 2; ++j) {
+                            uint32_t q, r;
+                            group_size.divmod(qo_packed_idx_base + lane_idx / 4 + j * 8 + mma_q * 16, q, r);
+                            const uint32_t qo_head_idx = kv_head_idx * group_size + r;
+                            const uint32_t qo_idx      = q;
+                            if (qo_idx < qo_len) {
+                                if (partition_kv) {
+                                    lse[(qo_idx * num_chunks + chunk_idx) * num_qo_heads + qo_head_idx] =
+                                        math::ptx_log2(d[mma_q][j]) + float(m[mma_q][j]);
+                                } else {
+                                    lse[qo_idx * num_qo_heads + qo_head_idx] =
+                                        math::ptx_log2(d[mma_q][j]) + float(m[mma_q][j]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+#if (__CUDA_ARCH__ < 800)
+    }
+#endif
+}
+
+template<typename KTraits, typename Params>
+__global__
+__launch_bounds__(KTraits::NUM_THREADS) void SinglePrefillWithKVCacheKernel(const __grid_constant__ Params params) {
+    extern __shared__ uint8_t smem[];
+    auto&                     smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+    SinglePrefillWithKVCacheDevice<KTraits>(params, smem_storage);
+}
+
+template<uint32_t        HEAD_DIM_QK,
+         uint32_t        HEAD_DIM_VO,
+         PosEncodingMode POS_ENCODING_MODE,
+         bool            USE_FP16_QK_REDUCTION,
+         MaskMode        MASK_MODE,
+         typename AttentionVariant,
+         typename Params>
+cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp, cudaStream_t stream) {
+    using DTypeQ                = typename Params::DTypeQ;
+    using DTypeKV               = typename Params::DTypeKV;
+    using DTypeO                = typename Params::DTypeO;
+    const uint32_t num_qo_heads = params.num_qo_heads;
+    const uint32_t num_kv_heads = params.num_kv_heads;
+    const uint32_t qo_len       = params.qo_len;
+    const uint32_t kv_len       = params.kv_len;
+    if (kv_len < qo_len && MASK_MODE == MaskMode::kCausal) {
+        std::ostringstream err_msg;
+        err_msg << "When mask_mode is set to MaskMode::kCausal, kv_len must be greater than or equal "
+                   "to qo_len, got kv_len"
+                << kv_len << " and qo_len " << qo_len;
+        FLASHINFER_ERROR(err_msg.str());
+    }
+
+    const uint32_t     group_size    = num_qo_heads / num_kv_heads;
+    constexpr uint32_t NUM_MMA_D_QK  = HEAD_DIM_QK / 16;
+    constexpr uint32_t NUM_MMA_D_VO  = HEAD_DIM_VO / 16;
+    int64_t            packed_qo_len = qo_len * group_size;
+    uint32_t           cta_tile_q    = FA2DetermineCtaTileQ(packed_qo_len, HEAD_DIM_VO);
+
+    DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
+        constexpr uint32_t NUM_WARPS_Q  = get_num_warps_q(CTA_TILE_Q);
+        constexpr uint32_t NUM_WARPS_KV = get_num_warps_kv(CTA_TILE_Q);
+        constexpr uint32_t NUM_MMA_Q    = get_num_mma_q(CTA_TILE_Q);
+
+        using DTypeQKAccum =
+            typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ, half>, half, float>::type;
+
+        int dev_id = 0;
+        FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+        int max_smem_per_sm = 0;
+        FLASHINFER_CUDA_CALL(
+            cudaDeviceGetAttribute(&max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
+        // we expect each sm execute two threadblocks
+        const int num_ctas_per_sm =
+            max_smem_per_sm >= 2
+                                   * (CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)
+                                      + (HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV)) ?
+                2 :
+                1;
+        const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
+
+        const uint32_t max_num_mma_kv_reg =
+            (HEAD_DIM_VO >= 128 && NUM_MMA_Q == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama
+             && !USE_FP16_QK_REDUCTION) ?
+                2 :
+                (8 / NUM_MMA_Q);
+        const uint32_t max_num_mma_kv_smem = (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ))
+                                             / ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV));
+
+        // control NUM_MMA_KV for maximum warp occupancy
+        DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
+            using KTraits = KernelTraits<MASK_MODE,
+                                         CTA_TILE_Q,
+                                         NUM_MMA_Q,
+                                         NUM_MMA_KV,
+                                         NUM_MMA_D_QK,
+                                         NUM_MMA_D_VO,
+                                         NUM_WARPS_Q,
+                                         NUM_WARPS_KV,
+                                         POS_ENCODING_MODE,
+                                         DTypeQ,
+                                         DTypeKV,
+                                         DTypeO,
+                                         DTypeQKAccum,
+                                         typename Params::IdType,
+                                         AttentionVariant>;
+            if constexpr (KTraits::IsInvalid()) {
+                // Invalid configuration, skip
+                std::ostringstream err_msg;
+                err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
+                        << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
+                        << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
+                        << " NUM_WARPS_KV=" << NUM_WARPS_KV
+                        << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
+                           " and report the issue to the developers.";
+                FLASHINFER_ERROR(err_msg.str());
+            } else {
+                constexpr uint32_t num_threads = (NUM_WARPS_Q * NUM_WARPS_KV) * WARP_SIZE;
+                auto               kernel      = SinglePrefillWithKVCacheKernel<KTraits, Params>;
+                size_t             smem_size   = sizeof(typename KTraits::SharedStorage);
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                int num_blocks_per_sm = 0;
+                int num_sm            = 0;
+                FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
+                FLASHINFER_CUDA_CALL(
+                    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks_per_sm, kernel, num_threads, smem_size));
+                uint32_t max_num_kv_chunks =
+                    (num_blocks_per_sm * num_sm) / (num_kv_heads * ceil_div(qo_len * group_size, CTA_TILE_Q));
+                uint32_t num_chunks;
+                if (max_num_kv_chunks > 0) {
+                    uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256);
+                    num_chunks          = ceil_div(kv_len, chunk_size);
+                } else {
+                    num_chunks = 0;
+                }
+
+                if (num_chunks <= 1 || tmp == nullptr) {
+                    // Enough parallelism, do not split-kv
+                    params.partition_kv = false;
+                    void* args[]        = {(void*)&params};
+                    dim3  nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), 1, num_kv_heads);
+                    dim3  nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+                } else {
+                    // Use cooperative groups to increase occupancy
+                    params.partition_kv = true;
+                    float* tmp_lse      = (float*)(tmp + num_chunks * qo_len * num_qo_heads * HEAD_DIM_VO);
+                    auto   o            = params.o;
+                    auto   lse          = params.lse;
+                    params.o            = tmp;
+                    params.lse          = tmp_lse;
+                    void* args[]        = {(void*)&params};
+                    dim3  nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), num_chunks, num_kv_heads);
+                    dim3  nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
+
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+                    if constexpr (AttentionVariant::use_softmax) {
+                        FLASHINFER_CUDA_CALL(
+                            MergeStates(tmp, tmp_lse, o, lse, num_chunks, qo_len, num_qo_heads, HEAD_DIM_VO, stream));
+                    } else {
+                        FLASHINFER_CUDA_CALL(
+                            AttentionSum(tmp, o, num_chunks, qo_len, num_qo_heads, HEAD_DIM_VO, stream));
+                    }
+                }
+            }
+        })
+    });
+    return cudaSuccess;
+}
+
+template<typename KTraits, typename Params>
+__global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKVCacheKernel(
+    const __grid_constant__ Params params) {
+    using DTypeQ = typename Params::DTypeQ;
+#if (__CUDA_ARCH__ < 800)
+    if constexpr (std::is_same_v<DTypeQ, nv_bfloat16>) {
+        FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
+    } else {
+#endif
+        using DTypeKV                                            = typename Params::DTypeKV;
+        using DTypeO                                             = typename Params::DTypeO;
+        using IdType                                             = typename Params::IdType;
+        using DTypeQKAccum                                       = typename KTraits::DTypeQKAccum;
+        using AttentionVariant                                   = typename KTraits::AttentionVariant;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_Q         = KTraits::NUM_MMA_Q;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_KV        = KTraits::NUM_MMA_KV;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_D_QK      = KTraits::NUM_MMA_D_QK;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_D_VO      = KTraits::NUM_MMA_D_VO;
+        [[maybe_unused]] constexpr uint32_t    HEAD_DIM_QK       = KTraits::HEAD_DIM_QK;
+        [[maybe_unused]] constexpr uint32_t    HEAD_DIM_VO       = KTraits::HEAD_DIM_VO;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_Q   = KTraits::UPCAST_STRIDE_Q;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_K   = KTraits::UPCAST_STRIDE_K;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_V   = KTraits::UPCAST_STRIDE_V;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_O   = KTraits::UPCAST_STRIDE_O;
+        [[maybe_unused]] constexpr uint32_t    CTA_TILE_Q        = KTraits::CTA_TILE_Q;
+        [[maybe_unused]] constexpr uint32_t    CTA_TILE_KV       = KTraits::CTA_TILE_KV;
+        [[maybe_unused]] constexpr uint32_t    NUM_WARPS_Q       = KTraits::NUM_WARPS_Q;
+        [[maybe_unused]] constexpr uint32_t    NUM_WARPS_KV      = KTraits::NUM_WARPS_KV;
+        [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_Q    = KTraits::SWIZZLE_MODE_Q;
+        [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_KV   = KTraits::SWIZZLE_MODE_KV;
+        [[maybe_unused]] constexpr uint32_t    KV_THR_LAYOUT_ROW = KTraits::KV_THR_LAYOUT_ROW;
+        [[maybe_unused]] constexpr uint32_t    KV_THR_LAYOUT_COL = KTraits::KV_THR_LAYOUT_COL;
+        [[maybe_unused]] constexpr MaskMode    MASK_MODE         = KTraits::MASK_MODE;
+
+        DTypeQ*             q                = params.q;
+        IdType*             request_indices  = params.request_indices;
+        IdType*             qo_tile_indices  = params.qo_tile_indices;
+        IdType*             kv_tile_indices  = params.kv_tile_indices;
+        IdType*             q_indptr         = params.q_indptr;
+        IdType*             kv_indptr        = params.kv_indptr;
+        DTypeKV*            k                = params.k;
+        DTypeKV*            v                = params.v;
+        IdType*             o_indptr         = params.o_indptr;
+        DTypeO*             o                = params.o;
+        float*              lse              = params.lse;
+        bool*               block_valid_mask = params.block_valid_mask;
+        const bool          partition_kv     = params.partition_kv;
+        const uint32_t      q_stride_n       = params.q_stride_n;
+        const uint32_t      q_stride_h       = params.q_stride_h;
+        const uint32_t      k_stride_n       = params.k_stride_n;
+        const uint32_t      k_stride_h       = params.k_stride_h;
+        const uint32_t      v_stride_n       = params.v_stride_n;
+        const uint32_t      v_stride_h       = params.v_stride_h;
+        const uint_fastdiv& group_size       = params.group_size;
+
+        static_assert(sizeof(DTypeQ) == 2);
+        const uint32_t kv_chunk_size = *(params.kv_chunk_size_ptr);
+        const dim3&    tid           = threadIdx;
+
+        auto           block = cg::this_thread_block();
+        const uint32_t bx = blockIdx.x, lane_idx = tid.x, warp_idx = get_warp_idx<KTraits>(tid.y, tid.z),
+                       kv_head_idx = blockIdx.z;
+        if (block_valid_mask && !block_valid_mask[bx]) {
+            return;
+        }
+        const uint32_t num_kv_heads = gridDim.z, num_qo_heads = group_size * num_kv_heads;
+        const uint32_t request_idx = request_indices[bx], qo_tile_idx = qo_tile_indices[bx],
+                       kv_tile_idx = kv_tile_indices[bx];
+        extern __shared__ uint8_t smem[];
+        auto&                     smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+        AttentionVariant          variant(params, /*batch_idx=*/request_idx, smem);
+        const uint32_t            qo_len = variant.qo_len, kv_len = variant.kv_len, window_left = variant.window_left;
+        const uint32_t            kv_len_safe    = kv_len > 0 ? kv_len : 1;
+        const uint32_t            qo_upper_bound = min(qo_len, ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size));
+
+        // skip out-of-window kv tile by add non-zero kv_start_idx offset
+        const uint32_t kv_start_idx =
+            sub_if_greater_or_zero(kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size, qo_len + window_left);
+        const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+        const uint32_t chunk_start =
+            partition_kv ? min(kv_tile_idx * max_chunk_size + kv_start_idx, kv_len) : kv_start_idx;
+        const uint32_t chunk_end =
+            partition_kv ? min((kv_tile_idx + 1) * max_chunk_size + kv_start_idx, kv_len) : kv_len;
+        const uint32_t chunk_size = chunk_end - chunk_start;
+
+        DTypeQKAccum      s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
+        alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
+        DTypeQKAccum      m[NUM_MMA_Q][2];
+        float             d[NUM_MMA_Q][2];
+        float             rope_freq[NUM_MMA_D_QK / 2][4];
+
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+            const float rope_rcp_scale = params.rope_rcp_scale;
+            const float rope_rcp_theta = params.rope_rcp_theta;
+            init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+        }
+        init_states<KTraits>(variant, o_frag, m, d);
+
+        const uint32_t qo_packed_idx_base =
+            (qo_tile_idx * NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) * NUM_MMA_Q * 16;
+        smem_t<SWIZZLE_MODE_Q> qo_smem(smem_storage.q_smem);
+        const uint32_t         o_stride_n = num_qo_heads * HEAD_DIM_VO, o_stride_h = HEAD_DIM_VO;
+
+        DTypeQ* q_ptr_base = q + q_indptr[request_idx] * q_stride_n + kv_head_idx * group_size * q_stride_h;
+
+        DTypeO* o_ptr_base =
+            partition_kv ?
+                o + (o_indptr[request_idx] + kv_tile_idx) * o_stride_n + (kv_head_idx * group_size) * o_stride_h :
+                o + o_indptr[request_idx] * o_stride_n + (kv_head_idx * group_size) * o_stride_h;
+
+        uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<UPCAST_STRIDE_Q>(
+            get_warp_idx_q<KTraits>(tid.y) * NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        asm volatile("griddepcontrol.wait;");
+#endif
+
+        load_q_global_smem<KTraits>(
+            qo_packed_idx_base, qo_upper_bound, q_ptr_base, q_stride_n, q_stride_h, group_size, &qo_smem, tid);
+
+        cp_async::commit_group();
+
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+            cp_async::wait_group<0>();
+            block.sync();
+            IdType* q_rope_offset = nullptr;
+
+            if constexpr (has_maybe_q_rope_offset_v<Params>) {
+                q_rope_offset = params.maybe_q_rope_offset;
+            }
+            if (!q_rope_offset) {
+                q_smem_inplace_apply_rotary<KTraits>(
+                    qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq, tid);
+            } else {
+                q_smem_inplace_apply_rotary_with_pos<KTraits>(qo_packed_idx_base,
+                                                              q_rope_offset + q_indptr[request_idx],
+                                                              &qo_smem,
+                                                              group_size,
+                                                              &q_smem_offset_r,
+                                                              rope_freq,
+                                                              tid);
+            }
+            block.sync();
+        }
+
+        const uint32_t num_iterations = ceil_div(
+            (MASK_MODE == MaskMode::kCausal ?
+                 min(chunk_size,
+                     sub_if_greater_or_zero(kv_len - qo_len + ceil_div(((qo_tile_idx + 1) * CTA_TILE_Q), group_size),
+                                            chunk_start)) :
+                 chunk_size),
+            CTA_TILE_KV);
+
+        const uint32_t window_iteration =
+            ceil_div(sub_if_greater_or_zero(kv_len + ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size),
+                                            qo_len + window_left + chunk_start),
+                     CTA_TILE_KV);
+
+        const uint32_t mask_iteration =
+            (MASK_MODE == MaskMode::kCausal ?
+                 min(chunk_size,
+                     sub_if_greater_or_zero(kv_len + ceil_div((qo_tile_idx * CTA_TILE_Q), group_size) - qo_len,
+                                            chunk_start)) :
+                 chunk_size)
+            / CTA_TILE_KV;
+
+        smem_t<SWIZZLE_MODE_KV> k_smem(smem_storage.k_smem), v_smem(smem_storage.v_smem);
+
+        uint32_t k_smem_offset_r = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
+                     get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + 8 * (lane_idx / 16) + lane_idx % 8,
+                     (lane_idx % 16) / 8),
+                 v_smem_offset_r = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+                     get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + lane_idx % 16, lane_idx / 16),
+                 k_smem_offset_w = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
+                     warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL, lane_idx % KV_THR_LAYOUT_COL),
+                 v_smem_offset_w = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+                     warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL, lane_idx % KV_THR_LAYOUT_COL);
+
+        DTypeKV* k_ptr =
+            k
+            + (kv_indptr[request_idx] + chunk_start + warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL)
+                  * k_stride_n
+            + kv_head_idx * k_stride_h + (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>();
+        DTypeKV* v_ptr =
+            v
+            + (kv_indptr[request_idx] + chunk_start + warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL)
+                  * v_stride_n
+            + kv_head_idx * v_stride_h + (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>();
+
+        produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(
+            k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, 0, chunk_size, tid);
+        cp_async::commit_group();
+        produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+            v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, 0, chunk_size, tid);
+        cp_async::commit_group();
+
+#pragma unroll 1
+        for (uint32_t iter = 0; iter < num_iterations; ++iter) {
+            cp_async::wait_group<1>();
+            block.sync();
+
+            if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+                IdType* k_rope_offset = nullptr;
+                if constexpr (has_maybe_k_rope_offset_v<Params>) {
+                    k_rope_offset = params.maybe_k_rope_offset;
+                }
+                k_smem_inplace_apply_rotary<KTraits>((k_rope_offset == nullptr ? 0 : k_rope_offset[request_idx])
+                                                         + chunk_start + iter * CTA_TILE_KV,
+                                                     &k_smem,
+                                                     &k_smem_offset_r,
+                                                     rope_freq,
+                                                     tid);
+                block.sync();
+            }
+
+            // compute attention score
+            compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+            uint32_t kv_idx_base =
+                chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
+            apply_per_token_k_scale<KTraits>(
+                params, variant, /*batch_idx=*/request_idx, kv_idx_base, s_frag, lane_idx, kv_head_idx);
+            logits_transform<KTraits>(params,
+                                      variant,
+                                      /*batch_idx=*/request_idx,
+                                      qo_packed_idx_base,
+                                      kv_idx_base,
+                                      qo_len,
+                                      kv_len,
+                                      group_size,
+                                      s_frag,
+                                      tid,
+                                      kv_head_idx);
+
+            // apply mask
+            if (MASK_MODE == MaskMode::kCustom || (iter >= mask_iteration || iter < window_iteration)) {
+                logits_mask<KTraits>(params,
+                                     variant,
+                                     /*batch_idx=*/request_idx,
+                                     qo_packed_idx_base,
+                                     kv_idx_base,
+                                     qo_len,
+                                     kv_len,
+                                     chunk_end,
+                                     group_size,
+                                     s_frag,
+                                     tid,
+                                     kv_head_idx);
+            }
+
+            // compute m,d states in online softmax
+            update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
+
+            block.sync();
+            produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(
+                k_smem, &k_smem_offset_w, &k_ptr, k_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size, tid);
+            cp_async::commit_group();
+            cp_async::wait_group<1>();
+            block.sync();
+
+            // compute sfm*v
+            compute_sfm_v<KTraits>(params,
+                                   variant,
+                                   /*batch_idx=*/request_idx,
+                                   kv_idx_base,
+                                   kv_head_idx,
+                                   &v_smem,
+                                   &v_smem_offset_r,
+                                   s_frag,
+                                   o_frag,
+                                   d);
+
+            block.sync();
+            produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
+                v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size, tid);
+            cp_async::commit_group();
+        }
+        cp_async::wait_group<0>();
+        block.sync();
+
+        finalize_m<KTraits>(variant, m);
+
+        // threadblock synchronization
+        threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
+
+        const uint32_t num_kv_chunks = ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
+        // transform output
+        transform_output<KTraits, Params>(params,
+                                          variant,
+                                          o_frag,
+                                          m,
+                                          d,
+                                          /*batch_idx=*/request_idx,
+                                          kv_tile_idx,
+                                          qo_packed_idx_base,
+                                          warp_idx,
+                                          lane_idx,
+                                          kv_head_idx,
+                                          group_size);
+
+        // write back
+        write_o_reg_gmem<KTraits>(o_frag,
+                                  &qo_smem,
+                                  o_ptr_base,
+                                  qo_packed_idx_base,
+                                  qo_len,
+                                  /*o_stride_n=*/
+                                  partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
+                                  /*o_stride_h=*/o_stride_h,
+                                  group_size,
+                                  tid);
+
+        // write lse
+        if constexpr (AttentionVariant::use_softmax) {
+            if (lse != nullptr) {
+                if (get_warp_idx_kv<KTraits>(tid.z) == 0) {
+#pragma unroll
+                    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                        for (uint32_t j = 0; j < 2; ++j) {
+                            uint32_t q, r;
+                            group_size.divmod(qo_packed_idx_base + lane_idx / 4 + j * 8 + mma_q * 16, q, r);
+                            const uint32_t qo_head_idx = kv_head_idx * group_size + r;
+                            const uint32_t qo_idx      = q;
+                            if (qo_idx < qo_len) {
+                                if (partition_kv) {
+                                    lse[(o_indptr[request_idx] + qo_idx * num_kv_chunks + kv_tile_idx) * num_qo_heads
+                                        + qo_head_idx] = math::ptx_log2(d[mma_q][j]) + float(m[mma_q][j]);
+                                } else {
+                                    lse[(o_indptr[request_idx] + qo_idx) * num_qo_heads + qo_head_idx] =
+                                        math::ptx_log2(d[mma_q][j]) + float(m[mma_q][j]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        asm volatile("griddepcontrol.launch_dependents;");
+#endif
+#if (__CUDA_ARCH__ < 800)
+    }
+#endif
+}
+
+template<typename KTraits, typename Params>
+__device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(const Params                     params,
+                                                                   typename KTraits::SharedStorage& smem_storage,
+                                                                   const dim3                       tid = threadIdx,
+                                                                   const uint32_t                   bx  = blockIdx.x,
+                                                                   const uint32_t kv_head_idx           = blockIdx.z,
+                                                                   const uint32_t num_kv_heads          = gridDim.z) {
+    using DTypeQ = typename Params::DTypeQ;
+#if (__CUDA_ARCH__ < 800)
+    if constexpr (std::is_same_v<DTypeQ, nv_bfloat16>) {
+        FLASHINFER_RUNTIME_ASSERT("Prefill kernels do not support bf16 on sm75.");
+    } else {
+#endif
+        using DTypeKV                                            = typename Params::DTypeKV;
+        using DTypeO                                             = typename Params::DTypeO;
+        using IdType                                             = typename Params::IdType;
+        using DTypeQKAccum                                       = typename KTraits::DTypeQKAccum;
+        using AttentionVariant                                   = typename KTraits::AttentionVariant;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_Q         = KTraits::NUM_MMA_Q;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_KV        = KTraits::NUM_MMA_KV;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_D_QK      = KTraits::NUM_MMA_D_QK;
+        [[maybe_unused]] constexpr uint32_t    NUM_MMA_D_VO      = KTraits::NUM_MMA_D_VO;
+        [[maybe_unused]] constexpr uint32_t    HEAD_DIM_QK       = KTraits::HEAD_DIM_QK;
+        [[maybe_unused]] constexpr uint32_t    HEAD_DIM_VO       = KTraits::HEAD_DIM_VO;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_Q   = KTraits::UPCAST_STRIDE_Q;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_K   = KTraits::UPCAST_STRIDE_K;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_V   = KTraits::UPCAST_STRIDE_V;
+        [[maybe_unused]] constexpr uint32_t    UPCAST_STRIDE_O   = KTraits::UPCAST_STRIDE_O;
+        [[maybe_unused]] constexpr uint32_t    NUM_WARPS_Q       = KTraits::NUM_WARPS_Q;
+        [[maybe_unused]] constexpr uint32_t    NUM_WARPS_KV      = KTraits::NUM_WARPS_KV;
+        [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_Q    = KTraits::SWIZZLE_MODE_Q;
+        [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_KV   = KTraits::SWIZZLE_MODE_KV;
+        [[maybe_unused]] constexpr uint32_t    CTA_TILE_Q        = KTraits::CTA_TILE_Q;
+        [[maybe_unused]] constexpr uint32_t    CTA_TILE_KV       = KTraits::CTA_TILE_KV;
+        [[maybe_unused]] constexpr uint32_t    KV_THR_LAYOUT_ROW = KTraits::KV_THR_LAYOUT_ROW;
+        [[maybe_unused]] constexpr uint32_t    KV_THR_LAYOUT_COL = KTraits::KV_THR_LAYOUT_COL;
+        [[maybe_unused]] constexpr MaskMode    MASK_MODE         = KTraits::MASK_MODE;
+
+        IdType*                            request_indices  = params.request_indices;
+        IdType*                            qo_tile_indices  = params.qo_tile_indices;
+        IdType*                            kv_tile_indices  = params.kv_tile_indices;
+        DTypeQ*                            q                = params.q;
+        IdType*                            q_indptr         = params.q_indptr;
+        IdType*                            o_indptr         = params.o_indptr;
+        DTypeO*                            o                = params.o;
+        float*                             lse              = params.lse;
+        bool*                              block_valid_mask = params.block_valid_mask;
+        const paged_kv_t<DTypeKV, IdType>& paged_kv         = params.paged_kv;
+        const bool                         partition_kv     = params.partition_kv;
+        const uint_fastdiv&                group_size       = params.group_size;
+
+        uint32_t* maybe_prefix_len_ptr = nullptr;
+        if constexpr (has_maybe_prefix_len_ptr_v<Params>) {
+            maybe_prefix_len_ptr = params.maybe_prefix_len_ptr;
+        }
+        uint16_t* maybe_token_pos_in_items_ptr = nullptr;
+        if constexpr (has_maybe_token_pos_in_items_ptr_v<Params>) {
+            maybe_token_pos_in_items_ptr = params.maybe_token_pos_in_items_ptr;
+        }
+        uint32_t token_pos_in_items_len = 0;
+        if constexpr (has_token_pos_in_items_len_v<Params>) {
+            token_pos_in_items_len = params.token_pos_in_items_len;
+        }
+        uint16_t* maybe_max_item_len_ptr = nullptr;
+        if constexpr (has_maybe_max_item_len_ptr_v<Params>) {
+            maybe_max_item_len_ptr = params.maybe_max_item_len_ptr;
+        }
+
+        static_assert(sizeof(DTypeQ) == 2);
+        auto           block         = cg::this_thread_block();
+        const uint32_t kv_chunk_size = *(params.kv_chunk_size_ptr);
+
+        const uint32_t lane_idx = tid.x, warp_idx = get_warp_idx<KTraits>(tid.y, tid.z);
+        if (block_valid_mask && !block_valid_mask[bx]) {
+            return;
+        }
+        const uint32_t num_qo_heads = num_kv_heads * group_size;
+
+        const uint32_t request_idx = request_indices[bx], qo_tile_idx = qo_tile_indices[bx],
+                       kv_tile_idx = kv_tile_indices[bx];
+        auto             smem      = reinterpret_cast<uint8_t*>(&smem_storage);
+        AttentionVariant variant(params, /*batch_idx=*/request_idx, smem);
+        const uint32_t   qo_len = variant.qo_len, kv_len = variant.kv_len, window_left = variant.window_left;
+        const uint32_t   kv_len_safe    = kv_len > 0 ? kv_len : 1;
+        const uint32_t   qo_upper_bound = min(qo_len, ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size));
+
+        const uint32_t kv_start_idx =
+            sub_if_greater_or_zero(kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size, qo_len + window_left);
+        const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+        const uint32_t chunk_start =
+            partition_kv ? min(kv_tile_idx * max_chunk_size + kv_start_idx, kv_len) : kv_start_idx;
+        const uint32_t chunk_end =
+            partition_kv ? min((kv_tile_idx + 1) * max_chunk_size + kv_start_idx, kv_len) : kv_len;
+        const uint32_t    chunk_size = chunk_end - chunk_start;
+        DTypeQKAccum      s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
+        alignas(16) float o_frag[NUM_MMA_Q][NUM_MMA_D_VO][8];
+        DTypeQKAccum      m[NUM_MMA_Q][2];
+        float             d[NUM_MMA_Q][2];
+        float             rope_freq[NUM_MMA_D_QK / 2][4];
+
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+            const float rope_rcp_scale = params.rope_rcp_scale;
+            const float rope_rcp_theta = params.rope_rcp_theta;
+            init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+        }
+        init_states<KTraits>(variant, o_frag, m, d);
+
+        const uint32_t qo_packed_idx_base =
+            (qo_tile_idx * NUM_WARPS_Q + get_warp_idx_q<KTraits>(tid.y)) * NUM_MMA_Q * 16;
+        const uint32_t         q_stride_n = params.q_stride_n, q_stride_h = params.q_stride_h;
+        smem_t<SWIZZLE_MODE_Q> qo_smem(smem_storage.q_smem);
+        const uint32_t         o_stride_n = num_qo_heads * HEAD_DIM_VO, o_stride_h = HEAD_DIM_VO;
+
+        DTypeQ* q_ptr_base = q + q_indptr[request_idx] * q_stride_n + (kv_head_idx * group_size) * q_stride_h;
+        DTypeO* o_ptr_base =
+            partition_kv ?
+                o + (o_indptr[request_idx] + kv_tile_idx) * o_stride_n + (kv_head_idx * group_size) * o_stride_h :
+                o + o_indptr[request_idx] * o_stride_n + (kv_head_idx * group_size) * o_stride_h;
+        uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<UPCAST_STRIDE_Q>(
+            get_warp_idx_q<KTraits>(tid.y) * NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        asm volatile("griddepcontrol.wait;");
+#endif
+
+        load_q_global_smem<KTraits>(
+            qo_packed_idx_base, qo_upper_bound, q_ptr_base, q_stride_n, q_stride_h, group_size, &qo_smem, tid);
+
+        cp_async::commit_group();
+
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+            cp_async::wait_group<0>();
+            block.sync();
+            IdType* q_rope_offset = nullptr;
+            if constexpr (has_maybe_q_rope_offset_v<Params>) {
+                q_rope_offset = params.maybe_q_rope_offset;
+            }
+            if (q_rope_offset == nullptr) {
+                q_smem_inplace_apply_rotary<KTraits>(
+                    qo_packed_idx_base, qo_len, kv_len, group_size, &qo_smem, &q_smem_offset_r, rope_freq, tid);
+            } else {
+                q_smem_inplace_apply_rotary_with_pos<KTraits>(qo_packed_idx_base,
+                                                              q_rope_offset + q_indptr[request_idx],
+                                                              &qo_smem,
+                                                              group_size,
+                                                              &q_smem_offset_r,
+                                                              rope_freq,
+                                                              tid);
+            }
+            block.sync();
+        }
+
+        smem_t<SWIZZLE_MODE_KV> k_smem(smem_storage.k_smem), v_smem(smem_storage.v_smem);
+        size_t                  thr_local_kv_offset[NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q];
+
+        uint32_t k_smem_offset_r = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
+                     get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + 8 * (lane_idx / 16) + lane_idx % 8,
+                     (lane_idx % 16) / 8),
+                 v_smem_offset_r = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+                     get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + lane_idx % 16, lane_idx / 16),
+                 k_smem_offset_w = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
+                     warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL, lane_idx % KV_THR_LAYOUT_COL),
+                 v_smem_offset_w = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+                     warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL, lane_idx % KV_THR_LAYOUT_COL);
+        const IdType last_indptr = paged_kv.indptr[paged_kv.batch_size];
+
+        uint32_t packed_page_iter_base = paged_kv.indptr[request_idx] * paged_kv.page_size + chunk_start;
+#pragma unroll
+        for (uint32_t i = 0; i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
+            uint32_t page_iter, entry_idx;
+            paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * KV_THR_LAYOUT_ROW
+                                          + lane_idx / KV_THR_LAYOUT_COL
+                                          + KV_THR_LAYOUT_ROW * NUM_WARPS_Q * NUM_WARPS_KV * i,
+                                      page_iter,
+                                      entry_idx);
+            thr_local_kv_offset[i] =
+                paged_kv.protective_get_kv_offset(page_iter,
+                                                  kv_head_idx,
+                                                  entry_idx,
+                                                  (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>(),
+                                                  last_indptr);
+        }
+        page_produce_kv<false, KTraits>(
+            &smem_storage, &k_smem_offset_w, paged_kv.k_data, 0, thr_local_kv_offset, chunk_size, warp_idx, lane_idx);
+        cp_async::commit_group();
+        page_produce_kv<true, KTraits>(
+            &smem_storage, &v_smem_offset_w, paged_kv.v_data, 0, thr_local_kv_offset, chunk_size, warp_idx, lane_idx);
+        cp_async::commit_group();
+
+        uint32_t num_iterations_prefix;
+        uint32_t num_iterations_mask;
+        uint32_t num_iterations = 0;
+
+        if constexpr (MASK_MODE != MaskMode::kMultiItemScoring) {
+            num_iterations = ceil_div(
+                (MASK_MODE == MaskMode::kCausal ?
+                     min(chunk_size,
+                         sub_if_greater_or_zero(
+                             kv_len - qo_len + ceil_div(((qo_tile_idx + 1) * CTA_TILE_Q), group_size), chunk_start)) :
+                     chunk_size),
+                CTA_TILE_KV);
+        } else if constexpr (MASK_MODE == MaskMode::kMultiItemScoring) {
+            num_iterations_prefix = ceil_div(
+                min(min(chunk_size,
+                        sub_if_greater_or_zero(kv_len - qo_len + ceil_div(((qo_tile_idx + 1) * CTA_TILE_Q), group_size),
+                                               chunk_start)),
+                    sub_if_greater_or_zero(__ldg(maybe_prefix_len_ptr + request_idx), chunk_start)),
+                CTA_TILE_KV);
+            num_iterations_mask =
+                max(min(chunk_size,
+                        sub_if_greater_or_zero(
+                            sub_if_greater_or_zero(kv_len - qo_len + ceil_div((qo_tile_idx * CTA_TILE_Q), group_size),
+                                                   __ldg(maybe_max_item_len_ptr + request_idx)),
+                            chunk_start))
+                        / (CTA_TILE_KV),
+                    num_iterations_prefix);
+
+            num_iterations =
+                max(num_iterations_mask,
+                    ceil_div(
+                        min(chunk_size,
+                            sub_if_greater_or_zero(
+                                kv_len - qo_len + ceil_div(((qo_tile_idx + 1) * CTA_TILE_Q), group_size), chunk_start)),
+                        CTA_TILE_KV));
+        }
+
+        const uint32_t window_iteration =
+            ceil_div(sub_if_greater_or_zero(kv_len + ceil_div((qo_tile_idx + 1) * CTA_TILE_Q, group_size),
+                                            qo_len + window_left + chunk_start),
+                     CTA_TILE_KV);
+
+        const uint32_t mask_iteration =
+            (MASK_MODE == MaskMode::kCausal || MASK_MODE == MaskMode::kMultiItemScoring ?
+                 min(chunk_size,
+                     sub_if_greater_or_zero(kv_len + ceil_div((qo_tile_idx * CTA_TILE_Q), group_size) - qo_len,
+                                            chunk_start)) :
+                 chunk_size)
+            / CTA_TILE_KV;
+
+#pragma unroll 1
+        for (uint32_t iter = 0; iter < num_iterations;
+             iter          = (MASK_MODE == MaskMode::kMultiItemScoring) ?
+                                 ((iter + 1 == num_iterations_prefix) ? num_iterations_mask : (iter + 1)) :
+                                 (iter + 1)) {
+            const uint32_t prefetch_skip_step =
+                (MASK_MODE == MaskMode::kMultiItemScoring) ?
+                    ((iter + 1 == num_iterations_prefix) ? (num_iterations_mask - num_iterations_prefix) : 0) :
+                    0;
+            packed_page_iter_base += (1 + prefetch_skip_step) * CTA_TILE_KV;
+#pragma unroll
+            for (uint32_t i = 0; i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
+                uint32_t page_iter, entry_idx;
+                paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * KV_THR_LAYOUT_ROW
+                                              + lane_idx / KV_THR_LAYOUT_COL
+                                              + KV_THR_LAYOUT_ROW * NUM_WARPS_Q * NUM_WARPS_KV * i,
+                                          page_iter,
+                                          entry_idx);
+                thr_local_kv_offset[i] =
+                    paged_kv.protective_get_kv_offset(page_iter,
+                                                      kv_head_idx,
+                                                      entry_idx,
+                                                      (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>(),
+                                                      last_indptr);
+            }
+            cp_async::wait_group<1>();
+            block.sync();
+
+            if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+                k_smem_inplace_apply_rotary<KTraits>(
+                    (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[request_idx]) + chunk_start
+                        + iter * CTA_TILE_KV,
+                    &k_smem,
+                    &k_smem_offset_r,
+                    rope_freq,
+                    tid);
+                block.sync();
+            }
+
+            // compute attention score
+            compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+            uint32_t kv_idx_base =
+                chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
+            apply_per_token_k_scale<KTraits>(
+                params, variant, /*batch_idx=*/request_idx, kv_idx_base, s_frag, lane_idx, kv_head_idx);
+            logits_transform<KTraits>(params,
+                                      variant,
+                                      /*batch_idx=*/request_idx,
+                                      qo_packed_idx_base,
+                                      kv_idx_base,
+                                      qo_len,
+                                      kv_len,
+                                      group_size,
+                                      s_frag,
+                                      tid,
+                                      kv_head_idx);
+
+            // apply mask
+            if (MASK_MODE == MaskMode::kCustom) {
+                logits_mask<KTraits>(params,
+                                     variant,
+                                     /*batch_idx=*/request_idx,
+                                     qo_packed_idx_base,
+                                     kv_idx_base,
+                                     qo_len,
+                                     kv_len,
+                                     chunk_end,
+                                     group_size,
+                                     s_frag,
+                                     tid,
+                                     kv_head_idx);
+            } else {
+                if constexpr (MASK_MODE != MaskMode::kMultiItemScoring) {
+                    if (iter >= mask_iteration || iter < window_iteration) {
+                        logits_mask<KTraits>(params,
+                                             variant,
+                                             /*batch_idx=*/request_idx,
+                                             qo_packed_idx_base,
+                                             kv_idx_base,
+                                             qo_len,
+                                             kv_len,
+                                             chunk_end,
+                                             group_size,
+                                             s_frag,
+                                             tid,
+                                             kv_head_idx);
+                    }
+                } else if constexpr (MASK_MODE == MaskMode::kMultiItemScoring) {
+                    if (iter + 1 >= num_iterations_prefix) {
+                        logits_mask_multi_item_scoring<KTraits>(params,
+                                                                variant,
+                                                                /*batch_idx=*/request_idx,
+                                                                qo_packed_idx_base,
+                                                                kv_idx_base,
+                                                                qo_len,
+                                                                kv_len,
+                                                                window_left,
+                                                                chunk_end,
+                                                                group_size,
+                                                                s_frag,
+                                                                __ldg(maybe_prefix_len_ptr + request_idx),
+                                                                maybe_token_pos_in_items_ptr
+                                                                    + request_idx * token_pos_in_items_len,
+                                                                tid.x,
+                                                                kv_head_idx);
+                    } else {
+                        if (iter >= mask_iteration || iter < window_iteration) {
+                            logits_mask<KTraits>(params,
+                                                 variant,
+                                                 /*batch_idx=*/request_idx,
+                                                 qo_packed_idx_base,
+                                                 kv_idx_base,
+                                                 qo_len,
+                                                 kv_len,
+                                                 chunk_end,
+                                                 group_size,
+                                                 s_frag,
+                                                 tid,
+                                                 kv_head_idx);
+                        }
+                    }
+                }
+            }
+
+            // compute m,d states in online softmax
+            update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
+
+            block.sync();
+            page_produce_kv<false, KTraits>(&smem_storage,
+                                            &k_smem_offset_w,
+                                            paged_kv.k_data,
+                                            (iter + 1) * CTA_TILE_KV,
+                                            thr_local_kv_offset,
+                                            chunk_size,
+                                            warp_idx,
+                                            lane_idx);
+            cp_async::commit_group();
+            cp_async::wait_group<1>();
+            block.sync();
+
+            // compute sfm*v
+            compute_sfm_v<KTraits>(params,
+                                   variant,
+                                   /*batch_idx=*/request_idx,
+                                   kv_idx_base,
+                                   kv_head_idx,
+                                   &v_smem,
+                                   &v_smem_offset_r,
+                                   s_frag,
+                                   o_frag,
+                                   d);
+
+            block.sync();
+            page_produce_kv<true, KTraits>(&smem_storage,
+                                           &v_smem_offset_w,
+                                           paged_kv.v_data,
+                                           (iter + 1) * CTA_TILE_KV,
+                                           thr_local_kv_offset,
+                                           chunk_size,
+                                           warp_idx,
+                                           lane_idx);
+            cp_async::commit_group();
+        }
+        cp_async::wait_group<0>();
+        block.sync();
+
+        finalize_m<KTraits>(variant, m);
+
+        // threadblock synchronization
+        threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
+
+        const uint32_t num_kv_chunks = ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
+
+        // transform output
+        transform_output<KTraits, Params>(params,
+                                          variant,
+                                          o_frag,
+                                          m,
+                                          d,
+                                          /*batch_idx=*/request_idx,
+                                          kv_tile_idx,
+                                          qo_packed_idx_base,
+                                          warp_idx,
+                                          lane_idx,
+                                          kv_head_idx,
+                                          group_size);
+
+        // write_back
+        write_o_reg_gmem<KTraits>(o_frag,
+                                  &qo_smem,
+                                  o_ptr_base,
+                                  qo_packed_idx_base,
+                                  qo_len,
+                                  /*o_stride_n=*/
+                                  partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
+                                  /*o_stride_h=*/o_stride_h,
+                                  group_size,
+                                  tid);
+
+        // write lse
+        if constexpr (variant.use_softmax) {
+            if (lse != nullptr) {
+                if (get_warp_idx_kv<KTraits>(tid.z) == 0) {
+#pragma unroll
+                    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+                        for (uint32_t j = 0; j < 2; ++j) {
+                            uint32_t q, r;
+                            group_size.divmod(qo_packed_idx_base + lane_idx / 4 + j * 8 + mma_q * 16, q, r);
+                            const uint32_t qo_head_idx = kv_head_idx * group_size + r;
+                            const uint32_t qo_idx      = q;
+                            if (qo_idx < qo_upper_bound) {
+                                if (partition_kv) {
+                                    lse[(o_indptr[request_idx] + qo_idx * num_kv_chunks + kv_tile_idx) * num_qo_heads
+                                        + qo_head_idx] = math::ptx_log2(d[mma_q][j]) + float(m[mma_q][j]);
+                                } else {
+                                    lse[(o_indptr[request_idx] + qo_idx) * num_qo_heads + qo_head_idx] =
+                                        math::ptx_log2(d[mma_q][j]) + float(m[mma_q][j]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        asm volatile("griddepcontrol.launch_dependents;");
+#endif
+
+#if (__CUDA_ARCH__ < 800)
+    }
+#endif
+}
+
+template<typename KTraits, typename Params>
+__global__
+__launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithPagedKVCacheKernel(const __grid_constant__ Params params) {
+    extern __shared__ uint8_t smem[];
+    auto&                     smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+    BatchPrefillWithPagedKVCacheDevice<KTraits>(params, smem_storage);
+}
+
+template<uint32_t        CTA_TILE_Q,
+         uint32_t        HEAD_DIM_QK,
+         uint32_t        HEAD_DIM_VO,
+         PosEncodingMode POS_ENCODING_MODE,
+         bool            USE_FP16_QK_REDUCTION,
+         MaskMode        MASK_MODE,
+         typename AttentionVariant,
+         typename Params>
+cudaError_t BatchPrefillWithRaggedKVCacheDispatched(
+    Params params, typename Params::DTypeO* tmp_v, float* tmp_s, bool enable_pdl, cudaStream_t stream) {
+    using DTypeQ                         = typename Params::DTypeQ;
+    using DTypeKV                        = typename Params::DTypeKV;
+    using DTypeO                         = typename Params::DTypeO;
+    const uint32_t     padded_batch_size = params.padded_batch_size;
+    const uint32_t     num_qo_heads      = params.num_qo_heads;
+    const uint32_t     num_kv_heads      = params.num_kv_heads;
+    constexpr uint32_t NUM_MMA_Q         = get_num_mma_q(CTA_TILE_Q);
+    constexpr uint32_t NUM_WARPS_Q       = get_num_warps_q(CTA_TILE_Q);
+    constexpr uint32_t NUM_WARPS_KV      = get_num_warps_kv(CTA_TILE_Q);
+
+    if (padded_batch_size == 0) {
+        // No request, skip
+        // this won't happen in CUDAGraph mode because we fixed the padded_batch_size
+        return cudaSuccess;
+    }
+
+    dim3               nblks(padded_batch_size, 1, num_kv_heads);
+    dim3               nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
+    constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
+    constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
+    using DTypeQKAccum =
+        typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ, half>, half, float>::type;
+
+    int dev_id = 0;
+    FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+    int max_smem_per_sm = 0;
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
+    // we expect each sm execute two threadblocks
+    const int num_ctas_per_sm =
+        max_smem_per_sm >= 2
+                               * (CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)
+                                  + (HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV)) ?
+            2 :
+            1;
+    const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
+
+    const uint32_t max_num_mma_kv_reg =
+        (HEAD_DIM_VO >= 128 && NUM_MMA_Q == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama
+         && !USE_FP16_QK_REDUCTION) ?
+            2 :
+            (8 / NUM_MMA_Q);
+    const uint32_t max_num_mma_kv_smem = (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ))
+                                         / ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV));
+
+    DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
+        using KTraits = KernelTraits<MASK_MODE,
+                                     CTA_TILE_Q,
+                                     NUM_MMA_Q,
+                                     NUM_MMA_KV,
+                                     NUM_MMA_D_QK,
+                                     NUM_MMA_D_VO,
+                                     NUM_WARPS_Q,
+                                     NUM_WARPS_KV,
+                                     POS_ENCODING_MODE,
+                                     DTypeQ,
+                                     DTypeKV,
+                                     DTypeO,
+                                     DTypeQKAccum,
+                                     typename Params::IdType,
+                                     AttentionVariant>;
+        if constexpr (KTraits::IsInvalid()) {
+            // Invalid configuration, skip
+            std::ostringstream err_msg;
+            err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
+                    << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
+                    << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
+                    << " NUM_WARPS_KV=" << NUM_WARPS_KV
+                    << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
+                       " and report the issue to the developers.";
+            FLASHINFER_ERROR(err_msg.str());
+        } else {
+            size_t smem_size = sizeof(typename KTraits::SharedStorage);
+            auto   kernel    = BatchPrefillWithRaggedKVCacheKernel<KTraits, Params>;
+            FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            // PDL launch config
+            cudaLaunchAttribute attribute[1];
+            cudaLaunchConfig_t  config;
+            if (enable_pdl) {
+                attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+                attribute[0].val.programmaticStreamSerializationAllowed = 1;
+                config.attrs                                            = attribute;
+                config.numAttrs                                         = 1;
+                config.gridDim                                          = nblks;
+                config.blockDim                                         = nthrs;
+                config.dynamicSmemBytes                                 = smem_size;
+                config.stream                                           = stream;
+            }
+
+            if (tmp_v == nullptr) {
+                // do not partition kv
+                params.partition_kv = false;
+                void* args[]        = {(void*)&params};
+                if (enable_pdl) {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+                } else {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+                }
+            } else {
+                // partition kv
+                params.partition_kv = true;
+                auto o              = params.o;
+                auto lse            = params.lse;
+                params.o            = tmp_v;
+                params.lse          = tmp_s;
+                void* args[]        = {(void*)&params};
+                if (enable_pdl) {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+                } else {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+                }
+                if constexpr (AttentionVariant::use_softmax) {
+                    FLASHINFER_CUDA_CALL(VariableLengthMergeStates(tmp_v,
+                                                                   tmp_s,
+                                                                   params.merge_indptr,
+                                                                   o,
+                                                                   lse,
+                                                                   params.max_total_num_rows,
+                                                                   params.total_num_rows,
+                                                                   num_qo_heads,
+                                                                   HEAD_DIM_VO,
+                                                                   enable_pdl,
+                                                                   stream));
+                } else {
+                    FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(tmp_v,
+                                                                    params.merge_indptr,
+                                                                    o,
+                                                                    params.max_total_num_rows,
+                                                                    params.total_num_rows,
+                                                                    num_qo_heads,
+                                                                    HEAD_DIM_VO,
+                                                                    enable_pdl,
+                                                                    stream));
+                }
+            }
+        }
+    });
+    return cudaSuccess;
+}
+
+template<uint32_t        CTA_TILE_Q,
+         uint32_t        HEAD_DIM_QK,
+         uint32_t        HEAD_DIM_VO,
+         PosEncodingMode POS_ENCODING_MODE,
+         bool            USE_FP16_QK_REDUCTION,
+         MaskMode        MASK_MODE,
+         typename AttentionVariant,
+         typename Params>
+cudaError_t BatchPrefillWithPagedKVCacheDispatched(
+    Params params, typename Params::DTypeO* tmp_v, float* tmp_s, bool enable_pdl, cudaStream_t stream) {
+    using DTypeQ                         = typename Params::DTypeQ;
+    using DTypeKV                        = typename Params::DTypeKV;
+    using DTypeO                         = typename Params::DTypeO;
+    const uint32_t     padded_batch_size = params.padded_batch_size;
+    const uint32_t     num_qo_heads      = params.num_qo_heads;
+    const uint32_t     num_kv_heads      = params.paged_kv.num_heads;
+    constexpr uint32_t NUM_MMA_Q         = get_num_mma_q(CTA_TILE_Q);
+    constexpr uint32_t NUM_WARPS_Q       = get_num_warps_q(CTA_TILE_Q);
+    constexpr uint32_t NUM_WARPS_KV      = get_num_warps_kv(CTA_TILE_Q);
+
+    if (padded_batch_size == 0) {
+        // No request, skip
+        // this won't happen in CUDAGraph mode because we fixed the padded_batch_size
+        return cudaSuccess;
+    }
+
+    dim3 nblks(padded_batch_size, 1, num_kv_heads);
+    dim3 nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
+
+    constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
+    constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
+    using DTypeQKAccum =
+        typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ, half>, half, float>::type;
+
+    int dev_id = 0;
+    FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+    int max_smem_per_sm = 0;
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
+    // we expect each sm execute two threadblocks
+    const int num_ctas_per_sm =
+        max_smem_per_sm >= 2
+                               * (CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)
+                                  + (HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV)) ?
+            2 :
+            1;
+    const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
+
+    const uint32_t max_num_mma_kv_reg =
+        (HEAD_DIM_VO >= 128 && NUM_MMA_Q == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama
+         && !USE_FP16_QK_REDUCTION) ?
+            2 :
+            (8 / NUM_MMA_Q);
+    const uint32_t max_num_mma_kv_smem = (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ))
+                                         / ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV));
+
+    DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
+        using KTraits = KernelTraits<MASK_MODE,
+                                     CTA_TILE_Q,
+                                     NUM_MMA_Q,
+                                     NUM_MMA_KV,
+                                     NUM_MMA_D_QK,
+                                     NUM_MMA_D_VO,
+                                     NUM_WARPS_Q,
+                                     NUM_WARPS_KV,
+                                     POS_ENCODING_MODE,
+                                     DTypeQ,
+                                     DTypeKV,
+                                     DTypeO,
+                                     DTypeQKAccum,
+                                     typename Params::IdType,
+                                     AttentionVariant>;
+        if constexpr (KTraits::IsInvalid()) {
+            // Invalid configuration, skip
+            std::ostringstream err_msg;
+            err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
+                    << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
+                    << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
+                    << " NUM_WARPS_KV=" << NUM_WARPS_KV
+                    << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
+                       " and report the issue to the developers.";
+            FLASHINFER_ERROR(err_msg.str());
+        } else {
+            size_t smem_size = sizeof(typename KTraits::SharedStorage);
+            auto   kernel    = BatchPrefillWithPagedKVCacheKernel<KTraits, Params>;
+            FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            // PDL launch config
+            cudaLaunchAttribute attribute[1];
+            cudaLaunchConfig_t  config;
+            if (enable_pdl) {
+                attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+                attribute[0].val.programmaticStreamSerializationAllowed = 1;
+                config.attrs                                            = attribute;
+                config.numAttrs                                         = 1;
+                config.gridDim                                          = nblks;
+                config.blockDim                                         = nthrs;
+                config.dynamicSmemBytes                                 = smem_size;
+                config.stream                                           = stream;
+            }
+
+            if (tmp_v == nullptr) {
+                // do not partition kv
+                params.partition_kv = false;
+                if (enable_pdl) {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+                } else {
+                    void* args[] = {(void*)&params};
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+                }
+            } else {
+                params.partition_kv = true;
+                auto o              = params.o;
+                auto lse            = params.lse;
+                params.o            = tmp_v;
+                params.lse          = tmp_s;
+                if (enable_pdl) {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+                } else {
+                    void* args[] = {(void*)&params};
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+                }
+                if constexpr (AttentionVariant::use_softmax) {
+                    FLASHINFER_CUDA_CALL(VariableLengthMergeStates(tmp_v,
+                                                                   tmp_s,
+                                                                   params.merge_indptr,
+                                                                   o,
+                                                                   lse,
+                                                                   params.max_total_num_rows,
+                                                                   params.total_num_rows,
+                                                                   num_qo_heads,
+                                                                   HEAD_DIM_VO,
+                                                                   enable_pdl,
+                                                                   stream));
+                } else {
+                    FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(tmp_v,
+                                                                    params.merge_indptr,
+                                                                    o,
+                                                                    params.max_total_num_rows,
+                                                                    params.total_num_rows,
+                                                                    num_qo_heads,
+                                                                    HEAD_DIM_VO,
+                                                                    enable_pdl,
+                                                                    stream));
+                }
+            }
+        }
+    });
+    return cudaSuccess;
+}
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_PREFILL_CUH_

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/flashinfer_direct_scale/include/flashinfer/attention/variant_helper.cuh
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/flashinfer_direct_scale/include/flashinfer/attention/variant_helper.cuh
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ATTENTION_VARIANT_HELPER_H
+#define FLASHINFER_ATTENTION_VARIANT_HELPER_H
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+#include <flashinfer/utils.cuh>
+
+namespace flashinfer {
+
+DEFINE_HAS_MEMBER(v_scale)
+
+#define REGISTER_QUERY_TRANSFORM(params, q, ...)                                                                       \
+    template<typename Params, typename T>                                                                              \
+    __device__ __forceinline__ T QueryTransform(const Params& params, void* q_smem) {                                  \
+        __VA_ARGS__                                                                                                    \
+    }
+
+#define REGISTER_KEY_TRANSFORM(params, k, ...)                                                                         \
+    template<typename Params, typename T>                                                                              \
+    __device__ __forceinline__ T KeyTransform(const Params& params, void* k_smem) {                                    \
+        __VA_ARGS__                                                                                                    \
+    }
+
+#define REGISTER_LOGITS_TRANSFORM(params, logits, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx, ...)            \
+    template<typename Params, typename T>                                                                              \
+    __device__ __forceinline__ T LogitsTransform(const Params& params,                                                 \
+                                                 T             logits,                                                 \
+                                                 uint32_t      batch_idx,                                              \
+                                                 uint32_t      qo_idx,                                                 \
+                                                 uint32_t      kv_idx,                                                 \
+                                                 uint32_t      qo_head_idx,                                            \
+                                                 uint32_t      kv_head_idx) {                                               \
+        __VA_ARGS__                                                                                                    \
+    }
+
+#define REGISTER_LOGITS_MASK(params, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx, ...)                         \
+    template<typename Params>                                                                                          \
+    __device__ __forceinline__ bool LogitsMask(const Params& params,                                                   \
+                                               uint32_t      batch_idx,                                                \
+                                               uint32_t      qo_idx,                                                   \
+                                               uint32_t      kv_idx,                                                   \
+                                               uint32_t      qo_head_idx,                                              \
+                                               uint32_t      kv_head_idx) {                                                 \
+        __VA_ARGS__                                                                                                    \
+    }
+
+#define REGISTER_M_D_UPDATE(params, kv_tile_idx, qo_head_idx, m, d, scale, ...)                                        \
+    template<typename Params, typename T_M>                                                                            \
+    __device__ __forceinline__ void update_m_d(                                                                        \
+        const Params& params, uint32_t kv_tile_idx, uint32_t qo_head_idx, T_M& m, float& d, float& scale) {            \
+        __VA_ARGS__                                                                                                    \
+    }
+
+#define REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, ...)                    \
+    template<typename Params, typename T, typename T_M>                                                                \
+    __device__ __forceinline__ T OutputTransform(const Params& params,                                                 \
+                                                 T             output,                                                 \
+                                                 uint32_t      batch_idx,                                              \
+                                                 uint32_t      qo_idx,                                                 \
+                                                 uint32_t      qo_head_idx,                                            \
+                                                 T_M&          m,                                                      \
+                                                 float&        d,                                                      \
+                                                 float         scale) {                                                        \
+        __VA_ARGS__                                                                                                    \
+    }
+
+struct AttentionVariantBase {
+    constexpr static bool use_softmax            = true;
+    static constexpr bool use_per_token_kv_scale = false;
+    REGISTER_LOGITS_TRANSFORM(params, logits, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx, { return logits; })
+
+    REGISTER_LOGITS_MASK(params, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx, { return true; })
+
+    REGISTER_M_D_UPDATE(params, kv_tile_idx, qo_head_idx, m, d, scale, { return; })
+
+    REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, {
+        float d_rcp       = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
+        float v_scale_val = get_v_scale(params);
+        return output * d_rcp * v_scale_val;
+    })
+
+    // Per-token KV scale hook. Custom variants can enable it and override this method.
+    // kv_selector is 0 for K and 1 for V.
+    template<typename Params>
+    __device__ __forceinline__ float
+    KVScale(const Params& params, uint32_t batch_idx, uint32_t kv_idx, uint32_t kv_head_idx, uint32_t kv_selector) {
+        return 1.f;
+    }
+
+    // Helper to get v_scale from params, returns 1.0f if not present
+    template<typename Params>
+    __device__ __forceinline__ static float get_v_scale(const Params& params) {
+        if constexpr (has_v_scale_v<Params>) {
+            return params.v_scale;
+        } else {
+            return 1.0f;
+        }
+    }
+};
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ATTENTION_VARIANT_HELPER_H

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/kv_cache_write_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/kv_cache_write_op.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Tuple
 import flashinfer.page as page
 import torch
 
-from rtp_llm.ops.compute_ops import LayerKVCache
+from rtp_llm.ops.compute_ops import LayerKVCache, rtp_llm_ops
 
 
 class KVCacheWriteOp:
@@ -15,19 +15,38 @@ class KVCacheWriteOp:
         self,
         num_kv_heads: int,
         head_size: int,
-        token_per_block: int,
+        physical_page_size: Optional[int] = None,
+        kernel_page_size: Optional[int] = None,
+        dynamic_mode: bool = False,
+        token_per_block: Optional[int] = None,
     ) -> None:
-        """
-        Initialize KV Cache Write operator.
+        """Initialize the KV cache writer for physical/kernel page geometry.
 
-        Args:
-            num_kv_heads: Number of key-value heads
-            head_size: Dimension of each attention head
-            token_per_block: Number of tokens per KV cache block (page size)
+        ``token_per_block`` remains as a compatibility alias for callers that
+        predate separate physical and kernel page sizes.
         """
+        if physical_page_size is None:
+            physical_page_size = token_per_block
+        elif token_per_block is not None and token_per_block != physical_page_size:
+            raise ValueError("token_per_block must match physical_page_size")
+        if physical_page_size is None or physical_page_size <= 0:
+            raise ValueError("physical_page_size must be positive")
+        if kernel_page_size is None:
+            kernel_page_size = physical_page_size
+        if kernel_page_size <= 0 or physical_page_size % kernel_page_size != 0:
+            raise ValueError(
+                "physical_page_size must be divisible by kernel_page_size, got "
+                f"{physical_page_size} and {kernel_page_size}"
+            )
+
         self.num_kv_heads = num_kv_heads
         self.head_size = head_size
-        self.token_per_block = token_per_block
+        self.physical_page_size = physical_page_size
+        self.kernel_page_size = kernel_page_size
+        self.subdivision = physical_page_size // kernel_page_size
+        self.dynamic_mode = dynamic_mode
+        # Keep the old attribute for warmup and compatibility users.
+        self.token_per_block = kernel_page_size
         self.params = None
 
     def set_params(self, params: Any):
@@ -49,14 +68,50 @@ class KVCacheWriteOp:
             kv_cache: KV cache [num_pages, 2, num_kv_heads, page_size, head_dim] (HND layout)
         """
         if kv_cache is not None:
-            # For real execution - use provided KV cache
-            # KV cache has shape [num_pages, 2, num_kv_heads, page_size, head_dim] (HND layout)
-            k_cache = kv_cache.kv_cache_base[
-                :, 0, :, :, :
-            ]  # [num_pages, num_kv_heads, page_size, head_dim]
-            v_cache = kv_cache.kv_cache_base[
-                :, 1, :, :, :
-            ]  # [num_pages, num_kv_heads, page_size, head_dim]
+            # FlashInfer requires batch_indices/positions size == nnz. Device
+            # planner buffers can be oversized, so narrow without a host sync.
+            nnz = key.size(0)
+            batch_indices = self.params.batch_indice_d.narrow(0, 0, nnz)
+            positions = self.params.positions_d.narrow(0, 0, nnz)
+
+            if self.dynamic_mode:
+                kv_scales = getattr(kv_cache, "kv_scale_base", None)
+                if kv_scales is None or kv_scales.numel() == 0:
+                    raise ValueError(
+                        "FP8 KV cache mode 2 requires a non-empty kv_scale_base"
+                    )
+
+                page_slots = self.params.decode_page_indptr_d[batch_indices.long()]
+                page_slots = page_slots + torch.div(
+                    positions, self.kernel_page_size, rounding_mode="floor"
+                )
+                target_kernel_pages = self.params.page_indice_d[page_slots.long()]
+                target_physical_pages = torch.div(
+                    target_kernel_pages,
+                    self.subdivision,
+                    rounding_mode="floor",
+                ).contiguous()
+                physical_token_offsets = (
+                    torch.remainder(target_kernel_pages, self.subdivision)
+                    * self.kernel_page_size
+                    + torch.remainder(positions, self.kernel_page_size)
+                ).contiguous()
+                rtp_llm_ops.quantize_and_write_fp8_kv_cache(
+                    key.contiguous(),
+                    value.contiguous(),
+                    kv_cache.kv_cache_base,
+                    kv_scales,
+                    target_physical_pages,
+                    physical_token_offsets,
+                    self.physical_page_size,
+                    self.kernel_page_size,
+                    self.subdivision,
+                )
+                return
+
+            # For legacy/base execution, cache dtype must already match K/V.
+            k_cache = kv_cache.kv_cache_base[:, 0, :, :, :]
+            v_cache = kv_cache.kv_cache_base[:, 1, :, :, :]
             if key.dtype != k_cache.dtype:
                 raise ValueError(
                     f"key dtype {key.dtype} must match K cache dtype {k_cache.dtype}"
@@ -66,26 +121,21 @@ class KVCacheWriteOp:
                     f"value dtype {value.dtype} must match V cache dtype {v_cache.dtype}"
                 )
 
-            # FlashInfer requires batch_indices/positions size == nnz.
-            # Device planner leaves buffers oversized, so narrow without a host sync.
-            nnz = key.size(0)
-            batch_indices = self.params.batch_indice_d.narrow(0, 0, nnz)
-            positions = self.params.positions_d.narrow(0, 0, nnz)
-
-            # Append K and V to paged cache using HND layout
+            # Append K and V to paged cache using HND layout.
             page.append_paged_kv_cache(  # type: ignore
-                key,  # append_key: [total_tokens, num_kv_heads, head_dim]
-                value,  # append_value: [total_tokens, num_kv_heads, head_dim]
+                key,
+                value,
                 batch_indices,
                 positions,
-                (k_cache, v_cache),  # paged_kv_cache: tuple of K and V caches
+                (k_cache, v_cache),
                 self.params.page_indice_d,
                 self.params.decode_page_indptr_d,
                 self.params.paged_kv_last_page_len_d,
-                "HND",  # kv_layout: HND layout (num_pages, num_kv_heads, page_size, head_dim)
+                "HND",
             )
-        else:
-            # For warmup/JIT compilation - create dummy KV cache
+        elif not self.dynamic_mode:
+            # For legacy/base warmup/JIT compilation - create dummy KV cache.
+            # Dynamic mode intentionally performs no write without a real cache.
             (
                 batch_indices,
                 positions,

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from typing import Any, Optional
 
 import torch
+from flashinfer import decode as flashinfer_decode
 from flashinfer.cascade import merge_state_in_place
 from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper
 from flashinfer.prefill import (
@@ -20,7 +22,15 @@ from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.flashinfer_mla im
 )
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.models_py.utils.arch import is_sm10x, is_sm90
-from rtp_llm.ops import AttentionConfigs, KvCacheDataType, ParallelismConfig, RopeStyle
+from rtp_llm.ops import (
+    AttentionConfigs,
+    KvCacheDataType,
+    ParallelismConfig,
+    RopeConfig,
+    RopeStyle,
+    check_rope_cache,
+    get_rope_cache_once,
+)
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCacheDecodeOp,
     LayerKVCache,
@@ -29,6 +39,7 @@ from rtp_llm.ops.compute_ops import (
     fill_mla_params,
     rtp_llm_ops,
 )
+from rtp_llm.ops.fused_rope_kvcache_op import FusedRopeKVCachePrefillOpQKVOut
 
 # Constants
 DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB = 128
@@ -71,29 +82,34 @@ def quantize_to_fp8_if_needed(
 
 
 # Global workspace buffer pool
-_g_py_flashinfer_workspace_pool: list[torch.Tensor] = []
+_g_py_flashinfer_workspace_pool: dict[torch.device, list[torch.Tensor]] = {}
 _g_py_flashinfer_pool_lock = __import__("threading").Lock()
+_g_flashinfer_jit_header_lock = __import__("threading").Lock()
+_g_dynamic_fp8_jit_modules: dict[str, tuple[Any, list[str]]] = {}
 
 
-def get_py_flashinfer_workspace_buffer(device: str = "cuda") -> torch.Tensor:
-    """Get a PyFlashInfer workspace buffer from the pool.
-
-    This function manages workspace buffers to support multiple concurrent instances.
-    """
+def get_py_flashinfer_workspace_buffer(
+    device: str | torch.device = "cuda",
+) -> torch.Tensor:
+    """Get a PyFlashInfer workspace buffer from the pool."""
+    resolved_device = torch.device(device)
+    if resolved_device.type == "cuda" and resolved_device.index is None:
+        resolved_device = torch.device("cuda", torch.cuda.current_device())
     with _g_py_flashinfer_pool_lock:
-        if _g_py_flashinfer_workspace_pool:
-            return _g_py_flashinfer_workspace_pool.pop()
+        device_pool = _g_py_flashinfer_workspace_pool.get(resolved_device)
+        if device_pool:
+            return device_pool.pop()
     return torch.zeros(
         DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB * 1024 * 1024,
         dtype=torch.uint8,
-        device=device,
+        device=resolved_device,
     )
 
 
 def release_py_flashinfer_workspace_buffer(buffer: torch.Tensor) -> None:
     """Release a PyFlashInfer workspace buffer back to the pool."""
     with _g_py_flashinfer_pool_lock:
-        _g_py_flashinfer_workspace_pool.append(buffer)
+        _g_py_flashinfer_workspace_pool.setdefault(buffer.device, []).append(buffer)
 
 
 def _host_i32(t):
@@ -107,19 +123,76 @@ def _host_i32(t):
 
 
 def _device_or(device_tensor, host_tensor):
-    """Prefer the *_device mirror; fall back to the base field.
-
-    Unit tests (and some callers) construct PyAttentionInputs with only the
-    base fields populated (possibly already CUDA-resident), so the device
-    mirror may be missing.
-    """
-    if device_tensor is not None and device_tensor.numel() >= 0:
+    """Prefer a populated *_device mirror; fall back to the base field."""
+    if device_tensor is not None and device_tensor.numel() > 0:
         return device_tensor
     return host_tensor
 
 
+def _is_dynamic_fp8(attn_configs: AttentionConfigs) -> bool:
+    return getattr(attn_configs, "fp8_kv_cache_mode", 0) == 2
+
+
+def _use_fused_mrope_prefill(
+    attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
+) -> bool:
+    rope_config = attn_configs.rope_config
+    mrope_dims = (
+        rope_config.mrope_dim1,
+        rope_config.mrope_dim2,
+        rope_config.mrope_dim3,
+    )
+    position_ids = getattr(attn_inputs, "combo_position_ids", None)
+    input_lengths = getattr(attn_inputs, "input_lengths", None)
+    valid_position_ids = (
+        isinstance(position_ids, torch.Tensor)
+        and position_ids.is_cuda
+        and position_ids.dtype == torch.int32
+        and position_ids.is_contiguous()
+        and isinstance(input_lengths, torch.Tensor)
+        and position_ids.numel() == 3 * int(input_lengths.sum().item())
+    )
+    return (
+        getattr(attn_inputs, "is_prefill", False)
+        and not getattr(attn_inputs, "is_cuda_graph", False)
+        and getattr(attn_configs, "fp8_kv_cache_mode", 0) == 1
+        and attn_configs.kv_cache_dtype == KvCacheDataType.FP8
+        and attn_configs.need_rope_kv_cache
+        and rope_config.style == RopeStyle.Mrope
+        and rope_config.mrope_interleaved
+        and rope_config.index_factor == 3
+        and all(dim > 0 for dim in mrope_dims)
+        and 2 * sum(mrope_dims) == rope_config.dim
+        and valid_position_ids
+    )
+
+
+def _supports_prefill_rope(
+    attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
+) -> bool:
+    if attn_configs.rope_config.style != RopeStyle.Mrope:
+        return True
+    return _use_fused_mrope_prefill(attn_configs, attn_inputs)
+
+
+def _active_page_indices(
+    page_indices: torch.Tensor, page_indptr: torch.Tensor
+) -> torch.Tensor:
+    if page_indptr is None or page_indptr.numel() == 0:
+        raise ValueError("paged attention requires a non-empty page indptr")
+    page_count = int(page_indptr[-1].item())
+    if page_count < 0 or page_count > page_indices.numel():
+        raise ValueError(
+            f"active page count {page_count} exceeds page index capacity "
+            f"{page_indices.numel()}"
+        )
+    return page_indices.narrow(0, 0, page_count)
+
+
 def attn_kv_dtype(attn_configs: AttentionConfigs) -> torch.dtype:
-    # Use one dtype source for both plan() and forward().
+    # Dynamic mode dequantizes into the model's base dtype before FlashInfer.
+    if _is_dynamic_fp8(attn_configs):
+        return attn_configs.dtype
     if attn_configs.kv_cache_dtype == KvCacheDataType.FP8:
         return torch.float8_e4m3fn
     return attn_configs.dtype
@@ -154,6 +227,9 @@ def supports_scalar_prefill_rope(
 
 
 def attn_q_dtype(attn_configs: AttentionConfigs) -> torch.dtype:
+    # Dynamic mode keeps Q in the base dtype to match the gathered cache.
+    if _is_dynamic_fp8(attn_configs):
+        return attn_configs.dtype
     # FA3 FP8 (Hopper wgmma) requires Q/KV in the same FP8 dtype and is
     # SM90-only with head_dim 64/128/256;
     # Otherwise keep Q in fp16/bf16 (FA2 KV-dequant path)
@@ -165,6 +241,283 @@ def attn_q_dtype(attn_configs: AttentionConfigs) -> torch.dtype:
     ):
         return torch.float8_e4m3fn
     return attn_configs.dtype
+
+
+def _page_geometry(attn_configs: AttentionConfigs) -> tuple[int, int, int]:
+    kernel_page_size = int(attn_configs.kernel_tokens_per_block)
+    if not _is_dynamic_fp8(attn_configs):
+        return kernel_page_size, kernel_page_size, 1
+    physical_page_size = int(attn_configs.tokens_per_block)
+    if (
+        physical_page_size <= 0
+        or kernel_page_size <= 0
+        or physical_page_size % kernel_page_size != 0
+    ):
+        raise ValueError(
+            "FP8 KV cache mode 2 requires tokens_per_block to be divisible by "
+            "kernel_tokens_per_block, got "
+            f"{physical_page_size} and {kernel_page_size}"
+        )
+    return (
+        physical_page_size,
+        kernel_page_size,
+        physical_page_size // kernel_page_size,
+    )
+
+
+_DYNAMIC_FP8_DIRECT_SCALE_JIT_VERSION = "v3"
+_DYNAMIC_FP8_DIRECT_SCALE_VARIANT_NAME = "RtpLlmDynamicFp8Attention<use_custom_mask>"
+_DYNAMIC_FP8_DIRECT_SCALE_VARIANT_DECL = r"""
+#include <flashinfer/attention/variants.cuh>
+
+template <typename Params>
+struct RtpLlmDynamicFp8DefaultParams {
+  const Params& source;
+  float sm_scale;
+  float logits_soft_cap;
+  int32_t window_left;
+  uint8_t* maybe_custom_mask;
+
+  __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {
+    return source.get_qo_len(batch_idx);
+  }
+
+  __device__ __forceinline__ uint32_t get_kv_len(uint32_t batch_idx) const {
+    return source.get_kv_len(batch_idx);
+  }
+};
+
+template <bool use_custom_mask>
+struct RtpLlmDynamicFp8Attention
+    : DefaultAttention<false, USE_SLIDING_WINDOW,
+                       USE_LOGITS_SOFT_CAP, false> {
+  using Base = DefaultAttention<false, USE_SLIDING_WINDOW,
+                                USE_LOGITS_SOFT_CAP, false>;
+
+  static constexpr bool use_per_token_kv_scale = true;
+
+  template <typename Params>
+  __device__ __forceinline__ RtpLlmDynamicFp8Attention(
+      const Params& params, uint32_t batch_idx, uint8_t* smem_ptr)
+      : Base(RtpLlmDynamicFp8DefaultParams<Params>{
+                 params, math::rsqrt(float(HEAD_DIM_QK)), 0.0f,
+                 params.window_left, nullptr},
+             batch_idx, smem_ptr) {}
+
+  template <typename Params>
+  __device__ __forceinline__ float KVScale(
+      const Params&, uint32_t, uint32_t, uint32_t, uint32_t) const {
+    return 1.0f;
+  }
+
+  __device__ __forceinline__ float KVScale(
+      const PagedParams& params, uint32_t batch_idx, uint32_t kv_idx,
+      uint32_t kv_head_idx, uint32_t kv_selector) const {
+    if (kv_idx >= this->kv_len) {
+      return 1.0f;
+    }
+
+    uint32_t page_offset, token_offset;
+    params.paged_kv.page_size.divmod(kv_idx, page_offset, token_offset);
+    const auto kernel_page_id =
+        params.paged_kv.indices[params.paged_kv.indptr[batch_idx] + page_offset];
+    const uint64_t scale_offset =
+        ((static_cast<uint64_t>(kernel_page_id) * 2 + kv_selector) *
+             params.paged_kv.num_heads +
+         kv_head_idx) *
+            params.paged_kv.page_size +
+        token_offset;
+    return params.kv_scale[scale_offset];
+  }
+};
+"""
+
+
+def _dtype_uri_component(dtype: torch.dtype) -> str:
+    return str(dtype).removeprefix("torch.").replace(".", "_")
+
+
+def _dynamic_fp8_decode_jit_args(
+    q_dtype: torch.dtype, output_dtype: torch.dtype, head_dim: int
+) -> tuple[Any, ...]:
+    kv_dtype = torch.float8_e4m3fn
+    index_dtype = torch.int32
+    uri = (
+        f"rtp_llm_dynamic_fp8_direct_scale_{_DYNAMIC_FP8_DIRECT_SCALE_JIT_VERSION}_"
+        f"q_{_dtype_uri_component(q_dtype)}_"
+        f"kv_{_dtype_uri_component(kv_dtype)}_"
+        f"o_{_dtype_uri_component(output_dtype)}_"
+        f"idx_{_dtype_uri_component(index_dtype)}_"
+        f"hdq_{head_dim}_hdv_{head_dim}"
+    )
+    return (
+        uri,
+        q_dtype,
+        kv_dtype,
+        output_dtype,
+        index_dtype,
+        head_dim,
+        head_dim,
+        ["kv_scale"],
+        ["float"],
+        [],
+        [],
+        _DYNAMIC_FP8_DIRECT_SCALE_VARIANT_NAME,
+        _DYNAMIC_FP8_DIRECT_SCALE_VARIANT_DECL,
+    )
+
+
+def _create_dynamic_fp8_decode_wrapper(
+    workspace: torch.Tensor,
+    q_dtype: torch.dtype,
+    output_dtype: torch.dtype,
+    head_dim: int,
+) -> BatchDecodeWithPagedKVCacheWrapper:
+    include_dir = (
+        Path(__file__).resolve().parent / "flashinfer_direct_scale" / "include"
+    )
+    patched_header = include_dir / "flashinfer" / "attention" / "prefill.cuh"
+    if not patched_header.is_file():
+        raise RuntimeError(f"missing FlashInfer direct-scale header: {patched_header}")
+
+    jit_args = _dynamic_fp8_decode_jit_args(q_dtype, output_dtype, head_dim)
+    uri = jit_args[0]
+    with _g_flashinfer_jit_header_lock:
+        cached_module = _g_dynamic_fp8_jit_modules.get(uri)
+        if cached_module is None:
+            original_generator = flashinfer_decode.gen_customize_batch_prefill_module
+
+            def generate_with_direct_scale_headers(*args, **kwargs):
+                spec = original_generator(*args, **kwargs)
+                spec.extra_include_dirs = [
+                    include_dir,
+                    *(spec.extra_include_dirs or []),
+                ]
+                return spec
+
+            flashinfer_decode.gen_customize_batch_prefill_module = (
+                generate_with_direct_scale_headers
+            )
+            try:
+                jit_module = flashinfer_decode.get_batch_prefill_jit_module(
+                    uri,
+                    flashinfer_decode.gen_customize_batch_prefill_module(
+                        "fa2", *jit_args
+                    ).build_and_load(),
+                )
+            finally:
+                flashinfer_decode.gen_customize_batch_prefill_module = (
+                    original_generator
+                )
+            cached_module = (jit_module, list(jit_args[7]))
+            _g_dynamic_fp8_jit_modules[uri] = cached_module
+
+    wrapper = BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        "HND",
+        backend="fa2",
+        use_tensor_cores=True,
+    )
+    # FlashInfer 0.6.9 has no constructor argument for a preloaded JIT module.
+    wrapper._jit_module = cached_module[0]
+    wrapper._jit_additional_tensor_names = list(cached_module[1])
+    return wrapper
+
+
+def _validate_dynamic_fp8_scale(
+    kv_cache: LayerKVCache, num_kv_heads: int, kernel_page_size: int
+) -> torch.Tensor:
+    kv_payload = kv_cache.kv_cache_base
+    kv_scale = getattr(kv_cache, "kv_scale_base", None)
+    if kv_payload is None or not isinstance(kv_payload, torch.Tensor):
+        raise ValueError("FP8 KV cache mode 2 requires a kv_cache_base tensor")
+    if not kv_payload.is_cuda:
+        raise ValueError("FP8 KV cache mode 2 requires kv_cache_base to be CUDA")
+    if kv_payload.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            "FP8 KV cache mode 2 requires kv_cache_base dtype torch.float8_e4m3fn"
+        )
+    if not kv_payload.is_contiguous():
+        raise ValueError("FP8 KV cache mode 2 requires contiguous kv_cache_base")
+    expected_payload_shape = (2, num_kv_heads, kernel_page_size)
+    if kv_payload.dim() != 5 or tuple(kv_payload.shape[1:4]) != expected_payload_shape:
+        raise ValueError(
+            "FP8 KV cache mode 2 requires kv_cache_base shape "
+            f"[num_kernel_pages, 2, {num_kv_heads}, {kernel_page_size}, head_dim], "
+            f"got {tuple(kv_payload.shape)}"
+        )
+    if kv_scale is None or not isinstance(kv_scale, torch.Tensor):
+        raise ValueError("FP8 KV cache mode 2 requires a kv_scale_base tensor")
+    if not kv_scale.is_cuda:
+        raise ValueError("FP8 KV cache mode 2 requires kv_scale_base to be CUDA")
+    if kv_scale.dtype != torch.float32:
+        raise ValueError(
+            "FP8 KV cache mode 2 requires kv_scale_base dtype torch.float32"
+        )
+    if not kv_scale.is_contiguous():
+        raise ValueError("FP8 KV cache mode 2 requires contiguous kv_scale_base")
+    if kv_scale.device != kv_payload.device:
+        raise ValueError(
+            "FP8 KV cache mode 2 requires kv_scale_base and kv_cache_base "
+            "on the same device"
+        )
+    expected_width = 2 * num_kv_heads * kernel_page_size
+    if (
+        kv_scale.dim() != 2
+        or kv_scale.shape[0] != kv_payload.shape[0]
+        or kv_scale.shape[1] != expected_width
+    ):
+        raise ValueError(
+            "FP8 KV cache mode 2 requires kv_scale_base shape "
+            f"[{kv_payload.shape[0]}, {expected_width}], got {tuple(kv_scale.shape)}"
+        )
+    return kv_scale
+
+
+def _compact_page_indices(source_page_indices: torch.Tensor) -> torch.Tensor:
+    """Create dense page ids on the same device used by FlashInfer plan()."""
+    return torch.arange(
+        source_page_indices.numel(),
+        dtype=source_page_indices.dtype,
+        device=source_page_indices.device,
+    )
+
+
+def _gather_dynamic_fp8_cache(
+    kv_cache: LayerKVCache,
+    source_page_indices: torch.Tensor,
+    output_dtype: torch.dtype,
+    num_kv_heads: int,
+    head_dim: int,
+    physical_page_size: int,
+    kernel_page_size: int,
+    subdivision: int,
+) -> torch.Tensor:
+    """Gather arbitrary persistent pages into a dense base-dtype cache."""
+    kv_scales = getattr(kv_cache, "kv_scale_base", None)
+    if kv_scales is None or kv_scales.numel() == 0:
+        raise ValueError("FP8 KV cache mode 2 requires a non-empty kv_scale_base")
+    output = torch.empty(
+        (
+            source_page_indices.numel(),
+            2,
+            num_kv_heads,
+            kernel_page_size,
+            head_dim,
+        ),
+        dtype=output_dtype,
+        device=kv_cache.kv_cache_base.device,
+    )
+    rtp_llm_ops.gather_and_dequantize_fp8_kv_cache(
+        kv_cache.kv_cache_base,
+        kv_scales,
+        source_page_indices,
+        output,
+        physical_page_size,
+        kernel_page_size,
+        subdivision,
+    )
+    return output
 
 
 class PyFlashinferPrefillPagedAttnOp(object):
@@ -181,7 +534,12 @@ class PyFlashinferPrefillPagedAttnOp(object):
         self.local_kv_head_num = attn_configs.kv_head_num
         self.head_dim_qk = attn_configs.size_per_head
         self.head_dim_vo = attn_configs.size_per_head
-        self.page_size = attn_configs.kernel_tokens_per_block
+        self.dynamic_fp8 = _is_dynamic_fp8(attn_configs)
+        (
+            self.physical_page_size,
+            self.page_size,
+            self.subdivision,
+        ) = _page_geometry(attn_configs)
         self.dtype = attn_configs.dtype
         self.kv_dtype = attn_kv_dtype(attn_configs)
         self.q_dtype = attn_q_dtype(attn_configs)
@@ -195,6 +553,7 @@ class PyFlashinferPrefillPagedAttnOp(object):
         # reserve buffer for q cast
         self._aligned_q_cast_buf = None
         self._compact_out_buf = None
+        self._active_source_page_indices = None
         # Use Paged KV Cache wrapper
         self.prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
             self.g_workspace_buffer,
@@ -307,10 +666,17 @@ class PyFlashinferPrefillPagedAttnOp(object):
             )
             qo_indptr = self.qo_indptr
 
+        plan_page_indices = self.fmha_params.page_indice_d
+        if self.dynamic_fp8:
+            self._active_source_page_indices = _active_page_indices(
+                plan_page_indices, self.fmha_params.decode_page_indptr_d
+            )
+            plan_page_indices = _compact_page_indices(self._active_source_page_indices)
+
         self.prefill_wrapper.plan(
             qo_indptr,
             self.fmha_params.decode_page_indptr_d,
-            self.fmha_params.page_indice_d,
+            plan_page_indices,
             self.fmha_params.paged_kv_last_page_len_d,
             self.local_head_num,
             self.local_kv_head_num,
@@ -351,11 +717,28 @@ class PyFlashinferPrefillPagedAttnOp(object):
             q.dim() == 3
         ), f"Expected q to be 3D tensor [total_tokens, num_heads, head_dim], got {q.dim()}D"
 
-        paged_kv_cache = kv_cache.kv_cache_base
-        if paged_kv_cache.dim() == 2:
-            paged_kv_cache = common.reshape_paged_kv_cache(
-                paged_kv_cache, self.local_kv_head_num, self.page_size, self.head_dim_qk
+        if self.dynamic_fp8:
+            if self._active_source_page_indices is None:
+                raise RuntimeError("paged prefill must be prepared before forward")
+            paged_kv_cache = _gather_dynamic_fp8_cache(
+                kv_cache,
+                self._active_source_page_indices,
+                self.dtype,
+                self.local_kv_head_num,
+                self.head_dim_qk,
+                self.physical_page_size,
+                self.page_size,
+                self.subdivision,
             )
+        else:
+            paged_kv_cache = kv_cache.kv_cache_base
+            if paged_kv_cache.dim() == 2:
+                paged_kv_cache = common.reshape_paged_kv_cache(
+                    paged_kv_cache,
+                    self.local_kv_head_num,
+                    self.page_size,
+                    self.head_dim_qk,
+                )
         # CUDA graph copy logic for prefill
         if self.prefill_cuda_graph_copy_params:
             assert (
@@ -448,11 +831,12 @@ class PyFlashinferPrefillPagedAttnOp(object):
             # Reshape back to 3D
             result = self._compact_out_buf.view(token_num, head_num, head_size)
         else:
-            # No CUDA graph copy, direct execution
-            # Paged FP8 defaults to unit scales and the output dtype from plan().
-            result = self.prefill_wrapper.run(
-                quantize_to_fp8_if_needed(q, self.q_dtype), paged_kv_cache
+            # Dynamic mode consumes base-dtype Q and a dequantized compact cache.
+            # Legacy FP8 keeps the existing unit-scale cast path.
+            q_input = (
+                q if self.dynamic_fp8 else quantize_to_fp8_if_needed(q, self.q_dtype)
             )
+            result = self.prefill_wrapper.run(q_input, paged_kv_cache)
 
         return result
 
@@ -476,6 +860,7 @@ class PyFlashinferPrefillAttnOp(object):
             self.g_workspace_buffer,
             backend=backend,
         )
+        self.dynamic_fp8 = _is_dynamic_fp8(attn_configs)
         self.dtype = attn_configs.dtype
         self.q_dtype = attn_q_dtype(attn_configs)
         self.kv_dtype = attn_kv_dtype(attn_configs)
@@ -545,9 +930,10 @@ class PyFlashinferPrefillAttnOp(object):
         v: torch.Tensor,
         kv_cache: Optional[LayerKVCache] = None,
     ) -> torch.Tensor:
-        q = quantize_to_fp8_if_needed(q, self.q_dtype)
-        k = quantize_to_fp8_if_needed(k, self.kv_dtype)
-        v = quantize_to_fp8_if_needed(v, self.kv_dtype)
+        if not self.dynamic_fp8:
+            q = quantize_to_fp8_if_needed(q, self.q_dtype)
+            k = quantize_to_fp8_if_needed(k, self.kv_dtype)
+            v = quantize_to_fp8_if_needed(v, self.kv_dtype)
         if q.dtype == torch.float8_e4m3fn:
             # FlashInfer's FA3 FP8 need scale_q, scale_k, scale_v and an output matching the planned dtype.
             out = torch.empty(
@@ -584,7 +970,12 @@ class PyFlashinferHybridPrefillAttnOp(object):
         self.local_kv_head_num = attn_configs.kv_head_num
         self.head_dim_qk = attn_configs.size_per_head
         self.head_dim_vo = attn_configs.size_per_head
-        self.page_size = attn_configs.kernel_tokens_per_block
+        self.dynamic_fp8 = _is_dynamic_fp8(attn_configs)
+        (
+            self.physical_page_size,
+            self.page_size,
+            self.subdivision,
+        ) = _page_geometry(attn_configs)
         self.dtype = attn_configs.dtype
         self.kv_dtype = attn_kv_dtype(attn_configs)
         self.q_dtype = attn_q_dtype(attn_configs)
@@ -662,10 +1053,14 @@ class PyFlashinferHybridPrefillAttnOp(object):
         prefix_paged_kv_indptr[-1] = self.fmha_params.reuse_cache_page_indice_h.numel()
         prefix_paged_kv_last_page_len = (prefix_lengths - 1) % self.page_size + 1
 
+        prefix_plan_page_indices = self.fmha_params.reuse_cache_page_indice_d
+        if self.dynamic_fp8:
+            prefix_plan_page_indices = _compact_page_indices(prefix_plan_page_indices)
+
         self.prefix_paged_wrapper.plan(
             qo_indptr,
             prefix_paged_kv_indptr,
-            self.fmha_params.reuse_cache_page_indice_d,
+            prefix_plan_page_indices,
             prefix_paged_kv_last_page_len,
             self.local_head_num,
             self.local_kv_head_num,
@@ -701,15 +1096,10 @@ class PyFlashinferHybridPrefillAttnOp(object):
         kv_cache_write_op: Optional[KVCacheWriteOp] = None,
     ) -> torch.Tensor:
         assert kv_cache is not None, "kv_cache is required for hybrid prefill"
-        paged_kv_cache = kv_cache.kv_cache_base
-        if paged_kv_cache.dim() == 2:
-            paged_kv_cache = common.reshape_paged_kv_cache(
-                paged_kv_cache, self.local_kv_head_num, self.page_size, self.head_dim_qk
-            )
-
-        q = quantize_to_fp8_if_needed(q, self.q_dtype)
-        k = quantize_to_fp8_if_needed(k, self.kv_dtype)
-        v = quantize_to_fp8_if_needed(v, self.kv_dtype)
+        if not self.dynamic_fp8:
+            q = quantize_to_fp8_if_needed(q, self.q_dtype)
+            k = quantize_to_fp8_if_needed(k, self.kv_dtype)
+            v = quantize_to_fp8_if_needed(v, self.kv_dtype)
         if q.dtype == torch.float8_e4m3fn:
             # Positional scale_q/scale_k/scale_v; see FP8_UNIT_SCALE.
             out = torch.empty(
@@ -731,7 +1121,27 @@ class PyFlashinferHybridPrefillAttnOp(object):
         if kv_cache_write_op is not None:
             kv_cache_write_op.forward(k, v, kv_cache)
 
-        # Paged FP8 defaults to unit scales and the output dtype from plan().
+        if self.dynamic_fp8:
+            paged_kv_cache = _gather_dynamic_fp8_cache(
+                kv_cache,
+                self.fmha_params.reuse_cache_page_indice_d,
+                self.dtype,
+                self.local_kv_head_num,
+                self.head_dim_qk,
+                self.physical_page_size,
+                self.page_size,
+                self.subdivision,
+            )
+        else:
+            paged_kv_cache = kv_cache.kv_cache_base
+            if paged_kv_cache.dim() == 2:
+                paged_kv_cache = common.reshape_paged_kv_cache(
+                    paged_kv_cache,
+                    self.local_kv_head_num,
+                    self.page_size,
+                    self.head_dim_qk,
+                )
+
         prefix_out, prefix_lse = self.prefix_paged_wrapper.run(
             q, paged_kv_cache, return_lse=True
         )
@@ -756,16 +1166,32 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
         """
         # Store configs and inputs
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
+        self.dynamic_fp8 = _is_dynamic_fp8(attn_configs)
         self.attn_configs = attn_configs
         self.attn_inputs = attn_inputs
 
         self.fmha_impl = self._create_fmha_impl(attn_configs, attn_inputs)
-        self.rope_impl = self._create_rope_impl(attn_configs)
-        # Create KV cache write op
+        use_fused_mrope = _use_fused_mrope_prefill(attn_configs, attn_inputs)
+        self.fused_mrope_impl = (
+            FusedRopeKVCachePrefillOpQKVOut(attn_configs) if use_fused_mrope else None
+        )
+        self.fused_mrope_params = (
+            self.fused_mrope_impl.prepare(attn_inputs)
+            if self.fused_mrope_impl is not None
+            else None
+        )
+        self.rope_impl = (
+            None
+            if self.fused_mrope_impl is not None
+            else self._create_rope_impl(attn_configs)
+        )
+        physical_page_size, kernel_page_size, _ = _page_geometry(attn_configs)
         self.kv_cache_write_op = KVCacheWriteOp(
             num_kv_heads=attn_configs.kv_head_num,
             head_size=attn_configs.size_per_head,
-            token_per_block=attn_configs.kernel_tokens_per_block,
+            physical_page_size=physical_page_size,
+            kernel_page_size=kernel_page_size,
+            dynamic_mode=self.dynamic_fp8,
         )
         self.create_params(attn_inputs)
         self.fmha_impl.prepare(attn_inputs)
@@ -831,6 +1257,18 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
 
         return query, key, value
 
+    def _apply_rope_and_split(
+        self, qkv: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.fused_mrope_impl is not None:
+            rotated_qkv = self.fused_mrope_impl.forward(
+                qkv, None, self.fused_mrope_params
+            )
+            return self._split_qkv(rotated_qkv)
+        if self.need_rope_kv_cache and self.rope_impl is not None:
+            return self.rope_impl.forward(qkv)
+        return self._split_qkv(qkv)
+
     def forward(
         self,
         qkv: torch.Tensor,
@@ -838,18 +1276,17 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
         layer_idx: int = 0,
     ) -> torch.Tensor:
         """Common forward implementation for all prefill implementations."""
-        if self.need_rope_kv_cache and self.rope_impl is not None:
-            query, key, value = self.rope_impl.forward(qkv)
-        else:
-            query, key, value = self._split_qkv(qkv)
+        query, key, value = self._apply_rope_and_split(qkv)
 
-        # Cast K/V once so the KV cache write and the attention op share
-        # the same tensors.
-        kv_dtype = attn_kv_dtype(self.attn_configs)
-        key = quantize_to_fp8_if_needed(key, kv_dtype)
-        value = quantize_to_fp8_if_needed(value, kv_dtype)
+        # Legacy FP8 shares one unit-scale cast between cache write and
+        # attention. Dynamic mode must preserve base-dtype post-RoPE K/V for
+        # per-row quantization and ragged attention.
+        if not self.dynamic_fp8:
+            kv_dtype = attn_kv_dtype(self.attn_configs)
+            key = quantize_to_fp8_if_needed(key, kv_dtype)
+            value = quantize_to_fp8_if_needed(value, kv_dtype)
 
-        if self.need_rope_kv_cache:
+        if self.need_rope_kv_cache or self.dynamic_fp8:
             self.kv_cache_write_op.forward(key, value, kv_cache)
 
         fmha_inputs = self._prepare_fmha_input(query, key, value)
@@ -907,11 +1344,14 @@ class PyFlashinferPagedPrefillImpl(PyFlashinferPrefillImplBase):
         return (
             not is_sm10x()
             and PyFlashinferPrefillPagedAttnOp.support(attn_inputs)
-            and supports_scalar_prefill_rope(attn_configs, attn_inputs)
+            and (
+                supports_scalar_prefill_rope(attn_configs, attn_inputs)
+                or _supports_prefill_rope(attn_configs, attn_inputs)
+            )
         )
 
     def support_cuda_graph(self) -> bool:
-        return True
+        return not self.dynamic_fp8
 
 
 class PyFlashinferHybridPrefillImpl(PyFlashinferPrefillImplBase):
@@ -941,20 +1381,20 @@ class PyFlashinferHybridPrefillImpl(PyFlashinferPrefillImplBase):
         layer_idx: int = 0,
     ) -> torch.Tensor:
         """Run ragged attention, append KV, then run paged prefix attention."""
-        # Single-stream flow: RoPE -> ragged attention -> KV write -> paged attention.
-        # Hybrid always needs the new K/V for its ragged half.
-        if self.need_rope_kv_cache and self.rope_impl is not None:
-            query, key, value = self.rope_impl.forward(qkv)
-        else:
-            query, key, value = self._split_qkv(qkv)
+        query, key, value = self._apply_rope_and_split(qkv)
 
-        query = quantize_to_fp8_if_needed(query, attn_q_dtype(self.attn_configs))
-        kv_dtype = attn_kv_dtype(self.attn_configs)
-        key = quantize_to_fp8_if_needed(key, kv_dtype)
-        value = quantize_to_fp8_if_needed(value, kv_dtype)
+        if not self.dynamic_fp8:
+            query = quantize_to_fp8_if_needed(query, attn_q_dtype(self.attn_configs))
+            kv_dtype = attn_kv_dtype(self.attn_configs)
+            key = quantize_to_fp8_if_needed(key, kv_dtype)
+            value = quantize_to_fp8_if_needed(value, kv_dtype)
 
         # Write new K/V after ragged attention and before paged attention.
-        kv_cache_write_op = self.kv_cache_write_op if self.need_rope_kv_cache else None
+        kv_cache_write_op = (
+            self.kv_cache_write_op
+            if self.need_rope_kv_cache or self.dynamic_fp8
+            else None
+        )
         result = self.fmha_impl.forward(
             query,
             key,
@@ -974,7 +1414,7 @@ class PyFlashinferHybridPrefillImpl(PyFlashinferPrefillImplBase):
             not attn_inputs.is_cuda_graph
             and not is_sm10x()
             and PyFlashinferHybridPrefillAttnOp.support(attn_inputs)
-            and attn_configs.rope_config.style != RopeStyle.Mrope
+            and _supports_prefill_rope(attn_configs, attn_inputs)
         )
 
     def support_cuda_graph(self) -> bool:
@@ -1021,10 +1461,9 @@ class PyFlashinferPrefillImpl(PyFlashinferPrefillImplBase):
         one. Without this fallback, sm_120 has no usable prefill impl for
         such cases.
         """
-        return (
-            PyFlashinferPrefillAttnOp.support(attn_inputs)
-            and attn_configs.rope_config.style != RopeStyle.Mrope
-        )
+        return PyFlashinferPrefillAttnOp.support(
+            attn_inputs
+        ) and _supports_prefill_rope(attn_configs, attn_inputs)
 
 
 def determine_use_tensor_core_from_configs(attn_configs: AttentionConfigs) -> bool:
@@ -1045,24 +1484,41 @@ class PyFlashinferDecodeAttnOp(object):
         self.local_kv_head_num = attn_configs.kv_head_num
         self.head_dim_qk = attn_configs.size_per_head
         self.head_dim_vo = attn_configs.size_per_head
-        self.seq_size_per_block = attn_configs.kernel_tokens_per_block
-        self.use_tensor_core = determine_use_tensor_core_from_configs(attn_configs)
-        self.decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
-            self.g_workspace_buffer,
-            "HND",
-            use_tensor_cores=self.use_tensor_core,
-        )
+        self.dynamic_fp8 = _is_dynamic_fp8(attn_configs)
+        (
+            self.physical_page_size,
+            self.seq_size_per_block,
+            self.subdivision,
+        ) = _page_geometry(attn_configs)
         self.dtype = attn_configs.dtype
-        self.kv_dtype = attn_kv_dtype(attn_configs)
-        # CUDA-core decode dequantizes FP8 KV; tensor-core decode uses the
-        # batch-prefill path and therefore shares attn_q_dtype().
-        self.q_dtype = (
-            attn_q_dtype(attn_configs) if self.use_tensor_core else self.dtype
-        )
+        if self.dynamic_fp8:
+            self.use_tensor_core = True
+            self.q_dtype = self.dtype
+            self.kv_dtype = torch.float8_e4m3fn
+            self.decode_wrapper = _create_dynamic_fp8_decode_wrapper(
+                self.g_workspace_buffer,
+                self.q_dtype,
+                self.dtype,
+                self.head_dim_qk,
+            )
+        else:
+            self.use_tensor_core = determine_use_tensor_core_from_configs(attn_configs)
+            self.decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
+                self.g_workspace_buffer,
+                "HND",
+                use_tensor_cores=self.use_tensor_core,
+            )
+            self.kv_dtype = attn_kv_dtype(attn_configs)
+            # CUDA-core decode dequantizes FP8 KV; tensor-core decode uses the
+            # batch-prefill path and therefore shares attn_q_dtype().
+            self.q_dtype = (
+                attn_q_dtype(attn_configs) if self.use_tensor_core else self.dtype
+            )
         self.enable_cuda_graph = attn_inputs.is_cuda_graph
         # Snapshot of the page indptr used by the last CUDA-core graph plan.
         # Dtype, head counts, and page size are fixed for this op's lifetime.
         self._cuda_core_plan_page_indptr_h: Optional[torch.Tensor] = None
+        self._dynamic_fp8_cuda_graph_state: Optional[tuple] = None
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
 
     def __del__(self):
@@ -1105,7 +1561,12 @@ class PyFlashinferDecodeAttnOp(object):
 
     def _plan_decode_wrapper(self, attn_inputs: PyAttentionInputs) -> None:
         use_cuda_core_graph_plan_cache = self._uses_cuda_core_graph_plan_cache()
-        if self.use_tensor_core:
+        if self.dynamic_fp8 and not self.enable_cuda_graph:
+            page_indptr = self.fmha_params.decode_page_indptr_h
+            page_indice = self.fmha_params.page_indice_d
+            last_page_len = self.fmha_params.paged_kv_last_page_len_h
+            plan_kwargs = {"non_blocking": True}
+        elif self.use_tensor_core:
             # Tensor-core decode plans from host mirrors in both eager and graph
             # modes; only replay decides whether another plan call is required.
             page_indptr = self.fmha_params.decode_page_indptr_h
@@ -1139,6 +1600,11 @@ class PyFlashinferDecodeAttnOp(object):
             last_page_len = self.fmha_params.paged_kv_last_page_len_d
             plan_kwargs = {}
 
+        if self.dynamic_fp8:
+            # The custom scale reader uses these IDs to address both the FP8
+            # payload and its scale row, so never remap them to dense IDs.
+            page_indice = _active_page_indices(page_indice, page_indptr)
+
         self.decode_wrapper.plan(
             page_indptr,
             page_indice,
@@ -1157,6 +1623,26 @@ class PyFlashinferDecodeAttnOp(object):
                 self.fmha_params.decode_page_indptr_h.clone()
             )
 
+    def _validate_dynamic_fp8_cuda_graph_state(self) -> None:
+        if not (self.dynamic_fp8 and self.enable_cuda_graph):
+            return
+        state = (
+            tuple(self.decode_wrapper._plan_info),
+            self.decode_wrapper._fixed_batch_size,
+            self.decode_wrapper._float_workspace_buffer.data_ptr(),
+            self.decode_wrapper._int_workspace_buffer.data_ptr(),
+            self.decode_wrapper._qo_indptr_buf.data_ptr(),
+            self.decode_wrapper._paged_kv_indptr_buf.data_ptr(),
+            self.decode_wrapper._paged_kv_indices_buf.data_ptr(),
+            self.decode_wrapper._paged_kv_last_page_len_buf.data_ptr(),
+        )
+        if self._dynamic_fp8_cuda_graph_state is None:
+            self._dynamic_fp8_cuda_graph_state = state
+        elif state != self._dynamic_fp8_cuda_graph_state:
+            raise RuntimeError(
+                "FP8 KV cache mode 2 CUDA graph plan or buffer addresses changed"
+            )
+
     def prepare(
         self,
         attn_inputs: PyAttentionInputs,
@@ -1171,7 +1657,28 @@ class PyFlashinferDecodeAttnOp(object):
         # CUDA-core topology cache. The device fill leaves those mirrors at
         # their stale capacity sizes (MIN_CACHE_BATCH_SIZE), which corrupts
         # the plan's batch size, so both graph backends use the host fill.
-        if (
+        if self.dynamic_fp8 and not self.enable_cuda_graph:
+            block_id_device = _device_or(
+                attn_inputs.kv_cache_kernel_block_id_device,
+                attn_inputs.kv_cache_kernel_block_id,
+            )
+            if block_id_device is not None and not block_id_device.is_cuda:
+                block_id_device = block_id_device.cuda()
+            sequence_lengths_plus_1_device = attn_inputs.sequence_lengths_plus_1_device
+            if (
+                sequence_lengths_plus_1_device is None
+                or not sequence_lengths_plus_1_device.is_cuda
+            ):
+                sequence_lengths_plus_1_device = (
+                    _host_i32(attn_inputs.sequence_lengths) + 1
+                ).to(block_id_device.device, non_blocking=True)
+            self.fmha_params.fill_decode_params_device(
+                _host_i32(attn_inputs.sequence_lengths),
+                sequence_lengths_plus_1_device,
+                block_id_device,
+                self.seq_size_per_block,
+            )
+        elif (
             attn_inputs.input_lengths.is_cuda
             and not self.use_tensor_core
             and not self.enable_cuda_graph
@@ -1223,6 +1730,7 @@ class PyFlashinferDecodeAttnOp(object):
                 )
 
         self._plan_decode_wrapper(attn_inputs)
+        self._validate_dynamic_fp8_cuda_graph_state()
         return self.fmha_params
 
     def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:
@@ -1243,11 +1751,16 @@ class PyFlashinferDecodeAttnOp(object):
             )
             if self._cuda_graph_replay_needs_replan():
                 self._plan_decode_wrapper(attn_inputs)
+            self._validate_dynamic_fp8_cuda_graph_state()
             return
 
         # Device-metadata compatibility path inherited from the base
         # implementation. CudaGraphRunner routes graph replay through the
         # pinned host mirrors above.
+        if self.dynamic_fp8:
+            raise RuntimeError(
+                "FP8 KV cache mode 2 CUDA graph replay requires host metadata mirrors"
+            )
         seq_plus_1 = attn_inputs.sequence_lengths_plus_1_device
         if seq_plus_1 is None or not seq_plus_1.is_cuda:
             seq_plus_1 = (attn_inputs.sequence_lengths.to(torch.int32) + 1).cuda()
@@ -1270,10 +1783,14 @@ class PyFlashinferDecodeAttnOp(object):
         self, q: torch.Tensor, kv_cache: Optional[LayerKVCache], params: ParamsBase
     ) -> torch.Tensor:
         assert kv_cache is not None, "kv_cache is required"
-        q = quantize_to_fp8_if_needed(
-            q.reshape(q.shape[0], self.local_head_num, self.head_dim_qk),
-            self.q_dtype,
-        )
+        q = q.reshape(q.shape[0], self.local_head_num, self.head_dim_qk)
+        if self.dynamic_fp8:
+            kv_scale = _validate_dynamic_fp8_scale(
+                kv_cache, self.local_kv_head_num, self.seq_size_per_block
+            )
+            return self.decode_wrapper.run(q, kv_cache.kv_cache_base, kv_scale)
+
+        q = quantize_to_fp8_if_needed(q, self.q_dtype)
         paged_kv_cache = kv_cache.kv_cache_base
         if paged_kv_cache is not None and paged_kv_cache.dim() == 2:
             paged_kv_cache = common.reshape_paged_kv_cache(
@@ -1282,7 +1799,6 @@ class PyFlashinferDecodeAttnOp(object):
                 self.seq_size_per_block,
                 self.head_dim_qk,
             )
-        # Decode FP8 defaults to unit scales and the output dtype from plan().
         return self.decode_wrapper.run(q, paged_kv_cache)
 
 
@@ -1293,24 +1809,44 @@ class PyFlashinferDecodeImpl(FMHAImplBase):
         attn_inputs: PyAttentionInputs,
         parallelism_config: Optional[ParallelismConfig] = None,
     ) -> None:
-        # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
+        self.dynamic_fp8 = _is_dynamic_fp8(attn_configs)
         self.fmha_impl = PyFlashinferDecodeAttnOp(attn_configs, attn_inputs)
-        self.rope_impl = FusedRopeKVCacheDecodeOp(attn_configs)
         self.attn_configs = attn_configs
-
-        # Store input info
         self.attn_inputs = attn_inputs
 
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         self.fmha_impl.set_params(self.fmha_params)
         self.fmha_impl.prepare(attn_inputs)
-        self.rope_params = self.rope_impl.prepare(attn_inputs)
+
+        if self.dynamic_fp8:
+            _, self.kernel_page_size, _ = _page_geometry(attn_configs)
+            self.dynamic_rope_config = attn_configs.rope_config
+            if not self.need_rope_kv_cache:
+                self.dynamic_rope_config = RopeConfig()
+                self.dynamic_rope_config.style = RopeStyle.No
+            self.dynamic_rope_cache = None
+            if self.dynamic_rope_config.style in (RopeStyle.Base, RopeStyle.Yarn):
+                rope_cache = get_rope_cache_once(
+                    self.dynamic_rope_config,
+                    attn_configs.max_seq_len,
+                    is_cuda=True,
+                    interleave=True,
+                )
+                if check_rope_cache(self.dynamic_rope_config, rope_cache):
+                    self.dynamic_rope_cache = rope_cache.data
+        else:
+            self.rope_impl = FusedRopeKVCacheDecodeOp(attn_configs)
+            self.rope_params = self.rope_impl.prepare(attn_inputs)
+            self.kv_cache_write_op = None
+
         self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
 
     def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs) -> None:
         """Prepare FlashInfer/RoPE buffers and metadata for CUDA graph replay."""
         self.fmha_impl.prepare_for_cuda_graph_replay(attn_inputs)
+        if self.dynamic_fp8:
+            return
         if self.need_rope_kv_cache:
             # Update rope params for correct position encoding during replay.
             new_rope_params = self.rope_impl.prepare(
@@ -1336,14 +1872,32 @@ class PyFlashinferDecodeImpl(FMHAImplBase):
         kv_cache: Optional[LayerKVCache],
         layer_idx: int = 0,
     ) -> torch.Tensor:
-        # Apply RoPE and KV Cache processing
-        if self.need_rope_kv_cache:
+        if self.dynamic_fp8:
+            if kv_cache is None:
+                raise ValueError("FP8 KV cache mode 2 requires kv_cache")
+            kv_scales = _validate_dynamic_fp8_scale(
+                kv_cache,
+                self.attn_configs.kv_head_num,
+                self.kernel_page_size,
+            )
+            qkv = rtp_llm_ops.fused_rope_quantize_and_write_fp8_kv_cache(
+                qkv,
+                kv_cache.kv_cache_base,
+                kv_scales,
+                self.fmha_params.batch_indice_d,
+                self.fmha_params.positions_d,
+                self.fmha_params.decode_page_indptr_d,
+                self.fmha_params.page_indice_d,
+                self.attn_configs.head_num,
+                self.attn_configs.kv_head_num,
+                self.kernel_page_size,
+                self.dynamic_rope_config,
+                self.dynamic_rope_cache,
+            )
+        elif self.need_rope_kv_cache:
             qkv = self.rope_impl.forward(qkv, kv_cache, self.rope_params)
 
-        # Apply write cache store if needed
         common.apply_write_cache_store(
             self.write_cache_store_impl, self.attn_inputs, kv_cache
         )
-
-        # Execute FMHA forward
         return self.fmha_impl.forward(qkv, kv_cache, self.fmha_params)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/base_attention_test.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/base_attention_test.py
@@ -5,7 +5,7 @@ from typing import List, NamedTuple, Optional, Sequence
 
 import torch
 
-from rtp_llm.ops import AttentionConfigs, KvCacheDataType, ParallelismConfig
+from rtp_llm.ops import AttentionConfigs, KvCacheDataType, ParallelismConfig, RopeStyle
 from rtp_llm.ops.compute_ops import LayerKVCache, PyAttentionInputs, get_typemeta
 from rtp_llm.test.utils.numeric_util import assert_close_with_mismatch_tolerance
 
@@ -203,6 +203,95 @@ class BaseAttentionTest(unittest.TestCase):
             seq_size_per_block=seq_size_per_block,
             tp_size=tp_size,
         )
+
+    @staticmethod
+    def _enable_qwen35_mrope_mode1(config: TestConfig) -> None:
+        attn_configs = config.attn_configs
+        attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        attn_configs.fp8_kv_cache_mode = 1
+        attn_configs.need_rope_kv_cache = True
+        attn_configs.max_seq_len = 2048
+        rope_config = attn_configs.rope_config
+        rope_config.style = RopeStyle.Mrope
+        rope_config.dim = 64
+        rope_config.base = 10000
+        rope_config.scale = 1.0
+        rope_config.max_pos = 2048
+        rope_config.index_factor = 3
+        rope_config.mrope_dim1 = 11
+        rope_config.mrope_dim2 = 11
+        rope_config.mrope_dim3 = 10
+        rope_config.mrope_interleaved = True
+
+    def _add_qwen35_mrope_inputs(
+        self,
+        attn_inputs: PyAttentionInputs,
+        input_lengths: Sequence[int],
+        prefix_lengths: Optional[Sequence[int]] = None,
+    ) -> torch.Tensor:
+        if prefix_lengths is None:
+            prefix_lengths = [0] * len(input_lengths)
+        cu_seqlens = [0]
+        padding_offsets = []
+        max_input_length = max(input_lengths)
+        position_chunks = []
+        for batch_idx, (prefix_length, input_length) in enumerate(
+            zip(prefix_lengths, input_lengths)
+        ):
+            cu_seqlens.append(cu_seqlens[-1] + input_length)
+            padding_offsets.extend(
+                [batch_idx * max_input_length - cu_seqlens[batch_idx]] * input_length
+            )
+            positions = torch.arange(
+                prefix_length,
+                prefix_length + input_length,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            position_chunks.append(
+                torch.stack((positions, positions, positions), dim=-1)
+            )
+
+        attn_inputs.cu_kv_seqlens_device = attn_inputs.cu_seqlens_device
+        attn_inputs.padding_offset = torch.tensor(
+            padding_offsets, dtype=torch.int32, device=self.device
+        )
+        attn_inputs.context_total_kv_length = 0
+        attn_inputs.combo_position_ids = torch.cat(position_chunks).contiguous()
+        return attn_inputs.combo_position_ids
+
+    @staticmethod
+    def _apply_qwen35_mrope_reference(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        rope_dim = 64
+        rotary_pairs = rope_dim // 2
+        mrope_sections = (11, 11, 10)
+        axes = torch.zeros(rotary_pairs, dtype=torch.long, device=q.device)
+        axes[1 : 3 * mrope_sections[1] : 3] = 1
+        axes[2 : 3 * mrope_sections[2] : 3] = 2
+        positions = position_ids[:, axes].to(torch.float32)
+        inv_freq = 10000 ** (
+            -2.0
+            * torch.arange(rotary_pairs, dtype=torch.float32, device=q.device)
+            / rope_dim
+        )
+        angle = positions * inv_freq.unsqueeze(0)
+        cos = torch.cos(angle).unsqueeze(1)
+        sin = torch.sin(angle).unsqueeze(1)
+
+        def rotate(tensor: torch.Tensor) -> torch.Tensor:
+            tensor_float = tensor.float()
+            low = tensor_float[..., :rotary_pairs]
+            high = tensor_float[..., rotary_pairs:rope_dim]
+            tail = tensor_float[..., rope_dim:]
+            return torch.cat(
+                [low * cos - high * sin, high * cos + low * sin, tail], dim=-1
+            ).to(tensor.dtype)
+
+        return rotate(q), rotate(k)
 
     def _assert_output_close(
         self,

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_mha_rotary_emb.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_mha_rotary_emb.py
@@ -4,6 +4,7 @@ import math
 import unittest
 from types import SimpleNamespace
 from typing import Tuple
+from unittest import mock
 
 import torch
 from flashinfer import get_batch_indices_positions, get_seq_lens
@@ -654,6 +655,89 @@ class TestMhaRotaryEmbeddingOp(unittest.TestCase):
             "\n✓ All implementations (Reference, Python, C++) produce consistent results"
         )
         print("=" * 80)
+
+
+class TestDynamicKVCacheWriteOp(unittest.TestCase):
+    def test_maps_kernel_pages_to_physical_pages_and_offsets(self):
+        writer = KVCacheWriteOp(
+            num_kv_heads=2,
+            head_size=4,
+            physical_page_size=32,
+            kernel_page_size=8,
+            dynamic_mode=True,
+        )
+        writer.set_params(
+            SimpleNamespace(
+                batch_indice_d=torch.tensor([0, 0, 1, 1], dtype=torch.int32),
+                positions_d=torch.tensor([0, 17, 8, 31], dtype=torch.int32),
+                decode_page_indptr_d=torch.tensor([0, 3, 7], dtype=torch.int32),
+                page_indice_d=torch.tensor(
+                    [10, 11, 12, 4, 7, 8, 15], dtype=torch.int32
+                ),
+            )
+        )
+        key = torch.randn(4, 2, 4, dtype=torch.bfloat16)
+        value = torch.randn_like(key)
+        cache = SimpleNamespace(
+            kv_cache_base=torch.empty(16, 2, 2, 8, 4, dtype=torch.float8_e4m3fn),
+            kv_scale_base=torch.empty(16, 2 * 2 * 8, dtype=torch.float32),
+        )
+
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op."
+            "rtp_llm_ops.quantize_and_write_fp8_kv_cache",
+            create=True,
+        ) as write_mock:
+            writer.forward(key, value, cache)
+
+        write_mock.assert_called_once()
+        args = write_mock.call_args.args
+        self.assertEqual(args[0].dtype, torch.bfloat16)
+        self.assertEqual(args[1].dtype, torch.bfloat16)
+        torch.testing.assert_close(
+            args[4], torch.tensor([2, 3, 1, 3], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            args[5], torch.tensor([16, 1, 24, 31], dtype=torch.int32)
+        )
+        self.assertEqual(args[6:], (32, 8, 4))
+
+    def test_dynamic_warmup_skips_write_and_real_cache_requires_scales(self):
+        writer = KVCacheWriteOp(
+            num_kv_heads=1,
+            head_size=4,
+            physical_page_size=16,
+            kernel_page_size=8,
+            dynamic_mode=True,
+        )
+        writer.set_params(
+            SimpleNamespace(
+                batch_indice_d=torch.tensor([0], dtype=torch.int32),
+                positions_d=torch.tensor([0], dtype=torch.int32),
+                decode_page_indptr_d=torch.tensor([0, 1], dtype=torch.int32),
+                page_indice_d=torch.tensor([0], dtype=torch.int32),
+            )
+        )
+        key = torch.randn(1, 1, 4, dtype=torch.float16)
+        value = torch.randn_like(key)
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op."
+            "rtp_llm_ops.quantize_and_write_fp8_kv_cache",
+            create=True,
+        ) as write_mock:
+            writer.forward(key, value, None)
+            write_mock.assert_not_called()
+            with self.assertRaisesRegex(ValueError, "kv_scale_base"):
+                writer.forward(
+                    key,
+                    value,
+                    SimpleNamespace(
+                        kv_cache_base=torch.empty(
+                            2, 2, 1, 8, 4, dtype=torch.float8_e4m3fn
+                        ),
+                        kv_scale_base=None,
+                    ),
+                )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_hybrid_mha_prefill.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_hybrid_mha_prefill.py
@@ -1,5 +1,6 @@
 import math
 import unittest
+from types import SimpleNamespace
 from typing import List
 from unittest import mock
 
@@ -7,7 +8,10 @@ import torch
 from flashinfer.cascade import merge_state
 from flashinfer.prefill import single_prefill_with_kv_cache
 
-from rtp_llm.models_py.modules.factory.attention import attn_factory
+from rtp_llm.models_py.modules.factory.attention import attn_factory, common
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op import (
+    KVCacheWriteOp,
+)
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     PyFlashinferHybridPrefillAttnOp,
     PyFlashinferHybridPrefillImpl,
@@ -17,7 +21,12 @@ from rtp_llm.models_py.modules.factory.attention.cuda_impl.test.base_attention_t
     fill_paged_kv_cache,
 )
 from rtp_llm.ops import AttentionConfigs, FMHAConfig, KvCacheDataType, RopeStyle
-from rtp_llm.ops.compute_ops import LayerKVCache, PyAttentionInputs, get_typemeta
+from rtp_llm.ops.compute_ops import (
+    LayerKVCache,
+    PyAttentionInputs,
+    get_typemeta,
+    rtp_llm_ops,
+)
 
 
 class TestPyFlashinferHybridPrefillAttnOp(BaseAttentionTest):
@@ -573,11 +582,624 @@ class TestHybridPrefillSupport(unittest.TestCase):
         self.assertFalse(PyFlashinferHybridPrefillImpl.support(self._config(), inputs))
 
 
+class _NoReleaseHybridAttnOp(PyFlashinferHybridPrefillAttnOp):
+    def __del__(self):
+        pass
+
+
+class TestDynamicFp8HybridUnit(unittest.TestCase):
+    def test_compact_prefix_plan_and_write_before_gather(self):
+        params = SimpleNamespace(
+            fill_params=mock.Mock(),
+            batch_reuse_info_vec_h=torch.tensor(
+                [[0, 1, 0, 1], [0, 9, 1, 2]], dtype=torch.int32
+            ),
+            reuse_cache_page_indice_h=torch.tensor([12, 4, 9], dtype=torch.int32),
+            reuse_cache_page_indice_d=torch.tensor([12, 4, 9], dtype=torch.int32),
+        )
+        events = []
+        ragged = SimpleNamespace(
+            plan=mock.Mock(),
+            run=mock.Mock(
+                side_effect=lambda *args, **kwargs: (
+                    events.append("ragged")
+                    or (torch.zeros_like(args[0]), torch.zeros(args[0].shape[:2]))
+                )
+            ),
+        )
+        prefix = SimpleNamespace(
+            plan=mock.Mock(),
+            run=mock.Mock(
+                side_effect=lambda *args, **kwargs: (
+                    events.append("prefix")
+                    or (torch.zeros_like(args[0]), torch.zeros(args[0].shape[:2]))
+                )
+            ),
+        )
+        op = _NoReleaseHybridAttnOp.__new__(_NoReleaseHybridAttnOp)
+        op.dynamic_fp8 = True
+        op.fmha_params = params
+        op.ragged_wrapper = ragged
+        op.prefix_paged_wrapper = prefix
+        op.local_head_num = 4
+        op.local_kv_head_num = 2
+        op.head_dim_qk = 4
+        op.head_dim_vo = 4
+        op.physical_page_size = 32
+        op.page_size = 8
+        op.subdivision = 4
+        op.dtype = torch.bfloat16
+        op.q_dtype = torch.bfloat16
+        op.kv_dtype = torch.bfloat16
+        op.is_causal = True
+        inputs = SimpleNamespace(
+            kv_cache_kernel_block_id=torch.tensor([[12, 4], [9, 0]]),
+            kv_cache_kernel_block_id_device=None,
+            prefix_lengths=torch.tensor([1, 9], dtype=torch.int32),
+            sequence_lengths=torch.tensor([2, 10], dtype=torch.int32),
+            input_lengths=torch.tensor([1, 1], dtype=torch.int32),
+            cu_seqlens_device=torch.tensor([0, 1, 2], dtype=torch.int32),
+        )
+        op.prepare(inputs)
+        torch.testing.assert_close(
+            prefix.plan.call_args.args[2],
+            torch.tensor([0, 1, 2], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            params.reuse_cache_page_indice_d,
+            torch.tensor([12, 4, 9], dtype=torch.int32),
+        )
+
+        q = torch.randn(2, 4, 4, dtype=torch.bfloat16)
+        k = torch.randn(2, 2, 4, dtype=torch.bfloat16)
+        v = torch.randn_like(k)
+        cache = SimpleNamespace(
+            kv_cache_base=torch.empty(16, 2, 2, 8, 4, dtype=torch.float8_e4m3fn),
+            kv_scale_base=torch.empty(16, 2 * 2 * 8, dtype=torch.float32),
+        )
+        writer = SimpleNamespace(
+            forward=mock.Mock(side_effect=lambda *args: events.append("write"))
+        )
+
+        def gather_side_effect(*args):
+            events.append("gather")
+
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "rtp_llm_ops.gather_and_dequantize_fp8_kv_cache",
+            side_effect=gather_side_effect,
+            create=True,
+        ) as gather_mock, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "quantize_to_fp8_if_needed",
+            side_effect=AssertionError("unit-scale cast must not run"),
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "merge_state_in_place"
+        ):
+            op.forward(q, k, v, cache, writer)
+
+        self.assertEqual(events, ["ragged", "write", "gather", "prefix"])
+        self.assertIs(gather_mock.call_args.args[2], params.reuse_cache_page_indice_d)
+        self.assertEqual(gather_mock.call_args.args[3].dtype, torch.bfloat16)
+
+    def test_mode2_hybrid_attention_matches_base_reference_with_subdivision(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+
+        device = torch.device("cuda")
+        torch.manual_seed(2026)
+        harness = TestPyFlashinferHybridPrefillAttnOp()
+        harness.device = device
+        prefix_lengths = [7, 9]
+        input_lengths = [2, 3]
+        sequence_lengths = [
+            prefix + current for prefix, current in zip(prefix_lengths, input_lengths)
+        ]
+        kernel_page_size = 4
+        physical_page_size = 8
+        subdivision = physical_page_size // kernel_page_size
+        config = harness._create_config(
+            head_num=4,
+            head_num_kv=2,
+            size_per_head=64,
+            seq_size_per_block=kernel_page_size,
+        )
+        config.attn_configs.tokens_per_block = physical_page_size
+        config.attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        config.attn_configs.fp8_kv_cache_mode = 2
+        config.attn_configs.is_causal = True
+        inputs = harness._create_chunked_prefill_attention_inputs(
+            len(prefix_lengths),
+            prefix_lengths,
+            input_lengths,
+            kernel_page_size,
+        )
+        block_table = torch.zeros_like(inputs.kv_cache_kernel_block_id)
+        physical_page_offset = 0
+        for batch_idx, sequence_length in enumerate(sequence_lengths):
+            kernel_pages = math.ceil(sequence_length / kernel_page_size)
+            for logical_page in range(kernel_pages):
+                physical_page = physical_page_offset + logical_page // subdivision
+                block_table[batch_idx, logical_page] = (
+                    physical_page * subdivision + logical_page % subdivision
+                )
+            physical_page_offset += math.ceil(sequence_length / physical_page_size)
+        physical_page_count = physical_page_offset
+        torch.testing.assert_close(
+            block_table,
+            torch.tensor([[0, 1, 2], [4, 5, 6]], dtype=torch.int32),
+        )
+        self.assertEqual(physical_page_count, 4)
+        inputs.kv_cache_kernel_block_id = block_table
+        inputs.kv_cache_kernel_block_id_device = block_table.to(device)
+
+        op = PyFlashinferHybridPrefillAttnOp(config.attn_configs, inputs)
+        params = op.prepare(inputs)
+
+        q_chunks = []
+        k_prefix_chunks = []
+        v_prefix_chunks = []
+        k_new_chunks = []
+        v_new_chunks = []
+        prefix_k_tokens = []
+        prefix_v_tokens = []
+        target_pages = []
+        target_offsets = []
+        block_table = inputs.kv_cache_kernel_block_id
+        for batch_idx, (prefix_length, input_length) in enumerate(
+            zip(prefix_lengths, input_lengths)
+        ):
+            q_new = torch.randn(input_length, 4, 64, device=device, dtype=torch.float16)
+            k_prefix = torch.randn(
+                prefix_length, 2, 64, device=device, dtype=torch.float16
+            )
+            v_prefix = torch.randn_like(k_prefix)
+            k_new = torch.randn(input_length, 2, 64, device=device, dtype=torch.float16)
+            v_new = torch.randn_like(k_new)
+            q_chunks.append(q_new)
+            k_prefix_chunks.append(k_prefix)
+            v_prefix_chunks.append(v_prefix)
+            k_new_chunks.append(k_new)
+            v_new_chunks.append(v_new)
+            for position in range(prefix_length):
+                kernel_page = int(
+                    block_table[batch_idx, position // kernel_page_size].item()
+                )
+                prefix_k_tokens.append(k_prefix[position])
+                prefix_v_tokens.append(v_prefix[position])
+                target_pages.append(kernel_page // subdivision)
+                target_offsets.append(
+                    kernel_page % subdivision * kernel_page_size
+                    + position % kernel_page_size
+                )
+
+        kernel_page_count = physical_page_count * subdivision
+        cache = LayerKVCache()
+        cache.kv_cache_base = torch.zeros(
+            kernel_page_count,
+            2,
+            2,
+            kernel_page_size,
+            64,
+            device=device,
+            dtype=torch.float8_e4m3fn,
+        )
+        cache.kv_scale_base = torch.ones(
+            kernel_page_count,
+            2 * 2 * kernel_page_size,
+            device=device,
+            dtype=torch.float32,
+        )
+        rtp_llm_ops.quantize_and_write_fp8_kv_cache(
+            torch.stack(prefix_k_tokens),
+            torch.stack(prefix_v_tokens),
+            cache.kv_cache_base,
+            cache.kv_scale_base,
+            torch.tensor(target_pages, device=device, dtype=torch.int32),
+            torch.tensor(target_offsets, device=device, dtype=torch.int32),
+            physical_page_size,
+            kernel_page_size,
+            subdivision,
+        )
+        scale_view = cache.kv_scale_base.view(kernel_page_count, 2, 2, kernel_page_size)
+        reference_chunks = []
+        for batch_idx, (prefix_length, input_length) in enumerate(
+            zip(prefix_lengths, input_lengths)
+        ):
+            restored_prefix_k = []
+            restored_prefix_v = []
+            for position in range(prefix_length):
+                kernel_page = int(
+                    block_table[batch_idx, position // kernel_page_size].item()
+                )
+                storage_token = position % kernel_page_size
+                restored_prefix_k.append(
+                    cache.kv_cache_base[kernel_page, 0, :, storage_token].float()
+                    * scale_view[kernel_page, 0, :, storage_token].unsqueeze(-1)
+                )
+                restored_prefix_v.append(
+                    cache.kv_cache_base[kernel_page, 1, :, storage_token].float()
+                    * scale_view[kernel_page, 1, :, storage_token].unsqueeze(-1)
+                )
+            reference_chunks.append(
+                harness._reference_chunked_prefill(
+                    q_chunks[batch_idx],
+                    torch.cat(
+                        [
+                            torch.stack(restored_prefix_k).to(
+                                k_prefix_chunks[batch_idx].dtype
+                            ),
+                            k_new_chunks[batch_idx],
+                        ]
+                    ),
+                    torch.cat(
+                        [
+                            torch.stack(restored_prefix_v).to(
+                                v_prefix_chunks[batch_idx].dtype
+                            ),
+                            v_new_chunks[batch_idx],
+                        ]
+                    ),
+                    prefix_length,
+                    input_length,
+                    torch.float16,
+                    torch.float16,
+                )
+            )
+
+        writer = KVCacheWriteOp(
+            num_kv_heads=2,
+            head_size=64,
+            physical_page_size=physical_page_size,
+            kernel_page_size=kernel_page_size,
+            dynamic_mode=True,
+        )
+        writer.set_params(params)
+
+        output = op.forward(
+            torch.cat(q_chunks),
+            torch.cat(k_new_chunks),
+            torch.cat(v_new_chunks),
+            cache,
+            writer,
+        )
+        reference = torch.cat(reference_chunks)
+        torch.testing.assert_close(output, reference, rtol=0.06, atol=0.04)
+
+        for batch_idx, (prefix_length, input_length) in enumerate(
+            zip(prefix_lengths, input_lengths)
+        ):
+            for chunk_offset in range(input_length):
+                position = prefix_length + chunk_offset
+                kernel_page = int(
+                    block_table[batch_idx, position // kernel_page_size].item()
+                )
+                storage_token = position % kernel_page_size
+                for kv, source in enumerate(
+                    (k_new_chunks[batch_idx], v_new_chunks[batch_idx])
+                ):
+                    restored = cache.kv_cache_base[
+                        kernel_page, kv, :, storage_token
+                    ].float() * scale_view[kernel_page, kv, :, storage_token].unsqueeze(
+                        -1
+                    )
+                    torch.testing.assert_close(
+                        restored,
+                        source[chunk_offset].float(),
+                        rtol=0.13,
+                        atol=0.02,
+                    )
+
+
+class TestDynamicFp8FactoryGating(unittest.TestCase):
+    @staticmethod
+    def _config() -> SimpleNamespace:
+        return SimpleNamespace(
+            fp8_kv_cache_mode=2,
+            use_mla=False,
+            use_logn_attn=False,
+            rope_config=SimpleNamespace(style=RopeStyle.Base),
+        )
+
+    @staticmethod
+    def _impl(name, constructor=None, supports_cuda_graph=False):
+        class Impl:
+            accepts_fmha_config = False
+
+            @staticmethod
+            def support(attn_configs, attn_inputs):
+                return True
+
+            @classmethod
+            def support_parallelism_config(cls, parallelism_config):
+                return True
+
+            def __new__(cls, *args, **kwargs):
+                if constructor is not None:
+                    return constructor()
+                return super().__new__(cls)
+
+            def support_cuda_graph(self):
+                return supports_cuda_graph
+
+        Impl.__name__ = name
+        return Impl
+
+    def test_only_native_flashinfer_backend_is_instantiated(self):
+        disallowed = self._impl(
+            "OtherBackend",
+            constructor=lambda: self.fail("disallowed backend was instantiated"),
+        )
+        allowed = self._impl("PyFlashinferPrefillImpl")
+        inputs = SimpleNamespace(is_prefill=True)
+        with mock.patch.object(attn_factory, "PREFILL_MHA_IMPS", [disallowed, allowed]):
+            result = attn_factory.get_fmha_impl(
+                self._config(), None, inputs, parallelism_config=None
+            )
+        self.assertIsInstance(result, allowed)
+
+    def test_decode_only_instantiates_native_flashinfer_backend(self):
+        disallowed = self._impl(
+            "OtherDecodeBackend",
+            constructor=lambda: self.fail("disallowed decode backend was instantiated"),
+        )
+        allowed = self._impl("PyFlashinferDecodeImpl")
+        inputs = SimpleNamespace(is_prefill=False)
+        with mock.patch.object(attn_factory, "DECODE_MHA_IMPS", [disallowed, allowed]):
+            result = attn_factory.get_fmha_impl(
+                self._config(), None, inputs, parallelism_config=None
+            )
+        self.assertIsInstance(result, allowed)
+
+    def test_mode2_cuda_graph_allows_native_single_token_decode(self):
+        allowed = self._impl("PyFlashinferDecodeImpl", supports_cuda_graph=True)
+        inputs = SimpleNamespace(is_prefill=False)
+        with mock.patch.object(attn_factory, "DECODE_MHA_IMPS", [allowed]):
+            result = attn_factory.get_fmha_impl(
+                self._config(),
+                None,
+                inputs,
+                is_cuda_graph=True,
+                parallelism_config=None,
+            )
+        self.assertIsInstance(result, allowed)
+
+    def test_allowed_backend_constructor_failure_does_not_fallback(self):
+        fallback_calls = []
+
+        def fail_constructor():
+            raise RuntimeError("construction failed")
+
+        broken = self._impl("PyFlashinferPrefillImpl", fail_constructor)
+        fallback = self._impl(
+            "PyFlashinferPagedPrefillImpl",
+            constructor=lambda: fallback_calls.append(True),
+        )
+        with mock.patch.object(attn_factory, "PREFILL_MHA_IMPS", [broken, fallback]):
+            with self.assertRaisesRegex(RuntimeError, "required attention backend"):
+                attn_factory.get_fmha_impl(
+                    self._config(),
+                    None,
+                    SimpleNamespace(is_prefill=True),
+                    parallelism_config=None,
+                )
+        self.assertEqual(fallback_calls, [])
+
+    def test_rejects_unsupported_mode2_features_before_selection(self):
+        cases = (
+            ("cuda_graph", lambda config: None, True, "CUDA graph"),
+            ("mla", lambda config: setattr(config, "use_mla", True), False, "MLA"),
+            (
+                "mrope",
+                lambda config: setattr(config.rope_config, "style", RopeStyle.Mrope),
+                False,
+                "MRoPE",
+            ),
+            (
+                "logn",
+                lambda config: setattr(config, "use_logn_attn", True),
+                False,
+                "use_logn_attn",
+            ),
+        )
+        for name, mutate, is_cuda_graph, message in cases:
+            with self.subTest(name=name):
+                config = self._config()
+                mutate(config)
+                with self.assertRaisesRegex(ValueError, message):
+                    attn_factory.get_fmha_impl(
+                        config,
+                        None,
+                        SimpleNamespace(is_prefill=True),
+                        is_cuda_graph=is_cuda_graph,
+                    )
+
+
 class TestPyFlashinferHybridPrefillAttnOpFP8(TestPyFlashinferHybridPrefillAttnOp):
     kv_cache_dtype = KvCacheDataType.FP8
     rtol = 4e-2
     atol = 4e-2
     max_mismatch_rate = 1e-5
+
+    def test_mode1_interleaved_mrope_preserves_hybrid_order(self):
+        prefix_lengths = [5, 7]
+        input_lengths = [3, 2]
+        sequence_lengths = [
+            prefix + current for prefix, current in zip(prefix_lengths, input_lengths)
+        ]
+        page_size = 4
+        config = self._create_config(
+            head_num=4,
+            head_num_kv=2,
+            size_per_head=256,
+            seq_size_per_block=page_size,
+        )
+        self._enable_qwen35_mrope_mode1(config)
+        inputs = self._create_chunked_prefill_attention_inputs(
+            len(prefix_lengths), prefix_lengths, input_lengths, page_size
+        )
+        position_ids = self._add_qwen35_mrope_inputs(
+            inputs, input_lengths, prefix_lengths
+        )
+        self.assertTrue(
+            PyFlashinferHybridPrefillImpl.support(config.attn_configs, inputs)
+        )
+
+        total_tokens = sum(input_lengths)
+        qkv = torch.randn(
+            total_tokens,
+            (config.head_num + 2 * config.head_num_kv) * config.size_per_head,
+            dtype=config.attn_configs.dtype,
+            device=self.device,
+        )
+        q, k, v = torch.split(
+            qkv,
+            [
+                config.head_num * config.size_per_head,
+                config.head_num_kv * config.size_per_head,
+                config.head_num_kv * config.size_per_head,
+            ],
+            dim=-1,
+        )
+        q = q.reshape(total_tokens, config.head_num, config.size_per_head)
+        k = k.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+        v = v.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+        expected_q, expected_k = self._apply_qwen35_mrope_reference(q, k, position_ids)
+
+        k_prefix = [
+            torch.randn(
+                length,
+                config.head_num_kv,
+                config.size_per_head,
+                dtype=config.attn_configs.dtype,
+                device=self.device,
+            )
+            for length in prefix_lengths
+        ]
+        v_prefix = [torch.randn_like(key) for key in k_prefix]
+        kv_cache = self._create_prefix_kv_cache(
+            k_prefix,
+            v_prefix,
+            prefix_lengths,
+            sequence_lengths,
+            page_size,
+            config.head_num_kv,
+            config.size_per_head,
+            inputs.kv_cache_kernel_block_id,
+            torch.float8_e4m3fn,
+        )
+        cache_before = kv_cache.kv_cache_base.clone()
+        expected_cache = cache_before.clone()
+        token_offset = 0
+        for batch_idx, (prefix_length, input_length) in enumerate(
+            zip(prefix_lengths, input_lengths)
+        ):
+            for chunk_offset in range(input_length):
+                position = prefix_length + chunk_offset
+                page_id = int(
+                    inputs.kv_cache_kernel_block_id[
+                        batch_idx, position // page_size
+                    ].item()
+                )
+                page_offset = position % page_size
+                expected_cache[page_id, 0, :, page_offset] = expected_k[
+                    token_offset + chunk_offset
+                ].to(torch.float8_e4m3fn)
+                expected_cache[page_id, 1, :, page_offset] = v[
+                    token_offset + chunk_offset
+                ].to(torch.float8_e4m3fn)
+            token_offset += input_length
+
+        impl = PyFlashinferHybridPrefillImpl(
+            config.attn_configs, inputs, config.parallelism_config
+        )
+        events = []
+        fused_forward = impl.fused_mrope_impl.forward
+        cache_write = impl.kv_cache_write_op.forward
+
+        def observed_fused_forward(qkv_input, cache, params):
+            events.append("fused_rope")
+            self.assertIsNone(cache)
+            return fused_forward(qkv_input, cache, params)
+
+        def observed_ragged(query, key, value, *args, **kwargs):
+            events.append("ragged_attention")
+            torch.testing.assert_close(
+                kv_cache.kv_cache_base.float(), cache_before.float(), rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                query.float(), expected_q.float(), rtol=1e-2, atol=1e-2
+            )
+            return (
+                torch.zeros_like(expected_q),
+                torch.zeros(
+                    expected_q.shape[:2], dtype=torch.float32, device=self.device
+                ),
+            )
+
+        def observed_cache_write(key, value, cache):
+            events.append("cache_write")
+            return cache_write(key, value, cache)
+
+        def observed_paged(query, cache, *args, **kwargs):
+            events.append("paged_attention")
+            self.assertIs(cache, kv_cache.kv_cache_base)
+            torch.testing.assert_close(
+                kv_cache.kv_cache_base.float(), expected_cache.float(), rtol=0, atol=0
+            )
+            return (
+                torch.zeros_like(expected_q),
+                torch.zeros(
+                    expected_q.shape[:2], dtype=torch.float32, device=self.device
+                ),
+            )
+
+        def observed_cache_store(*args, **kwargs):
+            events.append("cache_store")
+
+        with mock.patch.object(
+            impl.fused_mrope_impl,
+            "forward",
+            side_effect=observed_fused_forward,
+        ) as fused_mock, mock.patch.object(
+            impl.fmha_impl.ragged_wrapper,
+            "run",
+            side_effect=observed_ragged,
+        ), mock.patch.object(
+            impl.kv_cache_write_op,
+            "forward",
+            side_effect=observed_cache_write,
+        ) as write_mock, mock.patch.object(
+            impl.fmha_impl.prefix_paged_wrapper,
+            "run",
+            side_effect=observed_paged,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "merge_state_in_place"
+        ), mock.patch.object(
+            common,
+            "apply_write_cache_store",
+            side_effect=observed_cache_store,
+        ):
+            impl.forward(qkv.clone(), kv_cache)
+
+        fused_mock.assert_called_once()
+        write_mock.assert_called_once()
+        self.assertEqual(
+            events,
+            [
+                "fused_rope",
+                "ragged_attention",
+                "cache_write",
+                "paged_attention",
+                "cache_store",
+            ],
+        )
+        torch.testing.assert_close(
+            kv_cache.kv_cache_base.float(), expected_cache.float(), rtol=0, atol=0
+        )
+        self.assertTrue(torch.all(kv_cache.kv_scale_base == 1).item())
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_paged_mha_prefill.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_paged_mha_prefill.py
@@ -1,11 +1,21 @@
 import logging
+import math
 import unittest
+from types import SimpleNamespace
 from typing import List
+from unittest import mock
 
 import torch
 
+from rtp_llm.models_py.modules.factory.attention import common
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op import (
+    KVCacheWriteOp,
+)
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
+    PyFlashinferPagedPrefillImpl,
     PyFlashinferPrefillPagedAttnOp,
+    attn_kv_dtype,
+    attn_q_dtype,
 )
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.test.attention_ref import (
     compute_flashinfer_prefill_reference,
@@ -525,6 +535,349 @@ class TestPyFlashinferPrefillPagedAttnOpFP8(TestPyFlashinferPrefillPagedAttnOp):
     rtol = 4e-2
     atol = 4e-2
     max_mismatch_rate = 1e-5
+
+    def test_mode1_interleaved_mrope_writes_before_paged_attention(self):
+        sequence_lengths = [3, 5]
+        page_size = 4
+        config = self._create_config(
+            head_num=4,
+            head_num_kv=2,
+            size_per_head=256,
+            seq_size_per_block=page_size,
+        )
+        self._enable_qwen35_mrope_mode1(config)
+        inputs = self._create_prefill_attention_inputs(
+            len(sequence_lengths), sequence_lengths, page_size
+        )
+        position_ids = self._add_qwen35_mrope_inputs(inputs, sequence_lengths)
+        self.assertTrue(
+            PyFlashinferPagedPrefillImpl.support(config.attn_configs, inputs)
+        )
+
+        total_tokens = sum(sequence_lengths)
+        qkv = torch.randn(
+            total_tokens,
+            (config.head_num + 2 * config.head_num_kv) * config.size_per_head,
+            dtype=config.attn_configs.dtype,
+            device=self.device,
+        )
+        q, k, v = torch.split(
+            qkv,
+            [
+                config.head_num * config.size_per_head,
+                config.head_num_kv * config.size_per_head,
+                config.head_num_kv * config.size_per_head,
+            ],
+            dim=-1,
+        )
+        q = q.reshape(total_tokens, config.head_num, config.size_per_head)
+        k = k.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+        v = v.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+        expected_q, expected_k = self._apply_qwen35_mrope_reference(q, k, position_ids)
+
+        page_count = sum(math.ceil(length / page_size) for length in sequence_lengths)
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.zeros(
+            page_count,
+            2,
+            config.head_num_kv,
+            page_size,
+            config.size_per_head,
+            dtype=torch.float8_e4m3fn,
+            device=self.device,
+        )
+        kv_cache.kv_scale_base = torch.ones(
+            page_count,
+            2 * config.head_num_kv * page_size,
+            dtype=torch.float32,
+            device=self.device,
+        )
+        expected_cache = kv_cache.kv_cache_base.clone()
+        token_offset = 0
+        for batch_idx, sequence_length in enumerate(sequence_lengths):
+            for position in range(sequence_length):
+                page_id = int(
+                    inputs.kv_cache_kernel_block_id[
+                        batch_idx, position // page_size
+                    ].item()
+                )
+                page_offset = position % page_size
+                expected_cache[page_id, 0, :, page_offset] = expected_k[
+                    token_offset + position
+                ].to(torch.float8_e4m3fn)
+                expected_cache[page_id, 1, :, page_offset] = v[
+                    token_offset + position
+                ].to(torch.float8_e4m3fn)
+            token_offset += sequence_length
+
+        impl = PyFlashinferPagedPrefillImpl(
+            config.attn_configs, inputs, config.parallelism_config
+        )
+        events = []
+        fused_forward = impl.fused_mrope_impl.forward
+        cache_write = impl.kv_cache_write_op.forward
+
+        def observed_fused_forward(qkv_input, cache, params):
+            events.append("fused_rope")
+            self.assertIsNone(cache)
+            return fused_forward(qkv_input, cache, params)
+
+        def observed_cache_write(key, value, cache):
+            events.append("cache_write")
+            return cache_write(key, value, cache)
+
+        def observed_cache_store(*args, **kwargs):
+            events.append("cache_store")
+
+        def observed_attention(query, cache):
+            events.append("paged_attention")
+            self.assertIs(cache, kv_cache)
+            self.assertEqual(cache.kv_cache_base.dtype, torch.float8_e4m3fn)
+            torch.testing.assert_close(
+                cache.kv_cache_base.float(), expected_cache.float(), rtol=0, atol=0
+            )
+            return query
+
+        with mock.patch.object(
+            impl.fused_mrope_impl,
+            "forward",
+            side_effect=observed_fused_forward,
+        ) as fused_mock, mock.patch.object(
+            impl.kv_cache_write_op,
+            "forward",
+            side_effect=observed_cache_write,
+        ) as write_mock, mock.patch.object(
+            common,
+            "apply_write_cache_store",
+            side_effect=observed_cache_store,
+        ), mock.patch.object(
+            impl.fmha_impl,
+            "forward",
+            side_effect=observed_attention,
+        ):
+            output = impl.forward(qkv.clone(), kv_cache)
+
+        fused_mock.assert_called_once()
+        write_mock.assert_called_once()
+        self.assertEqual(
+            events, ["fused_rope", "cache_write", "cache_store", "paged_attention"]
+        )
+        torch.testing.assert_close(output, expected_q, rtol=1e-2, atol=1e-2)
+
+
+class _NoReleasePagedAttnOp(PyFlashinferPrefillPagedAttnOp):
+    def __del__(self):
+        pass
+
+
+class TestDynamicFp8PagedPrefillUnit(unittest.TestCase):
+    @staticmethod
+    def _config() -> SimpleNamespace:
+        return SimpleNamespace(
+            dtype=torch.bfloat16,
+            kv_cache_dtype=KvCacheDataType.FP8,
+            fp8_kv_cache_mode=2,
+            head_num=4,
+            kv_head_num=2,
+            size_per_head=4,
+            tokens_per_block=32,
+            kernel_tokens_per_block=8,
+            is_causal=True,
+        )
+
+    def test_mode2_uses_base_plan_dtypes_and_compact_page_ids(self):
+        config = self._config()
+        self.assertEqual(attn_q_dtype(config), torch.bfloat16)
+        self.assertEqual(attn_kv_dtype(config), torch.bfloat16)
+
+        params = SimpleNamespace(
+            fill_params=mock.Mock(),
+            decode_page_indptr_d=torch.tensor([0, 2], dtype=torch.int32),
+            page_indice_d=torch.tensor([9, 3, 77], dtype=torch.int32),
+            paged_kv_last_page_len_d=torch.tensor([2], dtype=torch.int32),
+        )
+        wrapper = SimpleNamespace(_qo_indptr_buf=None, plan=mock.Mock())
+        op = _NoReleasePagedAttnOp.__new__(_NoReleasePagedAttnOp)
+        op.g_workspace_buffer = torch.empty(0)
+        op.local_head_num = 4
+        op.local_kv_head_num = 2
+        op.head_dim_qk = 4
+        op.page_size = 8
+        op.dtype = torch.bfloat16
+        op.kv_dtype = torch.bfloat16
+        op.q_dtype = torch.bfloat16
+        op.is_causal = True
+        op.dynamic_fp8 = True
+        op.enable_cuda_graph = False
+        op.prefill_cuda_graph_copy_params = None
+        op.fmha_params = params
+        op.prefill_wrapper = wrapper
+        inputs = SimpleNamespace(
+            kv_cache_kernel_block_id=torch.tensor([[9, 3]], dtype=torch.int32),
+            kv_cache_kernel_block_id_device=None,
+            input_lengths=torch.tensor([2], dtype=torch.int32),
+            prefix_lengths=torch.tensor([0], dtype=torch.int32),
+            sequence_lengths=torch.tensor([2], dtype=torch.int32),
+            cu_seqlens_device=torch.tensor([0, 2], dtype=torch.int32),
+            prefill_cuda_graph_copy_params=None,
+        )
+
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "check_attention_inputs"
+        ):
+            op.prepare(inputs)
+
+        plan_args = wrapper.plan.call_args.args
+        torch.testing.assert_close(
+            plan_args[2], torch.tensor([0, 1], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            op._active_source_page_indices, torch.tensor([9, 3], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            params.page_indice_d, torch.tensor([9, 3, 77], dtype=torch.int32)
+        )
+        self.assertEqual(wrapper.plan.call_args.kwargs["q_data_type"], torch.bfloat16)
+        self.assertEqual(wrapper.plan.call_args.kwargs["kv_data_type"], torch.bfloat16)
+
+    def test_mode2_forward_gathers_original_pages_without_unit_cast(self):
+        op = _NoReleasePagedAttnOp.__new__(_NoReleasePagedAttnOp)
+        op.g_workspace_buffer = torch.empty(0)
+        op.dynamic_fp8 = True
+        op.dtype = torch.bfloat16
+        op.local_kv_head_num = 2
+        op.head_dim_qk = 4
+        op.physical_page_size = 32
+        op.page_size = 8
+        op.subdivision = 4
+        op.prefill_cuda_graph_copy_params = None
+        op.fmha_params = SimpleNamespace(
+            page_indice_d=torch.tensor([9, 3, 77], dtype=torch.int32)
+        )
+        op._active_source_page_indices = op.fmha_params.page_indice_d[:2]
+        op.prefill_wrapper = SimpleNamespace(run=mock.Mock(side_effect=lambda q, _: q))
+        q = torch.randn(2, 4, 4, dtype=torch.bfloat16)
+        cache = SimpleNamespace(
+            kv_cache_base=torch.empty(12, 2, 2, 8, 4, dtype=torch.float8_e4m3fn),
+            kv_scale_base=torch.empty(12, 2 * 2 * 8, dtype=torch.float32),
+        )
+
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "rtp_llm_ops.gather_and_dequantize_fp8_kv_cache",
+            create=True,
+        ) as gather_mock, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "quantize_to_fp8_if_needed",
+            side_effect=AssertionError("unit-scale cast must not run"),
+        ):
+            output = op.forward(q, cache)
+
+        self.assertIs(output, q)
+        gather_mock.assert_called_once()
+        gather_args = gather_mock.call_args.args
+        self.assertIs(gather_args[2], op._active_source_page_indices)
+        torch.testing.assert_close(
+            gather_args[2], torch.tensor([9, 3], dtype=torch.int32)
+        )
+        self.assertEqual(gather_args[3].shape, (2, 2, 2, 8, 4))
+        self.assertEqual(gather_args[3].dtype, torch.bfloat16)
+        self.assertEqual(gather_args[4:], (32, 8, 4))
+
+    def test_mode2_end_to_end_attention_matches_base_reference(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+
+        device = torch.device("cuda")
+        harness = BaseAttentionTest()
+        harness.device = device
+        config = harness._create_config(
+            head_num=4,
+            head_num_kv=2,
+            size_per_head=64,
+            seq_size_per_block=4,
+        )
+        config.attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        config.attn_configs.fp8_kv_cache_mode = 2
+        config.attn_configs.is_causal = True
+        sequence_lengths = [7, 11]
+        inputs = harness._create_prefill_attention_inputs(
+            len(sequence_lengths), sequence_lengths, config.seq_size_per_block
+        )
+        op = PyFlashinferPrefillPagedAttnOp(config.attn_configs, inputs)
+        params = op.prepare(inputs)
+
+        total_tokens = sum(sequence_lengths)
+        q = torch.randn(total_tokens, 4, 64, device=device, dtype=torch.float16)
+        k = torch.randn(total_tokens, 2, 64, device=device, dtype=torch.float16)
+        v = torch.randn(total_tokens, 2, 64, device=device, dtype=torch.float16)
+        page_count = sum(
+            math.ceil(length / config.seq_size_per_block) for length in sequence_lengths
+        )
+        cache = LayerKVCache()
+        cache.kv_cache_base = torch.empty(
+            page_count,
+            2,
+            2,
+            config.seq_size_per_block,
+            64,
+            device=device,
+            dtype=torch.float8_e4m3fn,
+        )
+        cache.kv_scale_base = torch.empty(
+            page_count,
+            2 * 2 * config.seq_size_per_block,
+            device=device,
+            dtype=torch.float32,
+        )
+        writer = KVCacheWriteOp(
+            num_kv_heads=2,
+            head_size=64,
+            physical_page_size=config.seq_size_per_block,
+            kernel_page_size=config.seq_size_per_block,
+            dynamic_mode=True,
+        )
+        writer.set_params(params)
+        writer.forward(k, v, cache)
+
+        scale_view = cache.kv_scale_base.view(
+            page_count, 2, 2, config.seq_size_per_block
+        )
+        restored_k_cache = (
+            cache.kv_cache_base[:, 0].float() * scale_view[:, 0].unsqueeze(-1)
+        ).to(k.dtype)
+        restored_v_cache = (
+            cache.kv_cache_base[:, 1].float() * scale_view[:, 1].unsqueeze(-1)
+        ).to(v.dtype)
+        restored_k = []
+        restored_v = []
+        for batch_idx, sequence_length in enumerate(sequence_lengths):
+            page_ids = inputs.kv_cache_kernel_block_id[
+                batch_idx, : math.ceil(sequence_length / config.seq_size_per_block)
+            ].tolist()
+            restored_k.append(
+                restored_k_cache[page_ids]
+                .permute(1, 0, 2, 3)
+                .reshape(2, -1, 64)
+                .permute(1, 0, 2)[:sequence_length]
+            )
+            restored_v.append(
+                restored_v_cache[page_ids]
+                .permute(1, 0, 2, 3)
+                .reshape(2, -1, 64)
+                .permute(1, 0, 2)[:sequence_length]
+            )
+
+        output = op.forward(q, cache)
+        reference = compute_flashinfer_prefill_reference(
+            q,
+            torch.cat(restored_k),
+            torch.cat(restored_v),
+            inputs.cu_seqlens_device,
+            causal=True,
+        )
+        torch.testing.assert_close(output, reference, rtol=0.06, atol=0.04)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_ragged_mha_prefill.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_ragged_mha_prefill.py
@@ -1,11 +1,14 @@
 import logging
+import math
 import unittest
 from typing import List
+from unittest import mock
 
 import torch
 
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     PyFlashinferPrefillAttnOp,
+    PyFlashinferPrefillImpl,
 )
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.test.attention_ref import (
     compute_flashinfer_prefill_reference,
@@ -323,6 +326,155 @@ class TestPyFlashinferPrefillAttnOpFP8(TestPyFlashinferPrefillAttnOp):
     rtol = 4e-2
     atol = 4e-2
     max_mismatch_rate = 5e-5
+
+    def test_mode1_interleaved_mrope_rotates_qk_and_writes_unit_scale_fp8(self):
+        sequence_lengths = [5, 3]
+        page_size = 4
+        config = self._create_config(
+            head_num=4,
+            head_num_kv=2,
+            size_per_head=256,
+            seq_size_per_block=page_size,
+        )
+        self._enable_qwen35_mrope_mode1(config)
+        config.attn_configs.is_causal = True
+        inputs = self._create_prefill_attention_inputs(
+            len(sequence_lengths), sequence_lengths, page_size
+        )
+        position_ids = self._add_qwen35_mrope_inputs(inputs, sequence_lengths)
+        self.assertTrue(PyFlashinferPrefillImpl.support(config.attn_configs, inputs))
+
+        total_tokens = sum(sequence_lengths)
+        qkv = torch.randn(
+            total_tokens,
+            (config.head_num + 2 * config.head_num_kv) * config.size_per_head,
+            dtype=config.attn_configs.dtype,
+            device=self.device,
+        )
+        q, k, v = torch.split(
+            qkv,
+            [
+                config.head_num * config.size_per_head,
+                config.head_num_kv * config.size_per_head,
+                config.head_num_kv * config.size_per_head,
+            ],
+            dim=-1,
+        )
+        q = q.reshape(total_tokens, config.head_num, config.size_per_head)
+        k = k.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+        v = v.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+        expected_q, expected_k = self._apply_qwen35_mrope_reference(q, k, position_ids)
+
+        total_blocks = sum(math.ceil(length / page_size) for length in sequence_lengths)
+        kv_cache, _, _ = self._create_kv_cache(
+            total_blocks,
+            page_size,
+            config.head_num_kv,
+            config.size_per_head,
+            dtype=torch.float8_e4m3fn,
+        )
+        impl = PyFlashinferPrefillImpl(
+            config.attn_configs, inputs, config.parallelism_config
+        )
+        self.assertIsNone(impl.rope_impl)
+        self.assertIsNotNone(impl.fused_mrope_impl)
+
+        with mock.patch.object(
+            impl.fused_mrope_impl,
+            "forward",
+            wraps=impl.fused_mrope_impl.forward,
+        ) as fused_forward, mock.patch.object(
+            impl.kv_cache_write_op,
+            "forward",
+            wraps=impl.kv_cache_write_op.forward,
+        ) as cache_write, mock.patch.object(
+            impl.fmha_impl,
+            "forward",
+            wraps=impl.fmha_impl.forward,
+        ) as fmha_forward:
+            output = impl.forward(qkv.clone(), kv_cache)
+
+        fused_forward.assert_called_once()
+        self.assertIsNone(fused_forward.call_args.args[1])
+        cache_write.assert_called_once()
+        fmha_forward.assert_called_once()
+        query, written_k, written_v = fmha_forward.call_args.args[:3]
+        self.assertEqual(written_k.dtype, torch.float8_e4m3fn)
+        self.assertEqual(written_v.dtype, torch.float8_e4m3fn)
+        torch.testing.assert_close(query, expected_q, rtol=1e-2, atol=1e-2)
+        reference = compute_flashinfer_prefill_reference(
+            expected_q.to(impl.fmha_impl.q_dtype).to(expected_q.dtype),
+            written_k.to(expected_k.dtype),
+            written_v.to(v.dtype),
+            inputs.cu_seqlens_device,
+            causal=True,
+        )
+        self._assert_output_close(output, reference, name="MRoPE ragged output")
+        torch.testing.assert_close(
+            written_k.float(),
+            expected_k.to(torch.float8_e4m3fn).float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            written_v.float(), v.to(torch.float8_e4m3fn).float(), rtol=0, atol=0
+        )
+
+        token_offset = 0
+        for batch_idx, sequence_length in enumerate(sequence_lengths):
+            for position in range(sequence_length):
+                page_id = int(
+                    inputs.kv_cache_kernel_block_id[
+                        batch_idx, position // page_size
+                    ].item()
+                )
+                page_offset = position % page_size
+                torch.testing.assert_close(
+                    kv_cache.kv_cache_base[page_id, 0, :, page_offset].float(),
+                    expected_k[token_offset + position].to(torch.float8_e4m3fn).float(),
+                    rtol=0,
+                    atol=0,
+                )
+                torch.testing.assert_close(
+                    kv_cache.kv_cache_base[page_id, 1, :, page_offset].float(),
+                    v[token_offset + position].to(torch.float8_e4m3fn).float(),
+                    rtol=0,
+                    atol=0,
+                )
+            token_offset += sequence_length
+        self.assertTrue(torch.all(kv_cache.kv_scale_base == 1).item())
+
+    def test_mode1_mrope_support_rejects_invalid_variants(self):
+        config = self._create_config(
+            head_num=4,
+            head_num_kv=2,
+            size_per_head=64,
+            seq_size_per_block=4,
+        )
+        self._enable_qwen35_mrope_mode1(config)
+        inputs = self._create_prefill_attention_inputs(1, [2], 4)
+        self._add_qwen35_mrope_inputs(inputs, [2])
+
+        cases = (
+            ("non_interleaved", "mrope_interleaved", False),
+            ("invalid_index_factor", "index_factor", 1),
+            ("invalid_sections", "mrope_dim3", 9),
+        )
+        for name, field, value in cases:
+            with self.subTest(name=name):
+                setattr(config.attn_configs.rope_config, field, value)
+                self.assertFalse(
+                    PyFlashinferPrefillImpl.support(config.attn_configs, inputs)
+                )
+                self._enable_qwen35_mrope_mode1(config)
+
+        inputs.combo_position_ids = torch.empty(
+            0, dtype=torch.int32, device=self.device
+        )
+        self.assertFalse(PyFlashinferPrefillImpl.support(config.attn_configs, inputs))
+        self._add_qwen35_mrope_inputs(inputs, [2])
+        config.attn_configs.fp8_kv_cache_mode = 2
+        self.assertFalse(PyFlashinferPrefillImpl.support(config.attn_configs, inputs))
 
     def test_out_of_fp8_range_kv(self):
         config = self._create_config(

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -2,6 +2,7 @@ import logging
 import math
 import sys
 import unittest
+from types import SimpleNamespace
 from typing import List, NamedTuple, Optional
 from unittest import mock
 
@@ -9,11 +10,17 @@ import torch
 from attention_ref import compute_flashinfer_decode_reference
 from base_attention_test import BaseAttentionTest, compare_tensors
 
+from rtp_llm.models_py.modules.factory.attention.attn_factory import (
+    _validate_dynamic_fp8_config,
+)
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     PyFlashinferDecodeAttnOp,
+    PyFlashinferDecodeImpl,
+    _validate_dynamic_fp8_scale,
 )
-from rtp_llm.ops import KvCacheDataType
+from rtp_llm.ops import KvCacheDataType, RopeConfig, RopeStyle
 from rtp_llm.ops.compute_ops import (
+    LayerKVCache,
     PyAttentionInputs,
     fill_mla_params,
     get_typemeta,
@@ -677,6 +684,367 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         finally:
             torch.cuda.synchronize()
 
+    def test_dynamic_fp8_cuda_graph_plan_and_buffers_are_stable(self):
+        config = self._create_config(
+            head_num=32,
+            head_num_kv=8,
+            size_per_head=128,
+            seq_size_per_block=64,
+            data_type="bf16",
+        )
+        config.attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        config.attn_configs.fp8_kv_cache_mode = 2
+
+        for capture_bs in (1, 2, 4, 8, 16, 32):
+            with self.subTest(capture_bs=capture_bs):
+                capture_inputs = self._create_cuda_graph_inputs(
+                    capture_bs,
+                    [4809] * capture_bs,
+                    config.seq_size_per_block,
+                )
+                attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+                fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+                attn_op.set_params(fmha_params)
+                attn_op.prepare(capture_inputs)
+                capture_signature = tuple(attn_op.decode_wrapper._plan_info)
+                capture_pointers = (
+                    attn_op.g_workspace_buffer.data_ptr(),
+                    attn_op.decode_wrapper._int_workspace_buffer.data_ptr(),
+                    attn_op.decode_wrapper._qo_indptr_buf.data_ptr(),
+                    fmha_params.decode_page_indptr_d.data_ptr(),
+                    fmha_params.page_indice_d.data_ptr(),
+                    fmha_params.paged_kv_last_page_len_d.data_ptr(),
+                )
+
+                replay_cases = [
+                    ([1] * capture_bs, capture_bs, False),
+                    (
+                        [63 + index % 3 for index in range(capture_bs)],
+                        capture_bs,
+                        False,
+                    ),
+                    (
+                        [64 + index % 3 for index in range(capture_bs)],
+                        capture_bs,
+                        True,
+                    ),
+                    (
+                        [4807 + index % 3 for index in range(capture_bs)],
+                        capture_bs,
+                        False,
+                    ),
+                ]
+                if capture_bs > 1:
+                    active_batch_size = max(1, capture_bs // 2)
+                    replay_cases.append(
+                        ([65] * active_batch_size, active_batch_size, True)
+                    )
+
+                for sequence_lengths, active_batch_size, sparse_ids in replay_cases:
+                    replay_inputs = self._create_cuda_graph_inputs(
+                        capture_bs,
+                        sequence_lengths,
+                        config.seq_size_per_block,
+                        active_batch_size=active_batch_size,
+                        padding_block_id=7,
+                    )
+                    if sparse_ids:
+                        sparse_table = (
+                            replay_inputs.kv_cache_kernel_block_id * 7 + 11
+                        ) % 97
+                        if capture_bs > 1:
+                            sparse_table[-1, 0] = sparse_table[0, 0]
+                        replay_inputs.kv_cache_kernel_block_id = sparse_table
+                        replay_inputs.kv_cache_kernel_block_id_device = (
+                            sparse_table.cuda()
+                        )
+                    attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+                    self.assertEqual(
+                        tuple(attn_op.decode_wrapper._plan_info),
+                        capture_signature,
+                        f"plan changed for batch={capture_bs}, lengths={sequence_lengths}",
+                    )
+                    self.assertEqual(
+                        (
+                            attn_op.g_workspace_buffer.data_ptr(),
+                            attn_op.decode_wrapper._int_workspace_buffer.data_ptr(),
+                            attn_op.decode_wrapper._qo_indptr_buf.data_ptr(),
+                            fmha_params.decode_page_indptr_d.data_ptr(),
+                            fmha_params.page_indice_d.data_ptr(),
+                            fmha_params.paged_kv_last_page_len_d.data_ptr(),
+                        ),
+                        capture_pointers,
+                    )
+
+    def test_dynamic_fp8_cuda_graph_rejects_changed_plan(self):
+        config = self._create_config(
+            head_num=32,
+            head_num_kv=8,
+            size_per_head=128,
+            seq_size_per_block=64,
+            data_type="bf16",
+        )
+        config.attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        config.attn_configs.fp8_kv_cache_mode = 2
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 65],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        attn_op.prepare(inputs)
+
+        changed_plan = list(attn_op.decode_wrapper._plan_info)
+        changed_plan[0] += 1
+        attn_op.decode_wrapper._plan_info = changed_plan
+        with self.assertRaisesRegex(RuntimeError, "plan or buffer addresses changed"):
+            attn_op._validate_dynamic_fp8_cuda_graph_state()
+
+    def test_dynamic_fp8_direct_decode_real_cuda_graph_replay(self):
+        config = self._create_config(
+            head_num=32,
+            head_num_kv=8,
+            size_per_head=128,
+            seq_size_per_block=64,
+            data_type="bf16",
+        )
+        config.attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        config.attn_configs.fp8_kv_cache_mode = 2
+        capture_bs = 4
+        capture_lengths = [129, 130, 131, 132]
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            capture_lengths,
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+
+        page_count = 64
+        local_head_num = config.head_num // config.tp_size
+        local_kv_head_num = config.head_num_kv // config.tp_size
+        payload = torch.randn(
+            page_count,
+            2,
+            local_kv_head_num,
+            config.seq_size_per_block,
+            config.size_per_head,
+            device="cuda",
+            dtype=torch.bfloat16,
+        ).to(torch.float8_e4m3fn)
+        scales = (
+            torch.rand(
+                page_count,
+                2,
+                local_kv_head_num,
+                config.seq_size_per_block,
+                device="cuda",
+                dtype=torch.float32,
+            )
+            .mul_(0.02)
+            .add_(0.01)
+        )
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = payload
+        kv_cache.kv_scale_base = scales.flatten(1)
+        q = self._create_query_tensor(
+            capture_bs, local_head_num, config.size_per_head
+        ).to(config.attn_configs.dtype)
+
+        graph = torch.cuda.CUDAGraph()
+        torch.cuda.synchronize()
+        with torch.cuda.graph(graph):
+            graph_output = attn_op.forward(q, kv_cache, fmha_params)
+        torch.cuda.synchronize()
+
+        graph_pointers = (
+            attn_op.g_workspace_buffer.data_ptr(),
+            attn_op.decode_wrapper._int_workspace_buffer.data_ptr(),
+            attn_op.decode_wrapper._qo_indptr_buf.data_ptr(),
+            fmha_params.decode_page_indptr_d.data_ptr(),
+            fmha_params.page_indice_d.data_ptr(),
+            fmha_params.paged_kv_last_page_len_d.data_ptr(),
+            q.data_ptr(),
+            payload.data_ptr(),
+            kv_cache.kv_scale_base.data_ptr(),
+            graph_output.data_ptr(),
+        )
+        capture_signature = tuple(attn_op.decode_wrapper._plan_info)
+        replay_cases = (
+            ([63, 64, 65, 129], 0),
+            ([65, 66, 127, 130], 16),
+        )
+        scale_view = kv_cache.kv_scale_base.view(
+            page_count,
+            2,
+            local_kv_head_num,
+            config.seq_size_per_block,
+        )
+        restored_k = (payload[:, 0].float() * scale_view[:, 0].unsqueeze(-1)).to(
+            q.dtype
+        )
+        restored_v = (payload[:, 1].float() * scale_view[:, 1].unsqueeze(-1)).to(
+            q.dtype
+        )
+
+        for sequence_lengths, block_id_offset in replay_cases:
+            replay_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                sequence_lengths,
+                config.seq_size_per_block,
+                block_id_offset=block_id_offset,
+            )
+            replay_q = torch.randn_like(q)
+            q.copy_(replay_q)
+            attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+            graph.replay()
+            torch.cuda.synchronize()
+
+            block_id_list = [
+                replay_inputs.kv_cache_kernel_block_id[
+                    batch_idx,
+                    : math.ceil(sequence_length / config.seq_size_per_block),
+                ].tolist()
+                for batch_idx, sequence_length in enumerate(sequence_lengths)
+            ]
+            reference = compute_flashinfer_decode_reference(
+                replay_q,
+                restored_k,
+                restored_v,
+                sequence_lengths,
+                block_id_list,
+                config.seq_size_per_block,
+            )
+            torch.testing.assert_close(
+                graph_output,
+                reference,
+                rtol=0.06,
+                atol=0.04,
+            )
+            self.assertEqual(
+                tuple(attn_op.decode_wrapper._plan_info), capture_signature
+            )
+            self.assertEqual(
+                (
+                    attn_op.g_workspace_buffer.data_ptr(),
+                    attn_op.decode_wrapper._int_workspace_buffer.data_ptr(),
+                    attn_op.decode_wrapper._qo_indptr_buf.data_ptr(),
+                    fmha_params.decode_page_indptr_d.data_ptr(),
+                    fmha_params.page_indice_d.data_ptr(),
+                    fmha_params.paged_kv_last_page_len_d.data_ptr(),
+                    q.data_ptr(),
+                    payload.data_ptr(),
+                    kv_cache.kv_scale_base.data_ptr(),
+                    graph_output.data_ptr(),
+                ),
+                graph_pointers,
+            )
+
+    def test_dynamic_fp8_impl_real_cuda_graph_replay(self):
+        config = self._create_config(
+            head_num=32,
+            head_num_kv=8,
+            size_per_head=128,
+            seq_size_per_block=64,
+            data_type="bf16",
+        )
+        config.attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        config.attn_configs.fp8_kv_cache_mode = 2
+        config.attn_configs.need_rope_kv_cache = False
+        capture_bs = 2
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [130, 131],
+            config.seq_size_per_block,
+        )
+        impl = PyFlashinferDecodeImpl(config.attn_configs, capture_inputs)
+        local_head_num = config.head_num // config.tp_size
+        local_kv_head_num = config.head_num_kv // config.tp_size
+        qkv = torch.randn(
+            capture_bs,
+            (local_head_num + 2 * local_kv_head_num) * config.size_per_head,
+            device="cuda",
+            dtype=config.attn_configs.dtype,
+        )
+
+        def new_cache() -> LayerKVCache:
+            cache = LayerKVCache()
+            cache.kv_cache_base = torch.zeros(
+                32,
+                2,
+                local_kv_head_num,
+                config.seq_size_per_block,
+                config.size_per_head,
+                device="cuda",
+                dtype=torch.float8_e4m3fn,
+            )
+            cache.kv_scale_base = torch.ones(
+                32,
+                2 * local_kv_head_num * config.seq_size_per_block,
+                device="cuda",
+                dtype=torch.float32,
+            )
+            return cache
+
+        graph_cache = new_cache()
+        graph = torch.cuda.CUDAGraph()
+        torch.cuda.synchronize()
+        with torch.cuda.graph(graph):
+            graph_output = impl.forward(qkv, graph_cache)
+        torch.cuda.synchronize()
+
+        for sequence_lengths, block_id_offset in (
+            ([63, 65], 4),
+            ([129, 130], 12),
+        ):
+            graph_cache.kv_cache_base.zero_()
+            graph_cache.kv_scale_base.fill_(1)
+            replay_qkv = torch.randn_like(qkv)
+            qkv.copy_(replay_qkv)
+            replay_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                sequence_lengths,
+                config.seq_size_per_block,
+                block_id_offset=block_id_offset,
+            )
+            impl.prepare_cuda_graph(replay_inputs)
+            graph.replay()
+            torch.cuda.synchronize()
+
+            eager_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                sequence_lengths,
+                config.seq_size_per_block,
+                block_id_offset=block_id_offset,
+            )
+            eager_inputs.is_cuda_graph = False
+            eager_impl = PyFlashinferDecodeImpl(config.attn_configs, eager_inputs)
+            eager_cache = new_cache()
+            eager_output = eager_impl.forward(replay_qkv.clone(), eager_cache)
+            torch.cuda.synchronize()
+
+            torch.testing.assert_close(
+                graph_output,
+                eager_output,
+                rtol=0.06,
+                atol=0.04,
+            )
+            torch.testing.assert_close(
+                graph_cache.kv_cache_base,
+                eager_cache.kv_cache_base,
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(
+                graph_cache.kv_scale_base,
+                eager_cache.kv_scale_base,
+                rtol=0,
+                atol=0,
+            )
+
     def test_cuda_core_replay_replans_only_on_page_topology_change(self):
         """CUDA-core replay caches only topology and refreshes graph buffers."""
         config = self._create_config(head_num=32, head_num_kv=32)
@@ -940,6 +1308,616 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
                     v_cache,
                     config.seq_size_per_block,
                 )
+
+
+class _NoReleaseDecodeAttnOp(PyFlashinferDecodeAttnOp):
+    def __del__(self):
+        pass
+
+
+class TestDynamicFp8DecodeUnit(unittest.TestCase):
+    @staticmethod
+    def _config() -> SimpleNamespace:
+        rope_config = RopeConfig()
+        rope_config.style = RopeStyle.Base
+        rope_config.dim = 4
+        rope_config.base = 10000
+        return SimpleNamespace(
+            dtype=torch.bfloat16,
+            kv_cache_dtype=KvCacheDataType.FP8,
+            fp8_kv_cache_mode=2,
+            head_num=4,
+            kv_head_num=2,
+            size_per_head=4,
+            tokens_per_block=32,
+            kernel_tokens_per_block=8,
+            need_rope_kv_cache=True,
+            rope_config=rope_config,
+            max_seq_len=128,
+        )
+
+    def test_mode2_allows_single_token_and_rejects_speculative_decode(self):
+        config = self._config()
+        config.use_mla = False
+        config.use_logn_attn = False
+        config.gen_num_per_cycle = 1
+        _validate_dynamic_fp8_config(config, is_cuda_graph=False)
+
+        config.gen_num_per_cycle = 2
+        with self.assertRaisesRegex(ValueError, "multi-token decode"):
+            _validate_dynamic_fp8_config(config, is_cuda_graph=False)
+
+    def test_mode2_constructs_and_caches_versioned_fa2_direct_scale_jit(self):
+        wrappers = [SimpleNamespace(_fixed_batch_size=0) for _ in range(2)]
+        loaded_module = object()
+        spec = SimpleNamespace(
+            extra_include_dirs=None,
+            build_and_load=mock.Mock(return_value=object()),
+        )
+        generator = mock.Mock(return_value=spec)
+        module_adapter = mock.Mock(return_value=loaded_module)
+        module = (
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha"
+        )
+        with mock.patch(
+            f"{module}.get_py_flashinfer_workspace_buffer",
+            return_value=torch.empty(0),
+        ), mock.patch(
+            f"{module}.BatchDecodeWithPagedKVCacheWrapper",
+            side_effect=wrappers,
+        ) as wrapper_cls, mock.patch(
+            f"{module}.flashinfer_decode.gen_customize_batch_prefill_module",
+            generator,
+        ), mock.patch(
+            f"{module}.flashinfer_decode.get_batch_prefill_jit_module",
+            module_adapter,
+        ), mock.patch.dict(
+            f"{module}._g_dynamic_fp8_jit_modules", clear=True
+        ):
+            op = _NoReleaseDecodeAttnOp(
+                self._config(), SimpleNamespace(is_cuda_graph=False)
+            )
+            cached_op = _NoReleaseDecodeAttnOp(
+                self._config(), SimpleNamespace(is_cuda_graph=False)
+            )
+
+        self.assertTrue(op.use_tensor_core)
+        self.assertEqual(op.q_dtype, torch.bfloat16)
+        self.assertEqual(op.kv_dtype, torch.float8_e4m3fn)
+        self.assertEqual(wrapper_cls.call_count, 2)
+        wrapper_kwargs = wrapper_cls.call_args.kwargs
+        self.assertEqual(wrapper_kwargs["backend"], "fa2")
+        self.assertTrue(wrapper_kwargs["use_tensor_cores"])
+        self.assertNotIn("jit_args", wrapper_kwargs)
+        generator.assert_called_once()
+        spec.build_and_load.assert_called_once()
+        module_adapter.assert_called_once()
+        self.assertIs(op.decode_wrapper._jit_module, loaded_module)
+        self.assertIs(cached_op.decode_wrapper._jit_module, loaded_module)
+        jit_args = generator.call_args.args[1:]
+        self.assertIn("direct_scale_v3", jit_args[0])
+        self.assertIn("q_bfloat16", jit_args[0])
+        self.assertIn("kv_float8_e4m3fn", jit_args[0])
+        self.assertIn("o_bfloat16", jit_args[0])
+        self.assertIn("idx_int32", jit_args[0])
+        self.assertIn("hdq_4_hdv_4", jit_args[0])
+        self.assertEqual(
+            jit_args[1:7],
+            (
+                torch.bfloat16,
+                torch.float8_e4m3fn,
+                torch.bfloat16,
+                torch.int32,
+                4,
+                4,
+            ),
+        )
+        self.assertEqual(jit_args[7], ["kv_scale"])
+        self.assertEqual(jit_args[8], ["float"])
+        self.assertEqual(jit_args[9:11], ([], []))
+        self.assertEqual(jit_args[11], "RtpLlmDynamicFp8Attention<use_custom_mask>")
+        self.assertIn("use_per_token_kv_scale = true", jit_args[12])
+        self.assertIn("RtpLlmDynamicFp8DefaultParams", jit_args[12])
+        self.assertIn("math::rsqrt(float(HEAD_DIM_QK))", jit_args[12])
+        self.assertIn("params.paged_kv.page_size.divmod", jit_args[12])
+        self.assertNotIn("using Base::Base", jit_args[12])
+        self.assertNotIn("physical_page_size", jit_args)
+        self.assertNotIn("subdivision", jit_args)
+
+    @staticmethod
+    def _decode_op() -> _NoReleaseDecodeAttnOp:
+        op = _NoReleaseDecodeAttnOp.__new__(_NoReleaseDecodeAttnOp)
+        op.g_workspace_buffer = torch.empty(0)
+        op.local_head_num = 4
+        op.local_kv_head_num = 2
+        op.head_dim_qk = 4
+        op.dynamic_fp8 = True
+        op.physical_page_size = 32
+        op.seq_size_per_block = 8
+        op.subdivision = 4
+        op.use_tensor_core = True
+        op.dtype = torch.bfloat16
+        op.q_dtype = torch.bfloat16
+        op.kv_dtype = torch.float8_e4m3fn
+        op.enable_cuda_graph = False
+        op._cuda_core_plan_page_indptr_h = None
+        page_indptr = torch.tensor([0, 2, 3], dtype=torch.int32)
+        page_indices = torch.tensor([12, 4, 9, 77], dtype=torch.int32)
+        last_page_len = torch.tensor([8, 1], dtype=torch.int32)
+        op.fmha_params = SimpleNamespace(
+            decode_page_indptr_h=page_indptr,
+            decode_page_indptr_d=page_indptr,
+            page_indice_h=page_indices,
+            page_indice_d=page_indices,
+            paged_kv_last_page_len_h=last_page_len,
+            paged_kv_last_page_len_d=last_page_len,
+        )
+        op.decode_wrapper = SimpleNamespace(plan=mock.Mock(), run=mock.Mock())
+        return op
+
+    def test_direct_scale_plan_and_forward_keep_original_page_ids(self):
+        op = self._decode_op()
+        op._plan_decode_wrapper(SimpleNamespace())
+
+        plan_args = op.decode_wrapper.plan.call_args.args
+        torch.testing.assert_close(
+            plan_args[1], torch.tensor([12, 4, 9], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            op.fmha_params.page_indice_d,
+            torch.tensor([12, 4, 9, 77], dtype=torch.int32),
+        )
+        self.assertEqual(
+            op.decode_wrapper.plan.call_args.kwargs["q_data_type"], torch.bfloat16
+        )
+        self.assertEqual(
+            op.decode_wrapper.plan.call_args.kwargs["kv_data_type"],
+            torch.float8_e4m3fn,
+        )
+
+        q = torch.randn(2, 4, 4, dtype=torch.bfloat16)
+        cache = SimpleNamespace(
+            kv_cache_base=torch.empty(16, 2, 2, 8, 4, dtype=torch.float8_e4m3fn),
+            kv_scale_base=torch.empty(16, 2 * 2 * 8, dtype=torch.float32),
+        )
+        op.decode_wrapper.run.side_effect = lambda query, _, __: query
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "_validate_dynamic_fp8_scale",
+            return_value=cache.kv_scale_base,
+        ) as validate_mock, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "rtp_llm_ops.gather_and_dequantize_fp8_kv_cache",
+            create=True,
+        ) as gather_mock, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "quantize_to_fp8_if_needed",
+            side_effect=AssertionError("unit-scale cast must not run"),
+        ):
+            output = op.forward(q, cache, op.fmha_params)
+
+        torch.testing.assert_close(output, q)
+        validate_mock.assert_called_once_with(cache, 2, 8)
+        gather_mock.assert_not_called()
+        run_args = op.decode_wrapper.run.call_args.args
+        self.assertEqual(run_args[0].dtype, torch.bfloat16)
+        self.assertIs(run_args[1], cache.kv_cache_base)
+        self.assertEqual(run_args[1].dtype, torch.float8_e4m3fn)
+        self.assertIs(run_args[2], cache.kv_scale_base)
+
+    def test_mode2_eager_prepare_uses_device_decode_metadata_fill(self):
+        op = self._decode_op()
+        op.decode_wrapper._fixed_batch_size = 0
+        sequence_lengths = torch.tensor([8, 12], dtype=torch.int32).pin_memory()
+        sequence_lengths_plus_1 = torch.tensor(
+            [9, 13], dtype=torch.int32, device="cuda"
+        )
+        block_table = torch.tensor([[12, 4], [9, 7]], dtype=torch.int32, device="cuda")
+        fill_decode = mock.Mock()
+        op.fmha_params = SimpleNamespace(
+            fill_decode_params_device=fill_decode,
+            fill_params=mock.Mock(side_effect=AssertionError("host fill must not run")),
+            fill_params_mha_device=mock.Mock(
+                side_effect=AssertionError("generic device fill must not run")
+            ),
+            decode_page_indptr_h=torch.tensor([0, 2, 4], dtype=torch.int32),
+            decode_page_indptr_d=torch.tensor(
+                [0, 2, 4], dtype=torch.int32, device="cuda"
+            ),
+            page_indice_h=torch.empty(0, dtype=torch.int32),
+            page_indice_d=block_table.flatten(),
+            paged_kv_last_page_len_h=torch.tensor([1, 5], dtype=torch.int32),
+            paged_kv_last_page_len_d=torch.tensor(
+                [1, 5], dtype=torch.int32, device="cuda"
+            ),
+        )
+        inputs = SimpleNamespace(
+            input_lengths=torch.ones(2, dtype=torch.int32),
+            sequence_lengths=sequence_lengths,
+            sequence_lengths_plus_1_device=sequence_lengths_plus_1,
+            kv_cache_kernel_block_id=block_table.cpu(),
+            kv_cache_kernel_block_id_device=block_table,
+        )
+
+        params = op.prepare(inputs)
+
+        self.assertIs(params, op.fmha_params)
+        fill_decode.assert_called_once_with(
+            sequence_lengths, sequence_lengths_plus_1, block_table, 8
+        )
+        plan_args = op.decode_wrapper.plan.call_args.args
+        self.assertIs(plan_args[0], op.fmha_params.decode_page_indptr_h)
+        self.assertTrue(plan_args[1].is_cuda)
+        self.assertIs(plan_args[2], op.fmha_params.paged_kv_last_page_len_h)
+
+    def test_direct_scale_validates_scale_storage_contract(self):
+        device = torch.device("cuda")
+        payload = torch.empty(16, 2, 2, 8, 4, device=device, dtype=torch.float8_e4m3fn)
+        valid_scale = torch.empty(16, 2 * 2 * 8, device=device, dtype=torch.float32)
+        cache = SimpleNamespace(
+            kv_cache_base=payload,
+            kv_scale_base=valid_scale,
+        )
+        self.assertIs(_validate_dynamic_fp8_scale(cache, 2, 8), valid_scale)
+
+        invalid_cases = (
+            (None, payload, "requires a kv_scale_base tensor"),
+            (
+                torch.empty(16, 32, dtype=torch.float32),
+                payload,
+                "requires kv_scale_base to be CUDA",
+            ),
+            (
+                torch.empty(16, 32, device=device, dtype=torch.float16),
+                payload,
+                "dtype torch.float32",
+            ),
+            (
+                torch.empty(32, 16, device=device, dtype=torch.float32).t(),
+                payload,
+                "contiguous kv_scale_base",
+            ),
+            (
+                valid_scale,
+                torch.empty(16, 2, 2, 8, 4, dtype=torch.float8_e4m3fn),
+                "requires kv_cache_base to be CUDA",
+            ),
+            (
+                torch.empty(16 * 32, device=device, dtype=torch.float32),
+                payload,
+                "shape",
+            ),
+            (
+                torch.empty(16, 31, device=device, dtype=torch.float32),
+                payload,
+                "shape",
+            ),
+        )
+        for scale, case_payload, message in invalid_cases:
+            with self.subTest(message=message):
+                invalid_cache = SimpleNamespace(
+                    kv_cache_base=case_payload,
+                    kv_scale_base=scale,
+                )
+                with self.assertRaisesRegex(ValueError, message):
+                    _validate_dynamic_fp8_scale(invalid_cache, 2, 8)
+
+    def test_mode2_decode_impl_with_rope_matches_base_reference_with_subdivision(
+        self,
+    ):
+        for subdivision in (1, 2, 4):
+            with self.subTest(subdivision=subdivision):
+                self._check_mode2_decode_with_subdivision(subdivision)
+
+    def _check_mode2_decode_with_subdivision(self, subdivision: int):
+        device = torch.device("cuda")
+        torch.manual_seed(2026)
+        harness = BaseAttentionTest()
+        harness.device = device
+        sequence_lengths = [9, 13]
+        kernel_page_size = 4
+        physical_page_size = kernel_page_size * subdivision
+        config = harness._create_config(
+            head_num=4,
+            head_num_kv=2,
+            size_per_head=64,
+            seq_size_per_block=kernel_page_size,
+            data_type="bf16",
+        )
+        config.attn_configs.tokens_per_block = physical_page_size
+        config.attn_configs.kv_cache_dtype = KvCacheDataType.FP8
+        config.attn_configs.fp8_kv_cache_mode = 2
+        config.attn_configs.need_rope_kv_cache = True
+        config.attn_configs.rope_config.style = RopeStyle.Base
+        config.attn_configs.rope_config.dim = 64
+        config.attn_configs.rope_config.base = 10000
+        config.attn_configs.rope_config.max_pos = 128
+        config.attn_configs.max_seq_len = 128
+        inputs = harness._create_attention_inputs_base(
+            len(sequence_lengths), sequence_lengths, kernel_page_size
+        )
+
+        block_table = torch.tensor([[8, 3, 9, 0], [8, 6, 3, 11]], dtype=torch.int32)
+        kernel_page_count = 12
+        inputs.kv_cache_kernel_block_id = block_table
+        inputs.kv_cache_kernel_block_id_device = block_table.to(device)
+
+        impl = PyFlashinferDecodeImpl(config.attn_configs, inputs)
+        torch.testing.assert_close(
+            impl.fmha_params.positions_d[:2].cpu(),
+            torch.tensor([8, 12], dtype=torch.int32),
+        )
+        qkv = torch.randn(
+            2,
+            (4 + 2 * 2) * 64,
+            device=device,
+            dtype=config.attn_configs.dtype,
+        )
+        q_flat, k_flat, v_flat = torch.split(qkv, [4 * 64, 2 * 64, 2 * 64], dim=-1)
+        raw_q = q_flat.reshape(2, 4, 64)
+        raw_k = k_flat.reshape(2, 2, 64)
+        expected_v = v_flat.reshape(2, 2, 64)
+        positions = torch.tensor([8, 12], device=device, dtype=torch.float32)
+        inv_freq = torch.exp(
+            -math.log(10000.0)
+            * torch.arange(0, 64, 2, device=device, dtype=torch.float32)
+            / 64
+        )
+        angles = positions[:, None] * inv_freq[None, :]
+        cos = angles.cos()[:, None, :]
+        sin = angles.sin()[:, None, :]
+
+        def rope_reference(tensor: torch.Tensor) -> torch.Tensor:
+            first = tensor[..., :32].float()
+            second = tensor[..., 32:].float()
+            return torch.cat(
+                [first * cos - second * sin, second * cos + first * sin], dim=-1
+            ).to(tensor.dtype)
+
+        expected_q = rope_reference(raw_q)
+        expected_k = rope_reference(raw_k)
+
+        k_cache = torch.zeros(
+            kernel_page_count,
+            2,
+            kernel_page_size,
+            64,
+            device=device,
+            dtype=config.attn_configs.dtype,
+        )
+        v_cache = torch.zeros_like(k_cache)
+        k_tokens = []
+        v_tokens = []
+        target_pages = []
+        target_offsets = []
+        block_id_list = []
+        history_tokens = {}
+        for batch_idx, sequence_length in enumerate(sequence_lengths):
+            block_ids = block_table[
+                batch_idx, : math.ceil(sequence_length / kernel_page_size)
+            ].tolist()
+            block_id_list.append(block_ids)
+            for position in range(sequence_length - 1):
+                kernel_page = block_ids[position // kernel_page_size]
+                kernel_offset = position % kernel_page_size
+                storage_location = (kernel_page, kernel_offset)
+                if storage_location not in history_tokens:
+                    key = torch.randn(
+                        2, 64, device=device, dtype=config.attn_configs.dtype
+                    )
+                    value = torch.randn_like(key)
+                    history_tokens[storage_location] = (key, value)
+                    k_tokens.append(key)
+                    v_tokens.append(value)
+                    k_cache[kernel_page, :, kernel_offset] = key
+                    v_cache[kernel_page, :, kernel_offset] = value
+                    target_pages.append(kernel_page // subdivision)
+                    target_offsets.append(
+                        kernel_page % subdivision * kernel_page_size + kernel_offset
+                    )
+
+            current_position = sequence_length - 1
+            current_kernel_page = block_ids[current_position // kernel_page_size]
+            current_kernel_offset = current_position % kernel_page_size
+            k_cache[current_kernel_page, :, current_kernel_offset] = expected_k[
+                batch_idx
+            ]
+            v_cache[current_kernel_page, :, current_kernel_offset] = expected_v[
+                batch_idx
+            ]
+
+        cache = LayerKVCache()
+        cache.kv_cache_base = torch.zeros(
+            kernel_page_count,
+            2,
+            2,
+            kernel_page_size,
+            64,
+            device=device,
+            dtype=torch.float8_e4m3fn,
+        )
+        cache.kv_scale_base = torch.ones(
+            kernel_page_count,
+            2 * 2 * kernel_page_size,
+            device=device,
+            dtype=torch.float32,
+        )
+        rtp_llm_ops.quantize_and_write_fp8_kv_cache(
+            torch.stack(k_tokens),
+            torch.stack(v_tokens),
+            cache.kv_cache_base,
+            cache.kv_scale_base,
+            torch.tensor(target_pages, device=device, dtype=torch.int32),
+            torch.tensor(target_offsets, device=device, dtype=torch.int32),
+            physical_page_size,
+            kernel_page_size,
+            subdivision,
+        )
+
+        output = impl.forward(qkv.clone(), cache)
+        scale_view = cache.kv_scale_base.view(kernel_page_count, 2, 2, kernel_page_size)
+        self.assertFalse(torch.equal(scale_view[:, 0], scale_view[:, 1]))
+        restored_k_cache = (
+            cache.kv_cache_base[:, 0].float() * scale_view[:, 0].unsqueeze(-1)
+        ).to(expected_q.dtype)
+        restored_v_cache = (
+            cache.kv_cache_base[:, 1].float() * scale_view[:, 1].unsqueeze(-1)
+        ).to(expected_q.dtype)
+        reference = compute_flashinfer_decode_reference(
+            expected_q,
+            restored_k_cache,
+            restored_v_cache,
+            sequence_lengths,
+            block_id_list,
+            kernel_page_size,
+        )
+        torch.testing.assert_close(output, reference, rtol=0.06, atol=0.04)
+
+        for batch_idx, sequence_length in enumerate(sequence_lengths):
+            position = sequence_length - 1
+            kernel_page = int(
+                block_table[batch_idx, position // kernel_page_size].item()
+            )
+            storage_token = position % kernel_page_size
+            for kv, expected in enumerate((expected_k, expected_v)):
+                restored = cache.kv_cache_base[
+                    kernel_page, kv, :, storage_token
+                ].float() * scale_view[kernel_page, kv, :, storage_token].unsqueeze(-1)
+                torch.testing.assert_close(
+                    restored,
+                    expected[batch_idx].float(),
+                    rtol=0.13,
+                    atol=0.02,
+                )
+
+    def test_impl_uses_one_fused_prepare_before_direct_decode(self):
+        config = self._config()
+        events = []
+        query = torch.randn(2, 4, 4, dtype=torch.bfloat16)
+        qkv = torch.empty(2, 32, dtype=torch.bfloat16)
+        payload = object()
+        scales = object()
+        cache = SimpleNamespace(kv_cache_base=payload, kv_scale_base=scales)
+        decode = SimpleNamespace(
+            set_params=mock.Mock(),
+            prepare=mock.Mock(),
+            prepare_for_cuda_graph_replay=mock.Mock(),
+            forward=mock.Mock(
+                side_effect=lambda *args: events.append("attention") or query
+            ),
+        )
+        fused_prepare = mock.Mock(
+            side_effect=lambda *args: events.append("fused_prepare") or query
+        )
+
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "PyFlashinferDecodeAttnOp",
+            return_value=decode,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "MhaRotaryEmbeddingOp"
+        ) as rope_op, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "KVCacheWriteOp"
+        ) as writer_op, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "FusedRopeKVCacheDecodeOp"
+        ) as legacy_fused_op, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "get_rope_cache_once",
+            return_value=SimpleNamespace(data=None),
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "check_rope_cache",
+            return_value=False,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "_validate_dynamic_fp8_scale",
+            return_value=scales,
+        ), mock.patch.object(
+            rtp_llm_ops,
+            "fused_rope_quantize_and_write_fp8_kv_cache",
+            fused_prepare,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "common.create_write_cache_store_impl",
+            return_value=None,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "common.apply_write_cache_store"
+        ):
+            impl = PyFlashinferDecodeImpl(config, SimpleNamespace())
+            graph_inputs = SimpleNamespace()
+            impl.prepare_cuda_graph(graph_inputs)
+            output = impl.forward(qkv, cache)
+
+        decode.prepare_for_cuda_graph_replay.assert_called_once_with(graph_inputs)
+        rope_op.assert_not_called()
+        writer_op.assert_not_called()
+        legacy_fused_op.assert_not_called()
+        fused_prepare.assert_called_once()
+        self.assertTrue(impl.support_cuda_graph())
+        self.assertIs(output, query)
+        self.assertEqual(events, ["fused_prepare", "attention"])
+        fused_args = fused_prepare.call_args.args
+        self.assertIs(fused_args[0], qkv)
+        self.assertIs(fused_args[1], payload)
+        self.assertIs(fused_args[2], scales)
+        self.assertIs(decode.forward.call_args.args[0], query)
+        self.assertIs(decode.forward.call_args.args[1], cache)
+        self.assertIs(decode.forward.call_args.args[2], impl.fmha_params)
+
+    def test_impl_uses_fused_prepare_with_no_rope_style_when_rope_is_disabled(self):
+        config = self._config()
+        config.need_rope_kv_cache = False
+        qkv = torch.arange(64, dtype=torch.bfloat16).reshape(2, 32)
+        query = qkv[:, :16].reshape(2, 4, 4)
+        payload = object()
+        scales = object()
+        cache = SimpleNamespace(kv_cache_base=payload, kv_scale_base=scales)
+        decode = SimpleNamespace(
+            set_params=mock.Mock(),
+            prepare=mock.Mock(),
+            forward=mock.Mock(side_effect=lambda query, *_: query),
+        )
+        fused_prepare = mock.Mock(return_value=query)
+
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "PyFlashinferDecodeAttnOp",
+            return_value=decode,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "MhaRotaryEmbeddingOp"
+        ) as rope_op, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "KVCacheWriteOp"
+        ) as writer_op, mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "_validate_dynamic_fp8_scale",
+            return_value=scales,
+        ), mock.patch.object(
+            rtp_llm_ops,
+            "fused_rope_quantize_and_write_fp8_kv_cache",
+            fused_prepare,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "common.create_write_cache_store_impl",
+            return_value=None,
+        ), mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha."
+            "common.apply_write_cache_store"
+        ):
+            impl = PyFlashinferDecodeImpl(config, SimpleNamespace())
+            output = impl.forward(qkv, cache)
+
+        rope_op.assert_not_called()
+        writer_op.assert_not_called()
+        fused_prepare.assert_called_once()
+        self.assertEqual(fused_prepare.call_args.args[10].style, RopeStyle.No)
+        self.assertIsNone(fused_prepare.call_args.args[11])
+        self.assertIs(output, query)
 
 
 class TestPyFlashinferDecodeAttnOpFP8(TestPyFlashinferDecodeAttnOp):

--- a/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
@@ -9,7 +9,7 @@ import librtp_compute_ops
 import libth_transformer_config
 import torch
 import typing
-__all__: list[str] = ['FlashInferMlaAttnParams', 'GroupTopKOp', 'SelectTopkOp', 'SparseMlaParams', 'XQAAttnOp', 'XQAParams', 'allocate_shared_buffer', 'concat_and_cache_mla', 'cp_gather_and_upconvert_fp8_kv_cache', 'cp_gather_indexer_k_quant_cache', 'cublas_gemm_bf16_bf16_fp32', 'cuda_graph_copy_large2small', 'cuda_graph_copy_small2large', 'cutlass_scaled_fp4_mm', 'debug_kernel', 'dispose_communicator', 'dsv4_top_k_per_row_prefill', 'embedding', 'embedding_bert', 'fast_topk_transform_fused', 'fast_topk_transform_ragged_fused', 'fast_topk_v2', 'fast_topk_v2_variable', 'fill_mla_params', 'fused_add_layernorm', 'fused_add_rmsnorm', 'fused_qk_rmsnorm', 'indexer_k_quant_and_cache', 'init_communicator', 'layernorm', 'mla_k_merge', 'moe_post_reorder', 'moe_pre_reorder', 'moe_topk_softmax', 'open_ipc_handle', 'per_tensor_quant_fp8', 'per_token_group_quant_fp8', 'per_token_group_quant_fp8_v2', 'per_token_group_quant_int8', 'per_token_quant_fp8', 'prepare_sparse_mla_params', 'register_buffer_to_communicator', 'reuse_kv_cache_indexed_batched', 'rmsnorm', 'scaled_fp4_experts_quant', 'scaled_fp4_quant', 'silu_and_mul', 'silu_and_mul_scaled_fp4_experts_quant', 'trt_fp8_quantize_128', 'trt_fp8_quantize_128_inplace', 'userbuffers_recv', 'userbuffers_ring_all_gather', 'userbuffers_send']
+__all__: list[str] = ['FlashInferMlaAttnParams', 'GroupTopKOp', 'SelectTopkOp', 'SparseMlaParams', 'XQAAttnOp', 'XQAParams', 'allocate_shared_buffer', 'concat_and_cache_mla', 'cp_gather_and_upconvert_fp8_kv_cache', 'cp_gather_indexer_k_quant_cache', 'cublas_gemm_bf16_bf16_fp32', 'cuda_graph_copy_large2small', 'cuda_graph_copy_small2large', 'cutlass_scaled_fp4_mm', 'debug_kernel', 'dispose_communicator', 'dsv4_top_k_per_row_prefill', 'embedding', 'embedding_bert', 'fast_topk_transform_fused', 'fast_topk_transform_ragged_fused', 'fast_topk_v2', 'fast_topk_v2_variable', 'fill_mla_params', 'fused_add_layernorm', 'fused_add_rmsnorm', 'fused_qk_rmsnorm', 'fused_rope_quantize_and_write_fp8_kv_cache', 'gather_and_dequantize_fp8_kv_cache', 'indexer_k_quant_and_cache', 'init_communicator', 'layernorm', 'mla_k_merge', 'moe_post_reorder', 'moe_pre_reorder', 'moe_topk_softmax', 'open_ipc_handle', 'per_tensor_quant_fp8', 'per_token_group_quant_fp8', 'per_token_group_quant_fp8_v2', 'per_token_group_quant_int8', 'per_token_quant_fp8', 'prepare_sparse_mla_params', 'quantize_and_write_fp8_kv_cache', 'register_buffer_to_communicator', 'reuse_kv_cache_indexed_batched', 'rmsnorm', 'scaled_fp4_experts_quant', 'scaled_fp4_quant', 'silu_and_mul', 'silu_and_mul_scaled_fp4_experts_quant', 'trt_fp8_quantize_128', 'trt_fp8_quantize_128_inplace', 'userbuffers_recv', 'userbuffers_ring_all_gather', 'userbuffers_send']
 
 
 class FlashInferMlaAttnParams(librtp_compute_ops.ParamsBase):
@@ -22,6 +22,10 @@ class FlashInferMlaAttnParams(librtp_compute_ops.ParamsBase):
     def fill_decode_cuda_graph_params(self, sequence_lengths_plus_1_d: torch.Tensor, kv_cache_block_id_device: torch.Tensor, seq_size_per_block: int) -> None:
         """
         Update FlashInfer decode metadata on device during CUDA graph replay
+        """
+    def fill_decode_params_device(self, sequence_lengths_h: torch.Tensor, sequence_lengths_plus_1_d: torch.Tensor, kv_cache_block_id_device: torch.Tensor, seq_size_per_block: int) -> None:
+        """
+        Fill eager decode metadata from host lengths and a device block table.
         """
     def fill_params_mha_device(self, prefix_lengths: torch.Tensor, sequence_lengths: torch.Tensor, input_lengths: torch.Tensor, kv_cache_block_id_device: torch.Tensor, seq_size_per_block: int, forbid_realloc: bool = False) -> None:
         """
@@ -303,6 +307,10 @@ def get_cutlass_batched_moe_mm_data(expert_offsets: torch.Tensor, problem_sizes1
     ...
 def get_cutlass_moe_mm_without_permute_info(topk_ids: torch.Tensor, expert_offsets: torch.Tensor, problem_sizes1: torch.Tensor, problem_sizes2: torch.Tensor, num_experts: int, n: int, k: int, problem_1_swap_ab: bool, problem_2_swap_ab: bool, blockscale_offsets: torch.Tensor | None = None) -> None:
     ...
+def gather_and_dequantize_fp8_kv_cache(kv_cache: torch.Tensor, kv_scales: torch.Tensor, source_kernel_page_ids: torch.Tensor, output: torch.Tensor, physical_page_size: int, kernel_page_size: int, subdivision: int) -> None:
+    """
+    Gather kernel pages from persistent FP8 KV cache and dequantize with per-row scales.
+    """
 def indexer_k_quant_and_cache(k: torch.Tensor, kv_cache: torch.Tensor, slot_mapping: torch.Tensor, quant_block_size: int, scale_fmt: str) -> None:
     """
     Indexer K quantization and cache kernel
@@ -351,6 +359,12 @@ def per_token_group_quant_int8(input: torch.Tensor, output_q: torch.Tensor, outp
     """
 def per_token_quant_fp8(input: torch.Tensor, output_q: torch.Tensor, output_s: torch.Tensor) -> None:
     ...
+def fused_rope_quantize_and_write_fp8_kv_cache(qkv: torch.Tensor, kv_cache: torch.Tensor, kv_scales: torch.Tensor, batch_indices: torch.Tensor, positions: torch.Tensor, page_indptr: torch.Tensor, page_indices: torch.Tensor, num_q_heads: int, num_kv_heads: int, kernel_page_size: int, rope_config: libth_transformer_config.RopeConfig, cos_sin_cache: torch.Tensor | None = None) -> torch.Tensor:
+    """Apply RoPE to packed QKV and dynamically quantize/write paged FP8 K/V."""
+def quantize_and_write_fp8_kv_cache(k: torch.Tensor, v: torch.Tensor, kv_cache: torch.Tensor, kv_scales: torch.Tensor, target_physical_page_ids: torch.Tensor, token_offsets: torch.Tensor, physical_page_size: int, kernel_page_size: int, subdivision: int) -> None:
+    """
+    Dynamically quantize post-RoPE K/V and write persistent paged FP8 cache rows.
+    """
 def cublas_gemm_bf16_bf16_fp32(input: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     """BF16 x BF16 GEMM with FP32 accumulation and FP32 output."""
 def prepare_sparse_mla_params(attention_inputs: librtp_compute_ops.PyAttentionInputs, seq_size_per_block: int) -> SparseMlaParams:

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -83,6 +83,7 @@ class ArpcConfig:
         ...
 class AttentionConfigs:
     dtype: torch.dtype
+    fp8_kv_cache_mode: int
     fuse_qkv_add_bias: bool
     head_num: int
     indexer_head_dim: int

--- a/rtp_llm/server/server_args/kv_cache_group_args.py
+++ b/rtp_llm/server/server_args/kv_cache_group_args.py
@@ -1,4 +1,18 @@
+import argparse
+
 from rtp_llm.server.server_args.util import str2bool
+
+
+def _parse_fp8_kv_cache_mode(value: str) -> int:
+    try:
+        mode = int(value)
+    except (TypeError, ValueError) as error:
+        raise argparse.ArgumentTypeError(
+            f"must be one of 0, 1, or 2, got {value!r}"
+        ) from error
+    if mode not in (0, 1, 2):
+        raise argparse.ArgumentTypeError(f"must be one of 0, 1, or 2, got {value!r}")
+    return mode
 
 
 def init_kv_cache_group_args(parser, kv_cache_config):
@@ -58,16 +72,16 @@ def init_kv_cache_group_args(parser, kv_cache_config):
         "--fp8_kv_cache",
         env_name="FP8_KV_CACHE",
         bind_to=(kv_cache_config, "fp8_kv_cache"),
-        type=int,
-        help="是否开启FP8的KV_CACHE",
+        type=_parse_fp8_kv_cache_mode,
+        help="FP8 KV cache 模式：0=关闭，1=legacy unit-scale，2=dynamic per-token-per-local-KV-head",
     )
     # compatible with old version
     kv_cache_group.add_argument(
         "--blockwise_use_fp8_kv_cache",
         env_name="BLOCKWISE_USE_FP8_KV_CACHE",
         bind_to=(kv_cache_config, "fp8_kv_cache"),
-        type=int,
-        help="是否开启FP8的KV_CACHE",
+        type=_parse_fp8_kv_cache_mode,
+        help="[deprecated] FP8 KV cache 模式：0=关闭，1=legacy unit-scale，2=dynamic per-token-per-local-KV-head",
     )
     kv_cache_group.add_argument(
         "--kv_cache_mem_mb",

--- a/rtp_llm/tools/api/model_basic_info_analyzer.py
+++ b/rtp_llm/tools/api/model_basic_info_analyzer.py
@@ -178,7 +178,7 @@ def _load_as_ft_style(
     quantization_config.quantization = quantization
 
     kv_cache_config = KVCacheConfig()
-    kv_cache_config.fp8_kv_cache = int(env_params.get("FP8_KV_CACHE", "0")) == 1
+    kv_cache_config.fp8_kv_cache = int(env_params.get("FP8_KV_CACHE", "0"))
 
     build_model_config(
         config,

--- a/rtp_llm/tools/api/model_size_evaluator_api.py
+++ b/rtp_llm/tools/api/model_size_evaluator_api.py
@@ -59,7 +59,7 @@ def eval_model_size(env_params, model_type, model_path, ptuning_path):
     quantization_config.quantization = quantization
 
     kv_cache_config = KVCacheConfig()
-    kv_cache_config.fp8_kv_cache = int(env_params.get("FP8_KV_CACHE", "0")) == 1
+    kv_cache_config.fp8_kv_cache = int(env_params.get("FP8_KV_CACHE", "0"))
 
     build_model_config(
         config,


### PR DESCRIPTION
## Summary
- Support Qwen3.5 interleaved MRoPE FlashInfer Prefill with FP8 KV cache mode1 on SM120, including Ragged, Paged, and Hybrid paths.
- Add FP8 KV cache mode2 with per-token, per-KV-head dynamic quantization scales for FlashInfer Prefill and Decode.
- Preserve existing TRT, regular RoPE, Decode, linear-attention, and non-FP8 behavior while preventing duplicate KV-cache writes.

## Usage
- Qwen3.5 normally uses `--fp8_kv_cache 1`; this is the supported unit-scale FP8 KV path for interleaved MRoPE.
- Use `--fp8_kv_cache 2` for per-token dynamic FP8 KV quantization on supported non-MRoPE paths.
- For local PD separation, use `--cache_store_rdma_mode 0 --use_local 1`; the validated Qwen3.5 setup also uses `--seq_size_per_block 2048`.

## Test plan
- [x] SM120 FlashInfer Ragged, Paged, and Hybrid Prefill tests
- [x] FlashInfer Decode and FP8 KV quantization tests
- [x] Two-GPU Qwen3.5-9B local PD smoke with mode1 and prefix-cache reuse
- [x] CUDA Graph mode0/mode1 timeline validation
- [x] Re-run the complete targeted suite after the final upstream rebase