### PR TITLE
fix(dsv4/fp8): import `suppress` so FP8 indexer prefill cleanup stops masking the real error

### DIFF
--- a/rtp_llm/models_py/modules/dsv4/fp8/indexer.py
+++ b/rtp_llm/models_py/modules/dsv4/fp8/indexer.py
@@ -22,6 +22,7 @@ What this class does NOT do — by design:
 from __future__ import annotations
 
 import os
+from contextlib import suppress
 from typing import Any, Callable, Dict, NamedTuple, Optional
 
 import torch


### PR DESCRIPTION
### What

`rtp_llm/models_py/modules/dsv4/fp8/indexer.py` uses `suppress(Exception)` in two
places but never imports it:

| line | context |
|---|---|
| 515 | inside `except Exception:` in `_gather_prefill_k_cache`, right before `raise` |
| 543 | the whole body of `_discard_prefill_k_cache_gather` |

```python
from __future__ import annotations

import os
from typing import Any, Callable, Dict, NamedTuple, Optional
```

`contextlib` never appears in the file. `pyflakes` on current `main`:

```
rtp_llm/models_py/modules/dsv4/fp8/indexer.py:515:26: undefined name 'suppress'
rtp_llm/models_py/modules/dsv4/fp8/indexer.py:543:14: undefined name 'suppress'
```

### Why it matters

Both uses sit on error/cleanup paths, so the missing import turns a real failure
into a misleading `NameError` and skips the cleanup it was guarding.

`_discard_prefill_k_cache_gather` is called from two `finally:` blocks
(`indexer.py:1190` and `indexer.py:1398`). An exception raised inside `finally:`
*replaces* the exception being propagated, so whenever a prefill fails while a CP
all-gather handle is still live, the caller never sees the actual error — and the
assembler handle is leaked because `discard_assemble_indexer_k_async` is never
reached.

The `except Exception:` handler at 511-517 has the same shape: the
`suppress`-guarded discard is supposed to run before the `raise` re-raises the
original `prepare_assemble_indexer_k_async` failure; instead the handler itself
dies with `NameError`.

### Verification

The two methods were lifted verbatim out of `main` with `ast.get_source_segment`
and driven with a stub assembler (no GPU needed), before and after the import:

```
### UNPATCHED (upstream main)
[1] direct call  Indexer._discard_prefill_k_cache_gather(pending)
    -> NameError: name 'suppress' is not defined
[2] the real shape: forward()'s `finally:` (L1190 / L1398)
    -> caller sees NameError: name 'suppress' is not defined
    cleanup actually reached the assembler: False

### PATCHED  (from contextlib import suppress)
[1] direct call  Indexer._discard_prefill_k_cache_gather(pending)
    -> returned normally; assembler cleanup attempted: 1
[2] the real shape: forward()'s `finally:` (L1190 / L1398)
    -> caller sees RuntimeError: fp8_mqa_indexer_score: DeepGEMM kernel launch failed
    cleanup actually reached the assembler: True
```

### Fix

One import line, matching how the sibling module in the same package already does
it (`rtp_llm/models_py/modules/dsv4/fp8/attention.py:19`:
`from contextlib import contextmanager, suppress`), placed in isort order between
`import os` and the `typing` import.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
