### PR TITLE
fix: complete SCR template lifecycle and defer engine computation

### DIFF
--- a/docs/SCR_DEFERRED_ENGINE.md
+++ b/docs/SCR_DEFERRED_ENGINE.md
@@ -1,0 +1,9 @@
+# Deferred engine startup for SCR templates
+
+A pre-service template initializes model weights, warmup, KV cache, executor and scheduler before the checkpoint barrier. The normal engine computation loop starts only after template release, through LocalRpcServer::startDeferredServices. This applies to every rank, including ranks without a TP broadcaster.
+
+Deferring network listeners alone is insufficient for Decode with DP greater than one: the background scheduler can submit dummy streams and GPU kernels even when no client request is accepted. A CUDA synchronization at barrier arrival does not prevent subsequent submissions.
+
+Normal startup keeps its existing immediate loop start. Repeated release must not create another thread, and aborting a prepared template must safely stop an engine whose loop never started.
+
+Validation target: //rtp_llm/cpp/normal_engine/test:deferred_engine_start_test (CUDA). It checks stop-before-start and one-time release followed by generation. The live acceptance must additionally verify Decode DP2 dump/restore and a real PD request with correlated KV transfer, including cross-node restore. Unit tests and compilation do not establish that acceptance.

--- a/docs/scr_runtime_fixup.md
+++ b/docs/scr_runtime_fixup.md
@@ -1,0 +1,84 @@
+# SCR 运行状态修正与同类问题排查
+
+本补丁基于开源提交 `1e3627051f17eedb09c49b14037b82e277052c99`。修复范围是进程运行身份及其已知消费者；本地验证通过不代表完整镜像或真实跨机 restore 已通过。
+
+## 问题与执行顺序
+
+CRIU 恢复的内存包含 seed 的环境变量、单例、配置副本、连接和文件描述符。构造函数通常不会重新执行。仅更新环境变量，也不会自动修正已经派生出来的成员字段。
+
+原 C++ Logger 构造时读取 `GetDefaultIp(ip_)`，随后一直用这个字段生成前缀。最小复现保留 Logger 对象，把网络地址由 `192.0.2.10` 改成 `.20`，下一条日志仍然输出 `.10`。
+
+统一入口位于 [scr_runtime_fixup.py](../rtp_llm/utils/scr_runtime_fixup.py)：
+
+```text
+Epsilon 屏障成功返回
+  → fixup_runtime_after_restore(generation, lifecycle)
+      → 每次读取恢复输入，校验支持的字段
+      → 获取本轮 Pod IP，更新进程环境
+      → 刷新 C++ Logger 和已加载的 HippoHelper 身份缓存
+      → lifecycle.restore_fixup：RPC 地址、前端身份等组件修正
+  → lifecycle.release_template：启动指标等延迟组件
+  → 启动服务监听和 NormalEngine 循环
+```
+
+入口也覆盖 seed 在 checkpoint 后继续运行的情况；不依赖可能被 dump 保存的 SCR_PHASE 判断是否应跳过修正。普通非模板路径保持原逻辑。每次恢复都重新读取输入，即使多次恢复使用同一个 checkpoint generation，也不跳过。记录的上轮身份仅供消费者和审计使用，不作为下轮发现地址的输入。
+
+输入、原生接口或组件 fixup 失败都会抛错，正常 release 不会执行；原有 abort 清理逻辑仍会运行。这不是所有组件状态都能回滚的事务。修正期间失败的进程不能被作为可服务的成功 restore 验收。
+
+## Logger 的修复
+
+[Logger.cc](../rtp_llm/cpp/utils/Logger.cc) 新增 `Logger::refreshRuntimeIdentity(ip)`，通过 [原生绑定](../rtp_llm/cpp/pybind/init.cc) 暴露 `refresh_logger_after_scr`。
+
+- 每个进程使用一个不可变 IP 快照，通过原子 shared_ptr 读写发布，避免与并发日志线程直接读写同一个 string。
+- engine、query access、stack trace 等已有 Logger，以及恢复后延迟创建的 Logger 都读取同一个快照；普通和 trace 前缀均覆盖。
+- 不重建 appender、不覆盖旧日志、不改变 rank；不带前缀的原始 access 日志格式保持原样。
+- CPU/frontend 进程不会为了日志主动加载 CUDA 扩展；已加载但缺少新接口的旧 native 库会明确失败。因此交付必须使用匹配的 Python 与 native 构建，不能只热补 Python。
+
+## 后续 restore env 文件的接入点
+
+`register_restore_env_provider(provider)` 注册进程级回调。回调接收 `generation`，在每次 fixup 时读取平台提供的文件并返回 `Mapping[str, str | None]`。也可以在直接调用统一函数时传入 `restore_env` 映射，用于测试或明确的集成入口。
+
+目前没有定义文件路径、格式，也没有假设该文件已经存在。接入时必须：
+
+1. 在每个参与进程的屏障之前注册 reader，文件内容在恢复后读取，不在 seed 中预读缓存。
+2. reader 校验恢复输入与当前 Pod / 本次恢复的绑定关系，拒绝过期文件；平台原子发布完整文件。相同 checkpoint generation 可以被重复恢复，不能仅凭 generation 相同认定文件新鲜。
+3. 从完整环境中选择已支持字段，作为数据解析，不能 shell `source`。
+4. 当前支持 RequestedIP、HIPPO_SLAVE_IP、HIPPO_ROLE、HIPPO_ROLE_SHORT_NAME、HIPPO_APP、HIPPO_SERVICE_NAME、kmonitorSinkAddress、kmonitorPort。None 删除对应 seed 环境值；例如删除旧短 role，允许新的 HIPPO_ROLE 生效。新增字段必须同时检查它的派生缓存和使用者。
+5. 明确提供的 RequestedIP 作为当前 Pod 地址；未提供或显式删除时重新解析当前网络身份，绝不回退到旧 RequestedIP。当前 Python 外部地址契约为非 loopback IPv4。
+
+未提供 HIPPO_SLAVE_IP 时无法从 Pod IP 推导宿主机 IP；代码保留现有环境并记录其新鲜度未验证。该问题需要平台文件输入后才能闭环。GPU 拓扑、模型参数、凭证、路径和 SCR 控制变量不在这个输入接口的覆盖范围。
+
+## 同类状态排查
+
+以下结论来自此基线代码检查，未使用新的线上运行结果替代证明。
+
+| 状态 | 当前机制与本次处理 | 仍需关注 |
+| --- | --- | --- |
+| C++ Logger.ip_ | 本次改为全进程共享、显式刷新的身份快照 | 完整 native 镜像和实际日志验收待做 |
+| Python HippoHelper 类级 host/container/role/app/group | 已有刷新方法，本次在统一入口先刷新；后续刷新复用本轮 Pod 身份 | host 等环境输入仍需平台提供；app_workdir 属于路径语义，未开放修改 |
+| native Kmonitor 的 RequestedIP、sink、标签 | 已有暂停/重建/发布时刷新机制；本次确保先应用恢复环境，并避免重新解析覆盖明确提供的 Pod IP | HIPPO_SLAVE_IP、kmonitorSinkAddress 不刷新时仍可能连旧宿主机 |
+| BackendRPCServerVisitor.source_ip | 构造时复制 server_config.ip；本次把身份刷新从 local-comm 扩展到所有走此模板入口的拓扑 | 地址成员仍由 endpoint manifest 决定；不把请求来源 IP 当作 rank 地址 |
+| Cache-store 对外地址与本机 loopback 通信 | 本次让 local-comm 的对外广告复用同一轮 Pod 身份；显式 manifest 地址保留 | 验收继续要求实际跨 Pod KV 传输 |
+| RemoteRpcServer.process_id_ / peer / cache-store | 现有代码延迟到 release 才读取 IP/PID、初始化 peer 和 transport | 不等于任意已运行通信对象都支持重建 |
+| ServerConfig.ip、DistributedServer.worker_info / TCPStore / NCCL 配置 | 多处启动时缓存；现有模板路径通过 endpoint manifest 和限定的 loopback 模式处理主要服务地址 | 不能把 manifest 更新等同于现存 TCPStore/NCCL 通信器都已重建；多节点和运行中 checkpoint 需要单独验证 |
+| HostService / VipServerWrapper.hosts / MasterService 路由快照与线程 | 构造阶段会发现地址并缓存，MasterService 创建刷新线程；本轮未看到这些类自身的完整模板 prepare/fixup/release 实现 | 明确列为后续审计项；周期刷新不能代替恢复前暂停、恢复后刷新、就绪门禁 |
+| MasterClient._channels | 按 target 缓存异步 gRPC channel，惰性创建 | seed 未接流量可减少捕获连接；运行中 checkpoint 必须处理已有 channel 的关闭/重建 |
+| GrammarValidator 沙箱池 | 现有 prepare 清理子进程与连接、release 恢复池目标 | 属于资源生命周期修复，不能用 env/string 刷新替代 |
+
+## 验证与交付界限
+
+新增两组可在 CPU 主机运行的测试：
+
+```bash
+python -m unittest rtp_llm.utils.test.scr_native_logger_test rtp_llm.utils.test.scr_runtime_fixup_test -v
+```
+
+native 测试编译真实 Logger.cc/Logger.h，alog/autil 使用明确的测试替身；检查旧实例、延迟创建实例、连续两次身份变化、trace 前缀、非法输入和并发读写。它不验证真实 alog 文件句柄、pybind 动态加载或 CRIU。
+
+Python 测试通过真实模板入口验证顺序、重复恢复、环境字段校验与删除、旧 native 拒绝、失败阻止正常 release，以及指标 / KV / 前端身份的一致性。原有 Kmonitor、local-comm 和生命周期测试纳入本地回归。
+
+本次核心回归 36 项通过，Python 语法、文档本地链接和 `git diff --check` 通过。测试使用独立的 `../fixup-test-venv`，补充了仓库锁定的 thrift 0.20.0，没有修改全局依赖。
+
+原有 `scr_template_utils_test.test_before_callback_uses_captured_device` 因 `_FakeEpsilon` 缺少 `is_available` 失败，已在未修改的基线独立复现；未修改该测试。涉及真实配置对象的 endpoint 测试依赖本机缺少的 libth_transformer，不能作为本地已通过项目。
+
+完整交付还需：构建匹配 Python/native 的镜像，重新生成 seed，做跨机、同机多次及 worker-kill 后恢复。用同一 attempt 的 UID/CID、restore 边界之后新写日志、Request ID 和真实 peer IP 关联证据。严格要求新日志使用新 Pod IP，检查所有 rank；同时检查实际 Kmonitor sink/tag 和业务输出，不能再仅靠 seed IP 别名选择日志宣称 Logger 已修复。

--- a/docs/scr_runtime_fixup.md
+++ b/docs/scr_runtime_fixup.md
@@ -34,17 +34,28 @@ Epsilon 屏障成功返回
 - 不重建 appender、不覆盖旧日志、不改变 rank；不带前缀的原始 access 日志格式保持原样。
 - CPU/frontend 进程不会为了日志主动加载 CUDA 扩展；已加载但缺少新接口的旧 native 库会明确失败。因此交付必须使用匹配的 Python 与 native 构建，不能只热补 Python。
 
-## 后续 restore env 文件的接入点
+## Restore env 文件与缺失降级
 
-`register_restore_env_provider(provider)` 注册进程级回调。回调接收 `generation`，在每次 fixup 时读取平台提供的文件并返回 `Mapping[str, str | None]`。也可以在直接调用统一函数时传入 `restore_env` 映射，用于测试或明确的集成入口。
+默认在每次屏障成功返回后的 fixup 中读取 `/etc/scr/envs.json`。不在 import、seed 初始化或第一次恢复时缓存文件内容，也不要求每个参与进程额外注册 reader。
 
-目前没有定义文件路径、格式，也没有假设该文件已经存在。接入时必须：
+目前按 JSON 对象接入，支持完整环境对象，从中选择已有修复契约允许的字段：
 
-1. 在每个参与进程的屏障之前注册 reader，文件内容在恢复后读取，不在 seed 中预读缓存。
-2. reader 校验恢复输入与当前 Pod / 本次恢复的绑定关系，拒绝过期文件；平台原子发布完整文件。相同 checkpoint generation 可以被重复恢复，不能仅凭 generation 相同认定文件新鲜。
-3. 从完整环境中选择已支持字段，作为数据解析，不能 shell `source`。
-4. 当前支持 RequestedIP、HIPPO_SLAVE_IP、HIPPO_ROLE、HIPPO_ROLE_SHORT_NAME、HIPPO_APP、HIPPO_SERVICE_NAME、kmonitorSinkAddress、kmonitorPort。None 删除对应 seed 环境值；例如删除旧短 role，允许新的 HIPPO_ROLE 生效。新增字段必须同时检查它的派生缓存和使用者。
-5. 明确提供的 RequestedIP 作为当前 Pod 地址；未提供或显式删除时重新解析当前网络身份，绝不回退到旧 RequestedIP。当前 Python 外部地址契约为非 loopback IPv4。
+```json
+{
+  "RequestedIP": "192.0.2.20",
+  "HIPPO_SLAVE_IP": "192.0.2.200",
+  "HIPPO_ROLE": "restored-role",
+  "HIPPO_ROLE_SHORT_NAME": null
+}
+```
+
+- 文件不存在（包括父目录不存在）时返回空更新，继续原有降级流程：从当前网络重新发现 Pod IP，其他环境值保留，然后执行组件 fixup 和正常 release。不会因为缺少文件而直接使 restore 失败；网络发现等原有步骤仍须成功。
+- 文件存在但 JSON/UTF-8 损坏、根节点不是对象、支持字段值非法，或者权限/读取错误，均抛错，阻止正常 release。空文件不是“文件不存在”，不能静默吞掉部分写入。
+- 当前支持 RequestedIP、HIPPO_SLAVE_IP、HIPPO_ROLE、HIPPO_ROLE_SHORT_NAME、HIPPO_APP、HIPPO_SERVICE_NAME、kmonitorSinkAddress、kmonitorPort。其他字段不应用，避免把 GPU 拓扑、SCR 控制变量等未经修复的派生状态一起修改。`null` 删除对应 seed 环境值；不出现的字段保留原值。
+- 明确提供的 RequestedIP 作为当前 Pod 地址；未提供或为 `null` 时重新解析当前网络身份，绝不回退到旧 RequestedIP。当前 Python 外部地址契约为非 loopback IPv4。
+- 平台必须为目标容器原子发布本次恢复的文件，并确保 seed 文件不会被误用。这个扁平 JSON 对象没有 Pod UID/attempt 字段，reader 不能独立认证文件的新鲜度；重新读取仅防止进程缓存，不代替平台的挂载/发布保证。相同 checkpoint generation 可重复恢复，不用它跳过读取。
+
+输入优先级是：显式 `restore_env`（包括空对象）→ 已注册的自定义 provider → 默认文件 reader。`register_restore_env_provider(provider)` 仍可注册进程级回调，在每次 fixup 时调用；传 `None` 恢复默认文件读取。需要不读文件的调用者可以明确传 `restore_env={}`，或注册返回空映射的 provider。自定义 provider 继续负责它自身协议的身份/新鲜度验证。
 
 未提供 HIPPO_SLAVE_IP 时无法从 Pod IP 推导宿主机 IP；代码保留现有环境并记录其新鲜度未验证。该问题需要平台文件输入后才能闭环。GPU 拓扑、模型参数、凭证、路径和 SCR 控制变量不在这个输入接口的覆盖范围。
 
@@ -67,17 +78,32 @@ Epsilon 屏障成功返回
 
 ## 验证与交付界限
 
-新增两组可在 CPU 主机运行的测试：
+可在 CPU 主机运行的直接回归：
 
 ```bash
-python -m unittest rtp_llm.utils.test.scr_native_logger_test rtp_llm.utils.test.scr_runtime_fixup_test -v
+python -m unittest rtp_llm.utils.test.scr_native_logger_test rtp_llm.utils.test.scr_runtime_fixup_test rtp_llm.utils.test.scr_restore_env_file_test -v
 ```
 
 native 测试编译真实 Logger.cc/Logger.h，alog/autil 使用明确的测试替身；检查旧实例、延迟创建实例、连续两次身份变化、trace 前缀、非法输入和并发读写。它不验证真实 alog 文件句柄、pybind 动态加载或 CRIU。
 
 Python 测试通过真实模板入口验证顺序、重复恢复、环境字段校验与删除、旧 native 拒绝、失败阻止正常 release，以及指标 / KV / 前端身份的一致性。原有 Kmonitor、local-comm 和生命周期测试纳入本地回归。
 
-本次核心回归 36 项通过，Python 语法、文档本地链接和 `git diff --check` 通过。测试使用独立的 `../fixup-test-venv`，补充了仓库锁定的 thrift 0.20.0，没有修改全局依赖。
+文件 reader 新增 12 项回归：缺文件正常 release、屏障后读取、同 generation 替换文件重读、第二次恢复文件消失时降级、完整环境过滤、null 删除、空对象、损坏/非法输入阻止 release、权限错误、自定义 provider 与显式输入优先级、普通启动不读文件。
+
+接入默认文件 reader 后，本次核心回归 48 项通过（含新增 12 项），Python 语法、文档本地链接和 `git diff --check` 通过。测试使用原有独立的 `../fixup-test-venv`，没有修改全局依赖。完整核心命令：
+
+```bash
+../fixup-test-venv/bin/python -m unittest \
+  rtp_llm.utils.test.scr_restore_env_file_test \
+  rtp_llm.utils.test.scr_runtime_fixup_test \
+  rtp_llm.utils.test.scr_native_logger_test \
+  rtp_llm.utils.test.scr_kmonitor_lifecycle_test \
+  rtp_llm.utils.test.scr_local_comm_test \
+  rtp_llm.utils.test.scr_template_lifecycle_test \
+  rtp_llm.utils.test.scr_advertise_ip_test -v
+```
+
+额外尝试的 scr_pd_advertisement_test 在导入配置时触发 rtp_llm.ops.find_upper_so 的父目录递归扫描，已中断本次扫描；它未执行到断言，不计入通过项，也没有修改该测试或其依赖代码。
 
 原有 `scr_template_utils_test.test_before_callback_uses_captured_device` 因 `_FakeEpsilon` 缺少 `is_available` 失败，已在未修改的基线独立复现；未修改该测试。涉及真实配置对象的 endpoint 测试依赖本机缺少的 libth_transformer，不能作为本地已通过项目。
 

--- a/docs/scr_runtime_fixup.md
+++ b/docs/scr_runtime_fixup.md
@@ -71,7 +71,8 @@ Epsilon 屏障成功返回
 | BackendRPCServerVisitor.source_ip | 构造时复制 server_config.ip；本次把身份刷新从 local-comm 扩展到所有走此模板入口的拓扑 | 地址成员仍由 endpoint manifest 决定；不把请求来源 IP 当作 rank 地址 |
 | Cache-store 对外地址与本机 loopback 通信 | 本次让 local-comm 的对外广告复用同一轮 Pod 身份；显式 manifest 地址保留 | 验收继续要求实际跨 Pod KV 传输 |
 | RemoteRpcServer.process_id_ / peer / cache-store | 现有代码延迟到 release 才读取 IP/PID、初始化 peer 和 transport | 不等于任意已运行通信对象都支持重建 |
-| ServerConfig.ip、DistributedServer.worker_info / TCPStore / NCCL 配置 | 多处启动时缓存；现有模板路径通过 endpoint manifest 和限定的 loopback 模式处理主要服务地址 | 不能把 manifest 更新等同于现存 TCPStore/NCCL 通信器都已重建；多节点和运行中 checkpoint 需要单独验证 |
+| ServerConfig.ip | 构造时缓存，前端请求 ID 机器位等消费者直接读取该字段；本次新增 server-config 模板 hook，在统一入口按本轮 Pod 身份刷新，插在 release 之前 | 仍需完整镜像与真实 restore 验收；确认没有其他启动期副本未刷新 |
+| DistributedServer.worker_info / TCPStore / NCCL 配置 | 多处启动时缓存；现有模板路径通过 endpoint manifest 和限定的 loopback 模式处理主要服务地址 | 不能把 manifest 更新等同于现存 TCPStore/NCCL 通信器都已重建；多节点和运行中 checkpoint 需要单独验证 |
 | HostService / VipServerWrapper.hosts / MasterService 路由快照与线程 | 构造阶段会发现地址并缓存，MasterService 创建刷新线程；本轮未看到这些类自身的完整模板 prepare/fixup/release 实现 | 明确列为后续审计项；周期刷新不能代替恢复前暂停、恢复后刷新、就绪门禁 |
 | MasterClient._channels | 按 target 缓存异步 gRPC channel，惰性创建 | seed 未接流量可减少捕获连接；运行中 checkpoint 必须处理已有 channel 的关闭/重建 |
 | GrammarValidator 沙箱池 | 现有 prepare 清理子进程与连接、release 恢复池目标 | 属于资源生命周期修复，不能用 env/string 刷新替代 |

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -27,6 +27,12 @@ pool is quiesced before the barrier and recreated when the template is released.
 The public integration switch is `RTPLLM_ENABLE_SCR=1`; the external controller
 selects `SCR_PHASE`.
 
+Process-local identity repair now runs through `fixup_runtime_after_restore`
+before component fixups and release. See [runtime fixup and audit](scr_runtime_fixup.md)
+for Logger repair, the future restore-environment provider contract, and remaining
+host/routing/transport risks. Rereading the restored process environment alone
+does not establish that host identity is fresh.
+
 The internal entrypoint sets `NCCL_SOCKET_IFNAME=lo` in this mode and preloads the
 SCR-injected NCCL interposer for the checkpoint phase. The interposer and the
 underlying NCCL implementation must exist before startup. The image retains the

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -12,6 +12,15 @@ The mode rejects multiple nodes, incomplete rank sets and mixed member addresses
 After restore, the saved `self.ip` may differ from newly resolved member addresses;
 that difference alone must not invalidate the topology.
 
+Loopback is only a control-channel address. Cache-store endpoints sent to a
+remote PD peer use the current Pod IP, resolved again during restore fixup;
+otherwise Decode would connect to its own loopback when fetching Prefill KV.
+Explicit non-loopback endpoint-manifest addresses remain unchanged. Failure to
+resolve a usable Pod IPv4 address rejects fixup instead of advertising the seed
+IP. The frontend request identity is refreshed at the same boundary. Acceptance
+must include a real cross-Pod KV transfer after the Pod IP changes; readiness
+and successful CRIU restore alone do not establish that this route works.
+
 Local health polling uses numeric loopback to avoid transient resolver netlink
 sockets during checkpoint. Grammar workers participate in the upstream template lifecycle; their sandbox
 pool is quiesced before the barrier and recreated when the template is released.

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -66,10 +66,13 @@ error, both reporters activate their external transport. They reread the Hippo
 runtime environment and rebuild the sink and identity tags so a restored process
 does not report with the seed Pod's host or container IP. Python also replaces
 stale runtime tags when rendering data points that were registered before the
-checkpoint. The native library must provide the matching lifecycle hooks; mixing
-new Python helpers with an older loaded native library rejects checkpoint
-participation rather than silently retaining sockets. Ordinary serving without
-SCR keeps the original eager reporting behavior.
+checkpoint. Native reporting applies the refreshed runtime identity at the
+publish boundary, so a metric declared before the checkpoint can retain its
+existing handle while its emitted records use the restored Pod's IP tags. The
+native library must provide the matching lifecycle hooks; mixing new Python
+helpers with an older loaded native library rejects checkpoint participation
+rather than silently retaining sockets. Ordinary serving without SCR keeps the
+original eager reporting behavior.
 
 CPU validation covers deferred Python transport activation, real TCP
 closure/reconnection, refreshed runtime identity, and native metric registration

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -2,7 +2,8 @@
 
 This branch adds opt-in stable loopback communication for ranks that share one
 Pod network namespace. It builds on `feat/dsv4_on_dev_scr` at
-`7eb9d7bc790b561e347e3bf4cc3c168c39787844`.
+`888476cf150c924b249d62b52afcd41753430e6b`, retaining its control-plane
+lifecycle and endpoint restore support.
 
 Set `RTP_LLM_SCR_LOCAL_COMM=1` on both the checkpoint seed and restore workload.
 Set `LOCAL_WORLD_SIZE` to `WORLD_SIZE`. RPC fan-out, TCPStore and NCCL rendezvous
@@ -12,10 +13,10 @@ After restore, the saved `self.ip` may differ from newly resolved member address
 that difference alone must not invalidate the topology.
 
 Local health polling uses numeric loopback to avoid transient resolver netlink
-sockets during checkpoint. With `SCR_ENABLE=1` and `SCR_PHASE=checkpoint`, grammar
-sandbox workers are created on first validation rather than eagerly at startup.
-Do not send grammar validation traffic before checkpoint: it can instantiate the
-sandbox pool. Ordinary startup retains eager pool creation.
+sockets during checkpoint. Grammar workers participate in the upstream template lifecycle; their sandbox
+pool is quiesced before the barrier and recreated when the template is released.
+The public integration switch is `RTPLLM_ENABLE_SCR=1`; the external controller
+selects `SCR_PHASE`.
 
 The internal entrypoint sets `NCCL_SOCKET_IFNAME=lo` in this mode and preloads the
 SCR-injected NCCL interposer for the checkpoint phase. The interposer and the
@@ -25,7 +26,9 @@ GCC 12 library search path needed by runtime JIT compilation.
 The fused RoPE call site supports both legacy and current rtp-kernel wrappers:
 the current API takes `position_ids` in prefill and separate position IDs plus
 sequence lengths in decode. Kernel feature detection is cached, uses the Python
-signature, and does not change tensors or native modules at runtime.
+signature, and does not change tensors or native modules at runtime. The paired
+image pins a kernel wheel using the current API, so this compatibility adapter
+is required even though the upstream branch removed it.
 
 ## Validation and acceptance boundary
 
@@ -61,8 +64,9 @@ or reporting thread. The native reporter initializes the factory configuration
 in manual mode and accepts metric registration, but does not start its metrics
 system or create the configured sink.
 
-After `epsilon.snapstart_checkpoint()` returns, including after a checkpoint
-error, both reporters activate their external transport. They reread the Hippo
+The upstream template lifecycle releases both reporters after the Epsilon
+barrier and restore fixup; its abort path also resumes prepared reporters.
+Both reporters then activate their external transport. They reread the Hippo
 runtime environment and rebuild the sink and identity tags so a restored process
 does not report with the seed Pod's host or container IP. Python also replaces
 stale runtime tags when rendering data points that were registered before the

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -74,6 +74,15 @@ helpers with an older loaded native library rejects checkpoint participation
 rather than silently retaining sockets. Ordinary serving without SCR keeps the
 original eager reporting behavior.
 
+CRIU can preserve `RequestedIP` from the seed even when the new Pod's hostname
+resolves to its new IP. Before native reporting resumes, the SCR helper resolves
+that hostname and refreshes `RequestedIP` in the process environment. If resolution
+fails, it logs the failure and leaves the existing value in place; that case still
+needs explicit monitoring validation. Rebuilding the native configuration also
+replaces its common tag map: otherwise the insert-only `host` tag would retain the
+seed value despite rerunning hostname resolution. Fresh-image acceptance checks
+both `container_ip` and `host` on actual emitted native records.
+
 CPU validation covers deferred Python transport activation, real TCP
 closure/reconnection, refreshed runtime identity, and native metric registration
 retention across sink replacement. Full acceptance must additionally verify

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -66,7 +66,9 @@ system or create the configured sink.
 
 The upstream template lifecycle releases both reporters after the Epsilon
 barrier and restore fixup; its abort path also resumes prepared reporters.
-Both reporters then activate their external transport. They reread the Hippo
+The main parent participates through the same lifecycle wrapper as its children,
+so its deferred Python reporter is also released. Both reporters then activate
+their external transport. They reread the Hippo
 runtime environment and rebuild the sink and identity tags so a restored process
 does not report with the seed Pod's host or container IP. Python also replaces
 stale runtime tags when rendering data points that were registered before the

--- a/docs/scr_single_pod_restore.md
+++ b/docs/scr_single_pod_restore.md
@@ -54,20 +54,26 @@ network namespace. Leave it unset for multi-node deployments.
 
 ## Monitoring connections at the checkpoint boundary
 
-Each SCR participant pauses its already-loaded Kmonitor reporters before entering
-the Epsilon barrier. Python reporters join their reporting thread and close Flume.
-The native reporter stops its sampling/sending threads and reinitializes the
-configured sink in manual mode, releasing the old transport while retaining the
-registered metric sources. It does not shut down the Kmonitor factory.
+During an SCR checkpoint or restore phase, each participant creates its Python
+and native metric registries at the normal initialization points, but defers the
+external Kmonitor transport. The Python reporter does not create its Flume client
+or reporting thread. The native reporter initializes the factory configuration
+in manual mode and accepts metric registration, but does not start its metrics
+system or create the configured sink.
 
-When the barrier returns, including after a checkpoint error, both reporters
-resume using their original configuration. The native library must provide the
-matching lifecycle hooks; mixing new Python helpers with an older loaded native
-library rejects checkpoint participation rather than silently retaining sockets.
-Ordinary serving without SCR does not pause reporting.
+After `epsilon.snapstart_checkpoint()` returns, including after a checkpoint
+error, both reporters activate their external transport. They reread the Hippo
+runtime environment and rebuild the sink and identity tags so a restored process
+does not report with the seed Pod's host or container IP. Python also replaces
+stale runtime tags when rendering data points that were registered before the
+checkpoint. The native library must provide the matching lifecycle hooks; mixing
+new Python helpers with an older loaded native library rejects checkpoint
+participation rather than silently retaining sockets. Ordinary serving without
+SCR keeps the original eager reporting behavior.
 
-CPU validation covers real Python TCP closure/reconnection and native metric
-registration retention across sink replacement. Full acceptance must additionally
-verify dump/restore, restored inference, and resumed reporting in a fresh image.
+CPU validation covers deferred Python transport activation, real TCP
+closure/reconnection, refreshed runtime identity, and native metric registration
+retention across sink replacement. Full acceptance must additionally verify
+dump/restore, restored inference, and resumed reporting in a fresh image.
 These hooks address the configured built-in sink; custom sinks and independently
 retained sink references require their own external-connection lifecycle checks.

--- a/patches/havenask/havenask.patch
+++ b/patches/havenask/havenask.patch
@@ -47,3 +47,65 @@ index 03ff7ce5..bdaff505 100644
  def genshared(name, lib):
      return native.genrule(
          name = name,
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp
+index f0f8590e..6597e6a6 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.cpp
+@@ -51,3 +51,13 @@
+ const string &MetricsRecord::Name() const { return info_->Name(); }
+-
++void MetricsRecord::OverrideTags(const map<string, string> &tags) {
++    if (tags.empty()) {
++        return;
++    }
++    auto mergedTags = tags_->GetTagsMap();
++    for (const auto &tag : tags) {
++        mergedTags[tag.first] = tag.second;
++    }
++    tags_.reset(new MetricsTags(mergedTags));
++}
++
+ void MetricsRecord::AddValue(const MetricsInfoPtr &info, double value) {
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h
+index cb2802e3..ec471b1b 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsRecord.h
+@@ -31,2 +31,3 @@ public:
+     const std::vector<MetricsValue *> &Values() const { return values_; }
++    void OverrideTags(const std::map<std::string, std::string> &tags);
+     void AddValue(const MetricsInfoPtr &info, double value);
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp
+index 0bebb64e..6625f88d 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.cpp
+@@ -55,2 +55,14 @@ MetricsSystem::~MetricsSystem() {
+ void MetricsSystem::Init(MetricsConfig *config) {
++    output_override_tags_.clear();
++    const auto &globalTags = config->global_tags()->GetTagsMap();
++    for (const auto &key : {"hippo_slave_ip", "host_ip", "container_ip"}) {
++        auto iter = globalTags.find(key);
++        if (iter != globalTags.end()) {
++            output_override_tags_[iter->first] = iter->second;
++        }
++    }
++    auto hostIter = config->CommonTags().find("host");
++    if (hostIter != config->CommonTags().end()) {
++        output_override_tags_[hostIter->first] = hostIter->second;
++    }
+     if (!initSink(config)) {
+@@ -116,2 +128,5 @@ void MetricsSystem::Stop() {
+ void MetricsSystem::PublishMetrics(MetricsRecords &records) {
++    for (auto record : records.getRecords()) {
++        record->OverrideTags(output_override_tags_);
++    }
+     for (auto e : sinks_) {
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h
+index 6ac5d7b8..840186ef 100644
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsSystem.h
+@@ -79,3 +79,4 @@ private:
+     std::queue<std::pair<int64_t, MetricsRecords>> publish_queue_;
+-
++    std::map<std::string, std::string> output_override_tags_;
++
+ private:

--- a/patches/havenask/havenask.patch
+++ b/patches/havenask/havenask.patch
@@ -109,3 +109,10 @@ index 6ac5d7b8..840186ef 100644
 +    std::map<std::string, std::string> output_override_tags_;
 +
  private:
+diff --git aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp
+--- aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp
++++ aios/kmonitor/cpp_client/src/kmonitor/client/core/MetricsConfig.cpp
+@@ -76,2 +76,3 @@ MetricsConfig &MetricsConfig::operator=(const MetricsConfig &config) {
+         use_common_tag_ = config.use_common_tag();
++        common_tags_ = config.CommonTags();
+     }

--- a/rtp_llm/aios/kmonitor/python_client/kmonitor/report_worker.py
+++ b/rtp_llm/aios/kmonitor/python_client/kmonitor/report_worker.py
@@ -14,7 +14,6 @@ from rtp_llm.aios.kmonitor.python_client.kmonitor.metrics.metric_base import (
 )
 from rtp_llm.aios.kmonitor.python_client.kmonitor.utils.hippo_helper import HippoHelper
 
-_ReportWorker__REPORT_HOST = os.getenv("HIPPO_SLAVE_IP", "localhost")
 _ReportWorker__REPORT_PORT = 4141
 _ReportWorker__FLUME_CLIENT_TIMEOUT_MS = 1000
 
@@ -24,11 +23,28 @@ _ReportWorker__REPORT_KMONITOR_MULTI_SEP = "@"
 _ReportWorker__REPORT_KMONITOR_KEYVALUE_SEP = "^"
 
 
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _defer_transport_for_scr() -> bool:
+    enabled = any(
+        _env_enabled(name)
+        for name in ("RTPLLM_ENABLE_SCR", "RTP_LLM_ENABLE_SCR", "SCR_ENABLE")
+    )
+    return enabled and os.environ.get("SCR_PHASE", "").strip().lower() in {
+        "checkpoint",
+        "restore",
+    }
+
+
 class ReportWorker(object):
     def __init__(self, *args):
         super(ReportWorker, self).__init__(*args)
-        self.init_tags = HippoHelper.get_hippo_tags()
-        self.init_tags.update(self.parse_kmon_tags(os.environ.get("kmonitorTags", "")))
+        self._runtime_tags = HippoHelper.get_hippo_tags()
+        self._configured_tags = self.parse_kmon_tags(os.environ.get("kmonitorTags", ""))
+        self.init_tags = self._runtime_tags.copy()
+        self.init_tags.update(self._configured_tags)
         logging.info(
             f"kmonitor report default tags: {json.dumps(self.init_tags, indent=4)}"
         )
@@ -36,17 +52,14 @@ class ReportWorker(object):
         self.metric_lock: Lock = Lock()
         self.started = False
         self._report_thread: Thread | None = None
+        self._transport_deferred = False
         if HippoHelper.is_hippo_env():
-            self.flume = FlumeClient(
-                _ReportWorker__REPORT_HOST,
-                _ReportWorker__REPORT_PORT,
-                timeout=_ReportWorker__FLUME_CLIENT_TIMEOUT_MS,
-            )
-            self.start()
-            logging.info(
-                f"hippo role [{HippoHelper.role}] at host [{HippoHelper.host_ip}-{HippoHelper.container_ip}] "
-                "started reporting kmonitor."
-            )
+            self.flume = None
+            self._transport_deferred = _defer_transport_for_scr()
+            if self._transport_deferred:
+                logging.info("defer kmonitor transport until SCR steady-point returns")
+            else:
+                self._activate_hippo_transport(refresh_identity=False)
         else:
             self.flume = None
             self.start()
@@ -76,8 +89,12 @@ class ReportWorker(object):
         self, metric_name: str, timestamp: int, data_point: MetricDataPoint
     ) -> ThriftFlumeEvent:
         value_str = str(data_point.value)
+        report_tags = data_point.tags.copy()
+        # Runtime identity is authoritative after restore. Metric instances can
+        # predate the restore and therefore still contain seed identity tags.
+        report_tags.update(self._runtime_tags)
         tag_str: str = " ".join(
-            ["=".join([k, v]) for (k, v) in list(data_point.tags.items())]
+            ["=".join([k, v]) for (k, v) in list(report_tags.items())]
         )
         report_message: bytes = " ".join(
             [metric_name, str(timestamp), value_str, tag_str]
@@ -115,6 +132,9 @@ class ReportWorker(object):
         logging.warn("kmonitor report process exited.")
 
     def start(self) -> None:
+        if self._report_thread is not None and self._report_thread.is_alive():
+            self.started = True
+            return
         self.started = True
         report_thread = Thread(target=self.report_cycle)
         report_thread.daemon = True
@@ -123,6 +143,31 @@ class ReportWorker(object):
 
     def stop(self) -> None:
         self.started = False
+
+    def _activate_hippo_transport(self, *, refresh_identity: bool = True) -> None:
+        if refresh_identity:
+            self._runtime_tags = HippoHelper.refresh_runtime_identity()
+            # KMonitor instances retain this dict by reference. Update it in
+            # place so metrics registered after restore also use fresh tags.
+            self.init_tags.clear()
+            self.init_tags.update(self._runtime_tags)
+            self.init_tags.update(self._configured_tags)
+        report_host = os.environ.get("HIPPO_SLAVE_IP", "localhost")
+        if self.flume is not None:
+            self.flume.close()
+        self.flume = FlumeClient(
+            report_host,
+            _ReportWorker__REPORT_PORT,
+            timeout=_ReportWorker__FLUME_CLIENT_TIMEOUT_MS,
+        )
+        self._transport_deferred = False
+        self.start()
+        logging.info(
+            "hippo role [%s] at host [%s-%s] started reporting kmonitor",
+            HippoHelper.role,
+            HippoHelper.host_ip,
+            HippoHelper.container_ip,
+        )
 
     def pause_for_checkpoint(self) -> bool:
         was_started = self.started
@@ -142,7 +187,9 @@ class ReportWorker(object):
         return was_started
 
     def resume_after_checkpoint(self, was_started: bool) -> None:
-        if was_started:
+        if HippoHelper.is_hippo_env() and (was_started or self._transport_deferred):
+            self._activate_hippo_transport()
+        elif was_started:
             try:
                 if self.flume is not None:
                     self.flume.reconnect()

--- a/rtp_llm/aios/kmonitor/python_client/kmonitor/utils/hippo_helper.py
+++ b/rtp_llm/aios/kmonitor/python_client/kmonitor/utils/hippo_helper.py
@@ -13,7 +13,7 @@ class HippoHelper:
         # 获取主机 IP 地址
         container_ip = socket.gethostbyname(hostname)
         logging.info(f"get container_ip from socket:{container_ip}")
-    except Exception as e:
+    except Exception:
         container_ip = host_ip
         logging.info(
             f"get container_ip from socket failed, use host_ip:{host_ip} as container_ip"
@@ -22,6 +22,33 @@ class HippoHelper:
     app = os.environ.get("HIPPO_APP", "")
     group = os.environ.get("HIPPO_SERVICE_NAME", "")
     app_workdir = os.environ.get("HIPPO_APP_WORKDIR", "")
+
+    @staticmethod
+    def refresh_runtime_identity() -> Dict[str, str]:
+        """Refresh Hippo identity after SCR restores into a new Pod."""
+
+        HippoHelper.host_ip = os.environ.get("HIPPO_SLAVE_IP", "")
+        try:
+            hostname = socket.gethostname()
+            HippoHelper.container_ip = socket.gethostbyname(hostname)
+            logging.info(
+                "refreshed container_ip from socket:%s", HippoHelper.container_ip
+            )
+        except Exception:
+            HippoHelper.container_ip = os.environ.get(
+                "RequestedIP", HippoHelper.host_ip
+            )
+            logging.info(
+                "refresh container_ip from socket failed, use runtime identity:%s",
+                HippoHelper.container_ip,
+            )
+        HippoHelper.role = os.environ.get(
+            "HIPPO_ROLE_SHORT_NAME", os.environ.get("HIPPO_ROLE", "")
+        )
+        HippoHelper.app = os.environ.get("HIPPO_APP", "")
+        HippoHelper.group = os.environ.get("HIPPO_SERVICE_NAME", "")
+        HippoHelper.app_workdir = os.environ.get("HIPPO_APP_WORKDIR", "")
+        return HippoHelper.get_hippo_tags()
 
     @staticmethod
     def is_hippo_env() -> bool:

--- a/rtp_llm/aios/kmonitor/python_client/kmonitor/utils/hippo_helper.py
+++ b/rtp_llm/aios/kmonitor/python_client/kmonitor/utils/hippo_helper.py
@@ -27,12 +27,17 @@ class HippoHelper:
     def refresh_runtime_identity() -> Dict[str, str]:
         """Refresh Hippo identity after SCR restores into a new Pod."""
 
+        from rtp_llm.utils.scr_runtime_fixup import get_restore_runtime_identity
+
+        identity = get_restore_runtime_identity()
         HippoHelper.host_ip = os.environ.get("HIPPO_SLAVE_IP", "")
         try:
             hostname = socket.gethostname()
-            HippoHelper.container_ip = socket.gethostbyname(hostname)
+            HippoHelper.container_ip = (
+                identity.pod_ip if identity is not None else socket.gethostbyname(hostname)
+            )
             logging.info(
-                "refreshed container_ip from socket:%s", HippoHelper.container_ip
+                "refreshed container_ip:%s", HippoHelper.container_ip
             )
         except Exception:
             HippoHelper.container_ip = os.environ.get(

--- a/rtp_llm/config/engine_config.py
+++ b/rtp_llm/config/engine_config.py
@@ -37,6 +37,7 @@ from rtp_llm.ops import (
     SpeculativeExecutionConfig,
     VitSeparation,
 )
+from rtp_llm.utils.scr_local_comm import cache_store_advertise_ip
 
 
 @dataclass
@@ -333,6 +334,7 @@ def update_worker_addrs(
         return
     worker_addrs = []
     worker_grpc_addrs = []
+    advertise_ip = cache_store_advertise_ip(world_info, parallelism_config)
     local_rank = parallelism_config.local_rank
     for member in world_info.members:
         if (
@@ -343,7 +345,7 @@ def update_worker_addrs(
             == parallelism_config.dp_rank
         ):
             worker_addrs.append(
-                f"{member.ip}:{member.cache_store_listen_port}:{member.cache_store_rdma_listen_port}"
+                f"{advertise_ip or member.ip}:{member.cache_store_listen_port}:{member.cache_store_rdma_listen_port}"
             )
             worker_grpc_addrs.append(f"{member.ip}:{member.rpc_server_port}")
             logging.info(

--- a/rtp_llm/cpp/engine_base/EngineBase.h
+++ b/rtp_llm/cpp/engine_base/EngineBase.h
@@ -59,6 +59,11 @@ public:
 
     virtual std::shared_ptr<GenerateStream> makeStream(const std::shared_ptr<GenerateInput>& input);
 
+    // Template initialization may prepare model state before starting computation.
+    virtual absl::Status startLoop() {
+        return absl::UnimplementedError("deferred engine start is not supported");
+    }
+
     virtual absl::Status stop() = 0;
 
     virtual absl::StatusOr<GenerateStreamPtr> preRun(const std::shared_ptr<GenerateInput>& generate_input,

--- a/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
+++ b/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
@@ -1,7 +1,6 @@
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
 #include "autil/EnvUtil.h"
 #include "rtp_llm/cpp/utils/Logger.h"
-#include "kmonitor/client/KMonitor.h"
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
@@ -1167,18 +1166,6 @@ void fillKmonitorConfig(kmonitor::MetricsConfig& metricsConfig, const KmonParam&
     setHippoTags(metricsConfig);
 }
 
-void refreshRegisteredKmonitorTags(const kmonitor::MetricsConfig& config) {
-    auto tags = config.global_tags()->GetTagsMap();
-    for (const auto& pair : config.CommonTags()) {
-        tags[pair.first] = pair.second;
-    }
-    for (const auto& monitorPair : *kmonitor::KMonitorFactory::GetKMonitorMap()) {
-        for (const auto& tagPair : tags) {
-            monitorPair.second->AddTag(tagPair.first, tagPair.second);
-        }
-    }
-}
-
 }  // namespace
 
 bool initKmonitorFactory() {
@@ -1279,7 +1266,6 @@ bool resumeKmonitorAfterScr() {
     auto* system = worker->getMetricsSystem();
     if (kmonitorTransportDeferred) {
         worker->addCommonTags();
-        refreshRegisteredKmonitorTags(*factoryConfig);
         kmonitor::KMonitorFactory::Start();
         if (!system->Started()) {
             return false;
@@ -1290,7 +1276,6 @@ bool resumeKmonitorAfterScr() {
     }
     system->Stop();
     worker->addCommonTags();
-    refreshRegisteredKmonitorTags(*factoryConfig);
     system->Init(factoryConfig);
     if (!system->Started()) {
         return false;

--- a/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
+++ b/rtp_llm/cpp/metrics/RtpLLMMetrics.cc
@@ -1,6 +1,7 @@
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
 #include "autil/EnvUtil.h"
 #include "rtp_llm/cpp/utils/Logger.h"
+#include "kmonitor/client/KMonitor.h"
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
@@ -1136,6 +1137,50 @@ void RtpLLMDiskCacheMetrics::report(const kmonitor::MetricsTags*           tags,
 #undef REPORT_QPS
 #undef REPORT_GAUGE
 
+namespace {
+
+bool kmonitorTransportDeferred = false;
+
+bool deferKmonitorTransportForScr() {
+    const auto phase = autil::EnvUtil::getEnv("SCR_PHASE", "");
+    const bool enabled = autil::EnvUtil::getEnv("RTPLLM_ENABLE_SCR", false)
+                         || autil::EnvUtil::getEnv("RTP_LLM_ENABLE_SCR", false)
+                         || autil::EnvUtil::getEnv("SCR_ENABLE", false);
+    return enabled && (phase == "checkpoint" || phase == "restore");
+}
+
+void fillKmonitorConfig(kmonitor::MetricsConfig& metricsConfig, const KmonParam& param, bool manuallyMode) {
+    metricsConfig.set_tenant_name(param.kmonitorTenant);
+    metricsConfig.set_service_name(param.kmonitorServiceName);
+    std::string sink_address = param.kmonitorSinkAddress;
+    if (!param.kmonitorPort.empty()) {
+        sink_address += ":" + param.kmonitorPort;
+    }
+    metricsConfig.set_sink_address(sink_address.c_str());
+    metricsConfig.set_enable_log_file_sink(param.kmonitorEnableLogFileSink);
+    metricsConfig.set_manually_mode(manuallyMode);
+    metricsConfig.set_inited(true);
+    metricsConfig.AddGlobalTag("hippo_slave_ip", param.hippoSlaveIp);
+    for (const auto& pair : param.kmonitorTags) {
+        metricsConfig.AddGlobalTag(pair.first, pair.second);
+    }
+    setHippoTags(metricsConfig);
+}
+
+void refreshRegisteredKmonitorTags(const kmonitor::MetricsConfig& config) {
+    auto tags = config.global_tags()->GetTagsMap();
+    for (const auto& pair : config.CommonTags()) {
+        tags[pair.first] = pair.second;
+    }
+    for (const auto& monitorPair : *kmonitor::KMonitorFactory::GetKMonitorMap()) {
+        for (const auto& tagPair : tags) {
+            monitorPair.second->AddTag(tagPair.first, tagPair.second);
+        }
+    }
+}
+
+}  // namespace
+
 bool initKmonitorFactory() {
     KmonParam param;
     param.init();
@@ -1155,41 +1200,37 @@ bool initKmonitorFactory() {
     }
 
     kmonitor::MetricsConfig metricsConfig;
-    metricsConfig.set_tenant_name(param.kmonitorTenant);
-    metricsConfig.set_service_name(param.kmonitorServiceName);
-    std::string sink_address = param.kmonitorSinkAddress;
-    if (!param.kmonitorPort.empty()) {
-        sink_address += ":" + param.kmonitorPort;
-    }
-    metricsConfig.set_sink_address(sink_address.c_str());
-    metricsConfig.set_enable_log_file_sink(param.kmonitorEnableLogFileSink);
-    // metricsConfig.set_enable_prometheus_sink(param.kmonitorEnablePrometheusSink);
-    metricsConfig.set_manually_mode(param.kmonitorManuallyMode);
-    metricsConfig.set_inited(true);
-    metricsConfig.AddGlobalTag("hippo_slave_ip", param.hippoSlaveIp);
-    for (auto& pair : param.kmonitorTags) {
-        metricsConfig.AddGlobalTag(pair.first, pair.second);
-    }
-    setHippoTags(metricsConfig);
+    const bool deferTransport = deferKmonitorTransportForScr();
+    fillKmonitorConfig(metricsConfig, param, deferTransport || param.kmonitorManuallyMode);
     if (!kmonitor::KMonitorFactory::Init(metricsConfig)) {
         RTP_LLM_LOG_ERROR("init kmonitor factory failed with");
         return false;
     }
+    kmonitorTransportDeferred = deferTransport;
 
     // registerBuildInMetrics to refresh sg_buildin_kmonitor for KMonitorWorker::Start
     kmonitor::KMonitorFactory::registerBuildInMetrics(nullptr, param.kmonitorMetricsPrefix);
     RTP_LLM_LOG_INFO("KMonitorFactory::registerBuildInMetrics() finished");
 
+    if (deferTransport) {
+        RTP_LLM_LOG_INFO("KMonitor transport deferred until SCR steady-point returns");
+        return true;
+    }
     kmonitor::KMonitorFactory::Start();
     RTP_LLM_LOG_INFO("KMonitorFactory::Start() finished");
     return true;
 }
 
 void stopKmonitorFactory() {
+    kmonitorTransportDeferred = false;
     kmonitor::KMonitorFactory::Shutdown();
 }
 
 bool pauseKmonitorForScr() {
+    if (kmonitorTransportDeferred) {
+        RTP_LLM_LOG_INFO("SCR native Kmonitor transport is already deferred");
+        return true;
+    }
     if (!kmonitor::KMonitorFactory::IsStarted()) {
         return false;
     }
@@ -1222,24 +1263,39 @@ bool pauseKmonitorForScr() {
 }
 
 bool resumeKmonitorAfterScr() {
-    if (!kmonitor::KMonitorFactory::IsStarted()) {
+    if (!kmonitorTransportDeferred && !kmonitor::KMonitorFactory::IsStarted()) {
         return false;
     }
     auto* worker = kmonitor::KMonitorFactory::GetWorker();
-    if (worker == nullptr || worker->getMetricsSystem() == nullptr) {
+    auto* factoryConfig = kmonitor::KMonitorFactory::GetConfig();
+    if (worker == nullptr || worker->getMetricsSystem() == nullptr || factoryConfig == nullptr) {
         return false;
     }
-    auto* config = kmonitor::KMonitorFactory::GetConfig();
-    if (config == nullptr) {
-        return false;
-    }
+    KmonParam param;
+    param.init();
+    kmonitor::MetricsConfig resumedConfig;
+    fillKmonitorConfig(resumedConfig, param, param.kmonitorManuallyMode);
+    *factoryConfig = resumedConfig;
     auto* system = worker->getMetricsSystem();
+    if (kmonitorTransportDeferred) {
+        worker->addCommonTags();
+        refreshRegisteredKmonitorTags(*factoryConfig);
+        kmonitor::KMonitorFactory::Start();
+        if (!system->Started()) {
+            return false;
+        }
+        kmonitorTransportDeferred = false;
+        RTP_LLM_LOG_INFO("SCR native Kmonitor activated with refreshed runtime identity");
+        return true;
+    }
     system->Stop();
-    system->Init(config);
+    worker->addCommonTags();
+    refreshRegisteredKmonitorTags(*factoryConfig);
+    system->Init(factoryConfig);
     if (!system->Started()) {
         return false;
     }
-    RTP_LLM_LOG_INFO("SCR native Kmonitor resumed");
+    RTP_LLM_LOG_INFO("SCR native Kmonitor activated with refreshed runtime identity");
     return true;
 }
 

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -86,6 +86,22 @@ TEST_F(ScrKmonitorLifecycleTest, RetainsRegisteredMetricsAndReleasesOldSink) {
     }
 }
 
+TEST_F(ScrKmonitorLifecycleTest, DeferredDefaultModeStartsAutomaticReporter) {
+    autil::EnvGuard scrEnabled("RTPLLM_ENABLE_SCR", "1");
+    autil::EnvGuard scrPhase("SCR_PHASE", "checkpoint");
+    autil::EnvGuard manualMode("kmonitorManuallyMode", "false");
+
+    ASSERT_TRUE(initKmonitorFactory());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_TRUE(pauseKmonitorForScr());
+    resumeKmonitorAfterScr();
+
+    EXPECT_TRUE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
+}
+
 TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     autil::EnvGuard scrEnabled("RTPLLM_ENABLE_SCR", "1");
     autil::EnvGuard scrPhase("SCR_PHASE", "checkpoint");
@@ -93,6 +109,9 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     autil::EnvGuard oldRequestedIp("RequestedIP", "10.1.0.1");
     autil::EnvGuard hippoRole("HIPPO_ROLE", "rtp_role");
     autil::EnvGuard serviceName("kmonitorServiceName", "scr_service");
+    // Keep the sampling threads disabled so ManuallySnapshot observes exactly
+    // the record produced below. Automatic-mode activation is covered above.
+    autil::EnvGuard manualMode("kmonitorManuallyMode", "true");
 
     ASSERT_TRUE(initKmonitorFactory());
     EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
@@ -126,7 +145,7 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     EXPECT_TRUE(kmonitor::KMonitorFactory::IsStarted());
     EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
     EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
-    EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
     EXPECT_EQ(kmonitor::KMonitorFactory::GetConfig()->sink_address(), "10.0.0.2:4141");
     EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_deferred"));
     auto* system = kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem();

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -4,12 +4,49 @@
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
+#include "kmonitor/client/core/MetricsCollector.h"
+#include "kmonitor/client/core/MetricsRecord.h"
 #include "kmonitor/client/core/MetricsSystem.h"
 #include "kmonitor/client/core/MetricsTags.h"
+#include "kmonitor/client/sink/Sink.h"
 #include "gtest/gtest.h"
+#include <map>
 #include <memory>
+#include <set>
+#include <string>
 
 namespace rtp_llm {
+
+class RecordingSink: public kmonitor::Sink {
+public:
+    explicit RecordingSink(const std::string& metricName): Sink("FlumeSink"), metricName_(metricName) {}
+
+    bool Init() override {
+        return true;
+    }
+
+    void PutMetrics(kmonitor::MetricsRecord* record) override {
+        if (record->Name() == metricName_ && !record->Values().empty()) {
+            sawMetric_ = true;
+            tags_      = record->Tags()->GetTagsMap();
+        }
+    }
+
+    void Flush() override {}
+
+    bool sawMetric() const {
+        return sawMetric_;
+    }
+
+    const std::map<std::string, std::string>& tags() const {
+        return tags_;
+    }
+
+private:
+    std::string                        metricName_;
+    bool                               sawMetric_ = false;
+    std::map<std::string, std::string> tags_;
+};
 
 class ScrKmonitorLifecycleTest: public ::testing::Test {
 protected:
@@ -55,6 +92,7 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     autil::EnvGuard oldHost("HIPPO_SLAVE_IP", "10.0.0.1");
     autil::EnvGuard oldRequestedIp("RequestedIP", "10.1.0.1");
     autil::EnvGuard hippoRole("HIPPO_ROLE", "rtp_role");
+    autil::EnvGuard serviceName("kmonitorServiceName", "scr_service");
 
     ASSERT_TRUE(initKmonitorFactory());
     EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
@@ -64,6 +102,21 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     auto* monitor = kmonitor::KMonitorFactory::GetKMonitor("scr_deferred");
     ASSERT_NE(monitor, nullptr);
     monitor->Register("retained", kmonitor::GAUGE);
+    auto* retainedMetric = monitor->DeclareMetric("retained", nullptr);
+    ASSERT_NE(retainedMetric, nullptr);
+    monitor->Report(retainedMetric, 1.0);
+    kmonitor::MetricsCollector seedCollector;
+    monitor->GetMetrics(&seedCollector, {kmonitor::NORMAL}, 1);
+    bool sawSeedMetric = false;
+    for (auto* record : seedCollector.GetRecords().getRecords()) {
+        if (record->Name() == "scr_service.retained" && !record->Values().empty()) {
+            sawSeedMetric = true;
+            EXPECT_EQ(record->Tags()->FindTag("hippo_slave_ip"), "10.0.0.1");
+            EXPECT_EQ(record->Tags()->FindTag("host_ip"), "10.0.0.1");
+            EXPECT_EQ(record->Tags()->FindTag("container_ip"), "10.1.0.1");
+        }
+    }
+    EXPECT_TRUE(sawSeedMetric);
     EXPECT_TRUE(pauseKmonitorForScr());
 
     autil::EnvGuard newHost("HIPPO_SLAVE_IP", "10.0.0.2");
@@ -76,10 +129,22 @@ TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
     EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
     EXPECT_EQ(kmonitor::KMonitorFactory::GetConfig()->sink_address(), "10.0.0.2:4141");
     EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_deferred"));
-    const auto tags = monitor->GetMetricsTags({})->GetTagsMap();
-    EXPECT_EQ(tags.at("hippo_slave_ip"), "10.0.0.2");
-    EXPECT_EQ(tags.at("host_ip"), "10.0.0.2");
-    EXPECT_EQ(tags.at("container_ip"), "10.1.0.2");
+    auto* system = kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem();
+    system->Stop();
+    auto recordingSink = std::make_shared<RecordingSink>("scr_service.retained");
+    ASSERT_TRUE(recordingSink->Init());
+    ASSERT_TRUE(system->AddSink(recordingSink));
+    monitor->Report(retainedMetric, 2.0);
+    system->ManuallySnapshot();
+    ASSERT_TRUE(recordingSink->sawMetric());
+    EXPECT_EQ(recordingSink->tags().at("hippo_slave_ip"), "10.0.0.2");
+    EXPECT_EQ(recordingSink->tags().at("host_ip"), "10.0.0.2");
+    EXPECT_EQ(recordingSink->tags().at("container_ip"), "10.1.0.2");
+    for (const auto& tag : recordingSink->tags()) {
+        EXPECT_NE(tag.second, "10.0.0.1");
+        EXPECT_NE(tag.second, "10.1.0.1");
+    }
+    EXPECT_TRUE(monitor->UndeclareMetric(retainedMetric));
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -1,9 +1,11 @@
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
+#include "autil/EnvUtil.h"
 #include "kmonitor/client/KMonitor.h"
 #include "kmonitor/client/KMonitorFactory.h"
 #include "kmonitor/client/KMonitorWorker.h"
 #include "kmonitor/client/core/MetricsConfig.h"
 #include "kmonitor/client/core/MetricsSystem.h"
+#include "kmonitor/client/core/MetricsTags.h"
 #include "gtest/gtest.h"
 #include <memory>
 
@@ -45,6 +47,39 @@ TEST_F(ScrKmonitorLifecycleTest, RetainsRegisteredMetricsAndReleasesOldSink) {
         EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
         EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_lifecycle"));
     }
+}
+
+TEST_F(ScrKmonitorLifecycleTest, DefersTransportAndRefreshesSinkAfterScr) {
+    autil::EnvGuard scrEnabled("RTPLLM_ENABLE_SCR", "1");
+    autil::EnvGuard scrPhase("SCR_PHASE", "checkpoint");
+    autil::EnvGuard oldHost("HIPPO_SLAVE_IP", "10.0.0.1");
+    autil::EnvGuard oldRequestedIp("RequestedIP", "10.1.0.1");
+    autil::EnvGuard hippoRole("HIPPO_ROLE", "rtp_role");
+
+    ASSERT_TRUE(initKmonitorFactory());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
+    auto* monitor = kmonitor::KMonitorFactory::GetKMonitor("scr_deferred");
+    ASSERT_NE(monitor, nullptr);
+    monitor->Register("retained", kmonitor::GAUGE);
+    EXPECT_TRUE(pauseKmonitorForScr());
+
+    autil::EnvGuard newHost("HIPPO_SLAVE_IP", "10.0.0.2");
+    autil::EnvGuard newRequestedIp("RequestedIP", "10.1.0.2");
+    resumeKmonitorAfterScr();
+
+    EXPECT_TRUE(kmonitor::KMonitorFactory::IsStarted());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->Started());
+    EXPECT_TRUE(kmonitor::KMonitorFactory::GetWorker()->getMetricsSystem()->GetSink("FlumeSink"));
+    EXPECT_FALSE(kmonitor::KMonitorFactory::GetConfig()->manually_mode());
+    EXPECT_EQ(kmonitor::KMonitorFactory::GetConfig()->sink_address(), "10.0.0.2:4141");
+    EXPECT_EQ(monitor, kmonitor::KMonitorFactory::GetKMonitor("scr_deferred"));
+    const auto tags = monitor->GetMetricsTags({})->GetTagsMap();
+    EXPECT_EQ(tags.at("hippo_slave_ip"), "10.0.0.2");
+    EXPECT_EQ(tags.at("host_ip"), "10.0.0.2");
+    EXPECT_EQ(tags.at("container_ip"), "10.1.0.2");
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
+++ b/rtp_llm/cpp/metrics/ScrKmonitorLifecycleTest.cc
@@ -60,6 +60,19 @@ TEST_F(ScrKmonitorLifecycleTest, InactiveFactoryStaysInactive) {
     EXPECT_FALSE(kmonitor::KMonitorFactory::IsStarted());
 }
 
+TEST_F(ScrKmonitorLifecycleTest, RebuiltConfigurationDiscardsSeedCommonTags) {
+    kmonitor::MetricsConfig seedConfig;
+    seedConfig.AddCommonTag("host", "10.1.0.1");
+    seedConfig.AddCommonTag("hippo_app", "seed_app");
+    kmonitor::MetricsConfig resumedConfig;
+    seedConfig = resumedConfig;
+    // addCommonTags uses emplace: a seed entry must be removed before a fresh
+    // runtime identity can be inserted into the rebuilt factory config.
+    seedConfig.AddCommonTag("host", "10.1.0.2");
+    EXPECT_EQ(seedConfig.CommonTags().at("host"), "10.1.0.2");
+    EXPECT_EQ(seedConfig.CommonTags().count("hippo_app"), 0);
+}
+
 TEST_F(ScrKmonitorLifecycleTest, RetainsRegisteredMetricsAndReleasesOldSink) {
     kmonitor::MetricsConfig config;
     config.set_inited(true);

--- a/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
@@ -63,7 +63,7 @@ grpc::Status LocalRpcServer::init(const EngineInitParams&                       
         pybind11::gil_scoped_release release;
         RTP_LLM_CHECK_WITH_INFO(!PyGILState_Check(),
                                 "running engine init with gil held may cause program hang, please check");
-        engine_.reset(new NormalEngine(maga_init_params, std::move(propose_params)));
+        engine_.reset(new NormalEngine(maga_init_params, std::move(propose_params), defer_engine_loop_));
     }
     if (!mm_process_engine.is_none()) {
         auto vit_separation = maga_init_params.vit_config.vit_separation;
@@ -92,6 +92,13 @@ void LocalRpcServer::updateRuntimeEndpoints(const RuntimeConfig& runtime_config)
 }
 
 void LocalRpcServer::startDeferredServices() {
+    // Every rank must start, including TP followers and ranks without a
+    // broadcaster. Do this before the broadcaster-specific early returns.
+    if (defer_engine_loop_) {
+        RTP_LLM_CHECK_WITH_INFO(engine_ != nullptr, "deferred engine is missing");
+        THROW_IF_STATUS_ERROR(engine_->startLoop());
+        defer_engine_loop_ = false;
+    }
     if (!defer_tp_broadcaster_ || tp_broadcaster_ || maga_init_params_.parallelism_config.tp_rank != 0
         || maga_init_params_.runtime_config.worker_grpc_addrs.empty()) {
         return;

--- a/rtp_llm/cpp/model_rpc/LocalRpcServer.h
+++ b/rtp_llm/cpp/model_rpc/LocalRpcServer.h
@@ -35,7 +35,10 @@ public:
 
     virtual void startDeferredServices();
     virtual void updateRuntimeEndpoints(const RuntimeConfig& runtime_config);
-    void setDeferServiceStart(bool defer) { defer_tp_broadcaster_ = defer; }
+    void setDeferServiceStart(bool defer) {
+        defer_tp_broadcaster_ = defer;
+        defer_engine_loop_ = defer;
+    }
 
     grpc::Status
     GetWorkerStatus(grpc::ServerContext* context, const ::StatusVersionPB* request, ::WorkerStatusPB* response);
@@ -133,6 +136,7 @@ protected:
     py::object                            weight_manager_;
     std::shared_ptr<BroadcastManager>     tp_broadcaster_;
     bool                                  defer_tp_broadcaster_{false};
+    bool                                  defer_engine_loop_{false};
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -77,7 +77,8 @@ bool shouldRefreshCacheStatusSnapshot(RoleType role_type, const std::list<Genera
 }  // anonymous namespace
 
 NormalEngine::NormalEngine(const EngineInitParams&                       params,
-                           std::unique_ptr<ProposeModelEngineInitParams> propose_params):
+                           std::unique_ptr<ProposeModelEngineInitParams> propose_params,
+                           bool defer_loop_start):
     EngineBase(params),
     model_config_(params.model_config_),
     parallelism_config(params.parallelism_config),
@@ -145,7 +146,13 @@ NormalEngine::NormalEngine(const EngineInitParams&                       params,
     releaseHostMemoryCache();
 
     initScheduler();
-    (void)startLoop();
+    if (defer_loop_start) {
+        // DP dummy streams also launch kernels without incoming requests.
+        // Keep the loop absent until the template has been released.
+        RTP_LLM_LOG_INFO("normal engine loop deferred until SCR release");
+    } else {
+        (void)startLoop();
+    }
 }
 
 void NormalEngine::initExecutor(const EngineInitParams&                        params,
@@ -482,6 +489,9 @@ KVCacheInfo NormalEngine::getCacheStatusInfo(int64_t latest_version, bool need_c
 }
 
 absl::Status NormalEngine::startLoop() {
+    if (loop_thread_) {
+        return absl::OkStatus();
+    }
     if (parallelism_config.tp_rank == 0) {
         RTP_LLM_LOG_INFO("start init system prompt");
         THROW_IF_STATUS_ERROR(initSystemPrompt());
@@ -497,7 +507,9 @@ absl::Status NormalEngine::stop() {
     RTP_LLM_LOG_INFO("stop normal engine");
     running_ = false;
     RETURN_IF_STATUS_ERROR(scheduler_->stop());
-    loop_thread_->join();
+    if (loop_thread_) {
+        loop_thread_->join();
+    }
     return absl::OkStatus();
 }
 

--- a/rtp_llm/cpp/normal_engine/NormalEngine.h
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.h
@@ -21,7 +21,9 @@ namespace rtp_llm {
 
 class NormalEngine: public EngineBase {
 public:
-    NormalEngine(const EngineInitParams& params, std::unique_ptr<ProposeModelEngineInitParams> propose_params);
+    NormalEngine(const EngineInitParams& params,
+                 std::unique_ptr<ProposeModelEngineInitParams> propose_params,
+                 bool defer_loop_start = false);
     ~NormalEngine();
 
     std::shared_ptr<GenerateStream> makeStream(const std::shared_ptr<GenerateInput>& input) override;
@@ -35,7 +37,7 @@ public:
 
     KVCacheInfo  getCacheStatusInfo(int64_t latest_version, bool need_cache_keys) override;
     absl::Status step();
-    absl::Status startLoop();
+    absl::Status startLoop() override;
     int64_t      getLastScheduleTime() override;
     void         reportMetrics(RtpLLMEngineMetricsCollector collector) {
         if (metrics_reporter_) {

--- a/rtp_llm/cpp/normal_engine/test/BUILD
+++ b/rtp_llm/cpp/normal_engine/test/BUILD
@@ -102,3 +102,12 @@ cc_test(
     },
     exec_properties = {'gpu':'H20'},
 )
+
+cc_test(
+    name = "deferred_engine_start_test",
+    srcs = ["DeferredEngineStartTest.cc"],
+    copts = test_copts,
+    deps = [":mock_engine"] + cuda13_torch_link_deps,
+    env = {"TEST_USING_DEVICE": "CUDA"},
+    exec_properties = {"gpu": "H20"},
+)

--- a/rtp_llm/cpp/normal_engine/test/DeferredEngineStartTest.cc
+++ b/rtp_llm/cpp/normal_engine/test/DeferredEngineStartTest.cc
@@ -1,0 +1,60 @@
+#include "rtp_llm/cpp/normal_engine/test/MockEngine.h"
+
+namespace rtp_llm {
+
+class DeferredEngineStartTest: public DeviceTestBase {
+protected:
+    std::shared_ptr<NormalEngine> prepareEngine() {
+        ModelConfig model_config;
+        RuntimeConfig runtime_config;
+        KVCacheConfig kv_cache_config;
+        auto params = createEngineInitParams(CustomConfig{}, model_config, runtime_config, kv_cache_config);
+        const auto vocab = model_config.vocab_size;
+        NormalExecutor::test_model_factory = [vocab](const GptModelInitParams&) {
+            return std::make_unique<MockModel>(vocab);
+        };
+        auto engine = std::make_shared<NormalEngine>(params, nullptr, true);
+        NormalExecutor::test_model_factory = nullptr;
+        return engine;
+    }
+
+    void TearDown() override {
+        NormalExecutor::test_model_factory = nullptr;
+        DeviceTestBase::TearDown();
+    }
+};
+
+TEST_F(DeferredEngineStartTest, AbortedTemplateCanStopBeforeLoopStarts) {
+    auto engine = prepareEngine();
+    ASSERT_TRUE(engine->resourceContext().cache_manager);
+    EXPECT_FALSE(engine->running_.load());
+    EXPECT_EQ(engine->loop_thread_, nullptr);
+    EXPECT_TRUE(engine->stop().ok());
+    // Destruction must also tolerate an initialized engine with no loop.
+    engine.reset();
+}
+
+TEST_F(DeferredEngineStartTest, ReleaseStartsOneLoopAndGenerates) {
+    auto engine = prepareEngine();
+    ASSERT_FALSE(engine->running_.load());
+    ASSERT_EQ(engine->loop_thread_, nullptr);
+    std::shared_ptr<EngineBase> base = engine;
+    ASSERT_TRUE(base->startLoop().ok());
+    auto first_thread = engine->loop_thread_;
+    ASSERT_NE(first_thread, nullptr);
+    ASSERT_TRUE(base->startLoop().ok());
+    EXPECT_EQ(engine->loop_thread_, first_thread);
+
+    auto input = std::make_shared<GenerateInput>();
+    input->input_ids = torch::tensor({1, 2, 3}, torch::kInt32);
+    input->generate_config = std::make_shared<GenerateConfig>();
+    input->generate_config->max_new_tokens = 3;
+    input->generate_config->is_streaming = false;
+    auto stream = engine->enqueue(input);
+    auto output = stream->nextOutput();
+    ASSERT_TRUE(output.ok()) << output.status().ToString();
+    EXPECT_EQ(output.value().generate_outputs[0].aux_info.output_len, 3);
+    EXPECT_TRUE(stream->hasEvent(StreamEvents::GenerateDone));
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/pybind/BUILD
+++ b/rtp_llm/cpp/pybind/BUILD
@@ -96,6 +96,7 @@ cc_library(
         "//rtp_llm/cpp/model_rpc:model_rpc_server",
         "//rtp_llm/cpp/engine_base/schedulers:schedulers",
         "//rtp_llm/cpp/cache:cache",
+        "//rtp_llm/cpp/utils:core_utils",
         "//rtp_llm/cpp/utils:signal_utils",
         "//:rtp_compute_ops",
         "@xgrammar//:xgrammar",

--- a/rtp_llm/cpp/pybind/init.cc
+++ b/rtp_llm/cpp/pybind/init.cc
@@ -2,6 +2,7 @@
 #include "rtp_llm/cpp/cache/Types.h"
 #include "rtp_llm/cpp/pybind/multi_gpu_gpt/RtpLLMOp.h"
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
+#include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/cpp/pybind/multi_gpu_gpt/RtpEmbeddingOp.h"
 #include "rtp_llm/cpp/pybind/multi_gpu_gpt/XGrammarBootstrap.h"
 #include "rtp_llm/models_py/bindings/OpDefs.h"
@@ -52,6 +53,7 @@ void registerEmbeddingOutput(const py::module& m) {
 }
 
 PYBIND11_MODULE(libth_transformer, m) {
+    m.def("refresh_logger_after_scr", &Logger::refreshRuntimeIdentity, py::arg("pod_ip"));
     m.def("pause_kmonitor_for_scr", &pauseKmonitorForScr, py::call_guard<py::gil_scoped_release>());
     m.def("resume_kmonitor_after_scr", &resumeKmonitorAfterScr, py::call_guard<py::gil_scoped_release>());
     registerRtpLLMOp(m);

--- a/rtp_llm/cpp/utils/Logger.cc
+++ b/rtp_llm/cpp/utils/Logger.cc
@@ -14,14 +14,38 @@
  * limitations under the License.
  */
 
+#include <arpa/inet.h>
+#include <atomic>
 #include <filesystem>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "autil/NetUtil.h"
 
 namespace rtp_llm {
+
+namespace {
+// One immutable override covers every Logger, including lazy instances created
+// after restore. The constructor-cached IP remains the normal-startup fallback.
+std::shared_ptr<const std::string> runtime_ip;
+}  // namespace
+
+void Logger::refreshRuntimeIdentity(const std::string& ip) {
+    in_addr ipv4;
+    in6_addr ipv6;
+    if (ip.find('\0') != std::string::npos
+        || (inet_pton(AF_INET, ip.c_str(), &ipv4) != 1 && inet_pton(AF_INET6, ip.c_str(), &ipv6) != 1)) {
+        throw std::invalid_argument("SCR logger runtime IP must be a numeric IP address");
+    }
+    std::atomic_store_explicit(&runtime_ip, std::make_shared<const std::string>(ip), std::memory_order_release);
+}
+
+std::string Logger::runtimeIp() const {
+    auto current = std::atomic_load_explicit(&runtime_ip, std::memory_order_acquire);
+    return current ? *current : ip_;
+}
 
 bool initLogger(std::string log_file_path) {
     std::cerr << "initLogger log_file_path: " << log_file_path << std::endl;

--- a/rtp_llm/cpp/utils/Logger.h
+++ b/rtp_llm/cpp/utils/Logger.h
@@ -68,6 +68,10 @@ public:
 
     void setBaseLevel(const uint32_t base_level);
 
+    // Update all existing and future loggers in this process after SCR restore.
+    // Publication is atomic with respect to concurrent prefix readers.
+    static void refreshRuntimeIdentity(const std::string& ip);
+
     template<typename... Args>
     void log(uint32_t          level,
              const std::string file,
@@ -134,13 +138,15 @@ private:
 
     uint32_t getLevelfromstr(const char* s);
 
+    std::string runtimeIp() const;
+
     inline const std::string getPrefix(const std::string& file, int line, const std::string& func) {
-        return "[RANK " + std::to_string(rank_) + "][" + ip_ + "][" + file + ":" + std::to_string(line) + "][" + func
+        return "[RANK " + std::to_string(rank_) + "][" + runtimeIp() + "][" + file + ":" + std::to_string(line) + "][" + func
                + "] ";
     }
 
     inline const std::string getTracePrefix() {
-        return "[RANK " + std::to_string(rank_) + "][" + ip_ + "] ";
+        return "[RANK " + std::to_string(rank_) + "][" + runtimeIp() + "] ";
     }
 
     inline const std::string getLevelName(const uint32_t level) {

--- a/rtp_llm/dash_sc/app.py
+++ b/rtp_llm/dash_sc/app.py
@@ -43,7 +43,10 @@ from rtp_llm.openai.renderer_factory import ChatRendererFactory
 from rtp_llm.openai.renderers.custom_renderer import RendererParams
 from rtp_llm.ops import TaskType
 from rtp_llm.server.backend_rpc_server_visitor import create_backend_rpc_server_visitor
-from rtp_llm.utils.scr_template_utils import register_backend_visitor_template_hook
+from rtp_llm.utils.scr_template_utils import (
+    register_backend_visitor_template_hook,
+    register_server_config_template_hook,
+)
 
 _PROXY_MODE_ENV_KEY = "DASH_SC_GRPC_PROXY_MODE"
 _FORWARD_ENV_KEY = "DASH_SC_GRPC_FORWARD_ADDR"
@@ -601,6 +604,8 @@ class DashScApp:
                     model_config=model_config,
                     source_role="dash",
                 )
+                # Refresh ServerConfig.ip before the visitor hook reads it during fixup.
+                register_server_config_template_hook(self.py_env_configs)
                 register_backend_visitor_template_hook(backend_visitor, self.py_env_configs)
 
                 base_tok = TokenizerFactory.create(

--- a/rtp_llm/frontend/frontend_worker.py
+++ b/rtp_llm/frontend/frontend_worker.py
@@ -31,7 +31,10 @@ from rtp_llm.utils.base_model_datatypes import GenerateResponse
 from rtp_llm.utils.complete_response_async_generator import (
     CompleteResponseAsyncGenerator,
 )
-from rtp_llm.utils.scr_template_utils import register_backend_visitor_template_hook
+from rtp_llm.utils.scr_template_utils import (
+    register_backend_visitor_template_hook,
+    register_server_config_template_hook,
+)
 
 
 class PipelineResponse(BaseModel):
@@ -113,6 +116,8 @@ class FrontendWorker:
         )
         self.backend_rpc_server_visitor = self.pipeline.backend_rpc_server_visitor
         self._py_env_configs = py_env_configs
+        # Refresh ServerConfig.ip before the visitor hook reads it during fixup.
+        register_server_config_template_hook(py_env_configs)
         register_backend_visitor_template_hook(self.backend_rpc_server_visitor, py_env_configs)
         self.generate_env_config = py_env_configs.generate_env_config
         self.server_config = py_env_configs.server_config

--- a/rtp_llm/ops/fused_rope_kvcache_op.py
+++ b/rtp_llm/ops/fused_rope_kvcache_op.py
@@ -1,3 +1,4 @@
+import inspect
 from dataclasses import dataclass
 from functools import cache
 from typing import Optional
@@ -16,6 +17,17 @@ def _get_fused_rope_kvcache():
     from rtp_kernel import fused_rope_kvcache
 
     return fused_rope_kvcache
+
+
+@cache
+def _uses_position_ids_api():
+    return (
+        "cu_seqlens"
+        in inspect.signature(
+            _get_fused_rope_kvcache().decode_fused_rope_kvcache
+        ).parameters
+    )
+
 
 @dataclass
 class FusedRopeAttnParams:
@@ -113,7 +125,11 @@ class FusedRopeKVCachePrefillOpBase:
                 rope_cache.data if check_rope_cache(rope_config, rope_cache) else None
             ),
             padding_offset=params.padding_offset,
-            cp_position_ids=params.cp_position_ids,
+            **{
+                (
+                    "position_ids" if _uses_position_ids_api() else "cp_position_ids"
+                ): params.cp_position_ids
+            },
             use_logn_attn=self.attn_configs.use_logn_attn,
             rope_style=rope_config.style,
             rope_dim=rope_config.dim,
@@ -185,7 +201,11 @@ class FusedRopeKVCacheDecodeOp:
         assert params.sequence_lengths.is_cuda, "sequence_lengths must be a CUDA tensor"
         return _get_fused_rope_kvcache().decode_fused_rope_kvcache(
             qkv,
-            params.sequence_lengths,
+            *(
+                (None, params.sequence_lengths)
+                if _uses_position_ids_api()
+                else (params.sequence_lengths,)
+            ),
             params.sequence_lengths.size(0),
             self.attn_configs.head_num,
             self.attn_configs.kv_head_num,

--- a/rtp_llm/server/backend_manager.py
+++ b/rtp_llm/server/backend_manager.py
@@ -151,7 +151,7 @@ class BackendManager(object):
             distributed_server=self._distributed_server,
         )
         phase = os.environ.get("SCR_PHASE", "").strip().lower()
-        role_type = self.py_env_configs.pd_sep_config.role_type
+        role_type = self.py_env_configs.role_config.role_type
         pd_role = str(getattr(role_type, "name", role_type)).lower() in {
             "prefill",
             "decode",

--- a/rtp_llm/start_server.py
+++ b/rtp_llm/start_server.py
@@ -27,7 +27,7 @@ from rtp_llm.utils.process_manager import (
 )
 from rtp_llm.utils.scr_template_utils import (
     ScrParticipantManifest,
-    arrive_scr_checkpoint_barrier,
+    arrive_scr_template_barrier as arrive_scr_checkpoint_barrier,
     build_scr_participant_manifest,
     configure_scr_environment,
     is_scr_template_phase_active,

--- a/rtp_llm/test/start_backend_scr_integration_test.py
+++ b/rtp_llm/test/start_backend_scr_integration_test.py
@@ -16,6 +16,38 @@ from rtp_llm.ops import RoleType, VitSeparation
 
 
 class BackendScrIntegrationTest(unittest.TestCase):
+    def test_parent_arrival_runs_template_lifecycle_hooks(self):
+        from rtp_llm.utils import scr_template_utils as scr
+        from rtp_llm.utils.scr_template_lifecycle import CallbackHook, TemplateLifecycle
+
+        order = []
+        lifecycle = TemplateLifecycle()
+        lifecycle.register(
+            "parent-reporter",
+            CallbackHook(
+                prepare=lambda generation: order.append("prepare"),
+                fixup=lambda generation: order.append("fixup"),
+                release=lambda generation: order.append("release"),
+            ),
+        )
+        manifest = SimpleNamespace(
+            worker_id=lambda role, instance: 0,
+            worker_num=1,
+            generation="parent-generation",
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"RTPLLM_ENABLE_SCR": "1", "SCR_PHASE": "checkpoint"},
+        ), mock.patch.object(
+            scr, "get_template_lifecycle", return_value=lifecycle
+        ), mock.patch.object(
+            scr, "arrive_scr_checkpoint_barrier",
+            side_effect=lambda **kwargs: order.append("barrier") or 0,
+        ):
+            self.assertEqual(launcher._start_parent_scr_arrival(manifest), 0)
+        self.assertEqual(order, ["prepare", "barrier", "fixup", "release"])
+        self.assertFalse(lifecycle.active)
+
     def _config(self, local_rank=1, world_rank=5):
         return SimpleNamespace(
             parallelism_config=SimpleNamespace(

--- a/rtp_llm/utils/scr_local_comm.py
+++ b/rtp_llm/utils/scr_local_comm.py
@@ -30,6 +30,11 @@ def cache_store_advertise_ip(world_info, parallelism_config):
     validate_local_members(world_info, parallelism_config)
     if world_info.members[0].ip != "127.0.0.1":
         return None
+    from rtp_llm.utils.scr_runtime_fixup import get_restore_runtime_identity
+
+    identity = get_restore_runtime_identity()
+    if identity is not None:
+        return identity.pod_ip
     return current_pod_ip()
 
 

--- a/rtp_llm/utils/scr_local_comm.py
+++ b/rtp_llm/utils/scr_local_comm.py
@@ -1,10 +1,36 @@
 """Opt-in communication for SCR ranks sharing one Pod network namespace."""
 
+import ipaddress
 import os
+import socket
 
 
 def local_comm_enabled():
     return os.environ.get("RTP_LLM_SCR_LOCAL_COMM") == "1"
+
+
+def current_pod_ip():
+    """Resolve the current network namespace, never a checkpoint-cached IP."""
+    address = socket.gethostbyname(socket.gethostname())
+    parsed = ipaddress.IPv4Address(address)
+    if parsed.is_loopback or parsed.is_unspecified or parsed.is_multicast:
+        raise ValueError("SCR external endpoints require a non-loopback Pod IP")
+    return address
+
+
+def cache_store_advertise_ip(world_info, parallelism_config):
+    """Keep local control addresses separate from cross-Pod KV advertisements.
+
+    Return an override only for the opt-in single-Pod loopback topology. Explicit
+    routable manifest addresses retain their authority. Resolve on every fixup
+    because both the seed environment and server configuration survive CRIU.
+    """
+    if not local_comm_enabled():
+        return None
+    validate_local_members(world_info, parallelism_config)
+    if world_info.members[0].ip != "127.0.0.1":
+        return None
+    return current_pod_ip()
 
 
 def validate_local_world(world_size, local_world_size, num_nodes):

--- a/rtp_llm/utils/scr_runtime_fixup.py
+++ b/rtp_llm/utils/scr_runtime_fixup.py
@@ -1,13 +1,14 @@
 """Repair process-local runtime state before releasing an SCR template.
 
-Restore environment input is supplied as data, never shell code. A future
-platform file adapter should be registered before arrival and read the file
-inside the provider on *each* invocation, not while constructing the seed.
+Restore environment input is supplied as data, never shell code. Read the
+platform file after each barrier, never while constructing the seed. A missing
+file preserves the existing namespace-discovery fallback.
 """
 
 from __future__ import annotations
 
 import ipaddress
+import json
 import logging
 import os
 import sys
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 
 
 LOGGER = logging.getLogger(__name__)
+RESTORE_ENV_FILE = "/etc/scr/envs.json"
 # Identity/metrics inputs only. GPU topology, model config, SCR control state,
 # credentials and filesystem paths require their own explicit repair contracts.
 RESTORE_ENV_KEYS = frozenset(
@@ -56,15 +58,42 @@ def get_restore_runtime_identity() -> RestoreRuntimeIdentity | None:
 
 
 def register_restore_env_provider(provider: RestoreEnvProvider | None) -> None:
-    """Install a process-local adapter before SCR arrival; None disables it.
+    """Override the default file reader; None restores the default reader.
 
     The adapter must validate the file's generation/current Pod identity and select
     supported keys. Returning None for an allowed key removes its seed value.
-    Each participating process needs its own registration. No format/path is
-    assumed until the platform defines the restore environment file contract.
+    Each participating process needs its own registration for a custom adapter.
+    Without one, each fixup reads /etc/scr/envs.json if present.
     """
     global _restore_env_provider
     _restore_env_provider = provider
+
+
+def _read_restore_env_file() -> Mapping[str, str | None]:
+    """Read a freshly published JSON environment object; absence is supported.
+
+    The platform must publish this file for the current container, atomically.
+    A full environment may contain unrelated keys; only repairable identity and
+    metrics inputs are selected. Null explicitly removes an allowed seed key.
+    """
+    try:
+        with open(RESTORE_ENV_FILE, encoding="utf-8") as source:
+            values = json.load(source)
+    except FileNotFoundError:
+        LOGGER.info(
+            "SCR restore environment file %s absent; using namespace discovery "
+            "and retaining other environment values",
+            RESTORE_ENV_FILE,
+        )
+        return {}
+    except (json.JSONDecodeError, UnicodeError):
+        # Do not include file contents (which may contain credentials) in errors.
+        raise ValueError(
+            "SCR restore environment file must contain valid JSON"
+        ) from None
+    if not isinstance(values, dict):
+        raise ValueError("SCR restore environment file must contain a JSON object")
+    return {key: value for key, value in values.items() if key in RESTORE_ENV_KEYS}
 
 
 def _validate_environment(values: Mapping[str, str | None]) -> dict[str, str | None]:
@@ -101,7 +130,11 @@ def fixup_runtime_after_restore(
     """
     global _runtime_identity
     if restore_env is None:
-        restore_env = _restore_env_provider(generation) if _restore_env_provider else {}
+        restore_env = (
+            _restore_env_provider(generation)
+            if _restore_env_provider is not None
+            else _read_restore_env_file()
+        )
     updates = _validate_environment(restore_env)
     # Only an explicitly fresh provider may override namespace discovery.
     # os.environ['RequestedIP'] by itself can still be the seed's value.

--- a/rtp_llm/utils/scr_runtime_fixup.py
+++ b/rtp_llm/utils/scr_runtime_fixup.py
@@ -1,0 +1,153 @@
+"""Repair process-local runtime state before releasing an SCR template.
+
+Restore environment input is supplied as data, never shell code. A future
+platform file adapter should be registered before arrival and read the file
+inside the provider on *each* invocation, not while constructing the seed.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from rtp_llm.utils.scr_local_comm import current_pod_ip
+
+if TYPE_CHECKING:
+    from rtp_llm.utils.scr_template_lifecycle import TemplateLifecycle
+
+
+LOGGER = logging.getLogger(__name__)
+# Identity/metrics inputs only. GPU topology, model config, SCR control state,
+# credentials and filesystem paths require their own explicit repair contracts.
+RESTORE_ENV_KEYS = frozenset(
+    {
+        "RequestedIP",
+        "HIPPO_SLAVE_IP",
+        "HIPPO_ROLE",
+        "HIPPO_ROLE_SHORT_NAME",
+        "HIPPO_APP",
+        "HIPPO_SERVICE_NAME",
+        "kmonitorSinkAddress",
+        "kmonitorPort",
+    }
+)
+RestoreEnvProvider = Callable[[str], Mapping[str, str | None]]
+_restore_env_provider: RestoreEnvProvider | None = None
+
+
+@dataclass(frozen=True)
+class RestoreRuntimeIdentity:
+    generation: str
+    pod_ip: str
+    environment_keys: tuple[str, ...]
+
+
+_runtime_identity: RestoreRuntimeIdentity | None = None
+
+
+def get_restore_runtime_identity() -> RestoreRuntimeIdentity | None:
+    """Latest repaired identity in this process; never used as the next input."""
+    return _runtime_identity
+
+
+def register_restore_env_provider(provider: RestoreEnvProvider | None) -> None:
+    """Install a process-local adapter before SCR arrival; None disables it.
+
+    The adapter must validate the file's generation/current Pod identity and select
+    supported keys. Returning None for an allowed key removes its seed value.
+    Each participating process needs its own registration. No format/path is
+    assumed until the platform defines the restore environment file contract.
+    """
+    global _restore_env_provider
+    _restore_env_provider = provider
+
+
+def _validate_environment(values: Mapping[str, str | None]) -> dict[str, str | None]:
+    if not isinstance(values, Mapping):
+        raise ValueError("restore environment provider must return a mapping")
+    result = dict(values)
+    if result.keys() - RESTORE_ENV_KEYS:
+        raise ValueError("restore environment contains unsupported keys")
+    for value in result.values():
+        if value is not None and (
+            not isinstance(value, str)
+            or "\0" in value
+            or "\n" in value
+            or "\r" in value
+        ):
+            raise ValueError(
+                "restore environment values must be single-line strings or None"
+            )
+    return result
+
+
+def fixup_runtime_after_restore(
+    generation: str,
+    lifecycle: TemplateLifecycle,
+    *,
+    restore_env: Mapping[str, str | None] | None = None,
+) -> RestoreRuntimeIdentity:
+    """Fresh inputs -> Logger/identity -> registered component repairs.
+
+    Called only after a successful template barrier, before any release hook.
+    Also runs when a checkpoint seed resumes. No cached phase/previous identity
+    is trusted to decide whether the process needs repair. Failures propagate;
+    the caller must not release serving after a partial fixup.
+    """
+    global _runtime_identity
+    if restore_env is None:
+        restore_env = _restore_env_provider(generation) if _restore_env_provider else {}
+    updates = _validate_environment(restore_env)
+    # Only an explicitly fresh provider may override namespace discovery.
+    # os.environ['RequestedIP'] by itself can still be the seed's value.
+    supplied_ip = updates.get("RequestedIP")
+    pod_ip = current_pod_ip() if supplied_ip is None else supplied_ip
+    parsed = ipaddress.IPv4Address(pod_ip)
+    if parsed.is_loopback or parsed.is_unspecified or parsed.is_multicast:
+        raise ValueError("restore identity requires a non-loopback Pod IP")
+    pod_ip = str(parsed)
+    extension = sys.modules.get("libth_transformer")
+    refresh_logger = getattr(extension, "refresh_logger_after_scr", None)
+    if extension is not None and not callable(refresh_logger):
+        raise RuntimeError(
+            "loaded native library lacks SCR Logger fixup; rebuild the complete image"
+        )
+
+    previous = _runtime_identity
+    for key, value in updates.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    os.environ["RequestedIP"] = pod_ip
+    if refresh_logger is not None:
+        refresh_logger(pod_ip)
+    identity = RestoreRuntimeIdentity(generation, pod_ip, tuple(sorted(updates)))
+    _runtime_identity = identity
+    # This class caches identity at import time. Refresh even before the Python
+    # reporter decides whether this is a Hippo environment on release.
+    hippo_module = sys.modules.get(
+        "rtp_llm.aios.kmonitor.python_client.kmonitor.utils.hippo_helper"
+    )
+    if hippo_module is not None:
+        hippo_module.HippoHelper.refresh_runtime_identity()
+    # Log only identity and key names, never the file body/environment values.
+    LOGGER.info(
+        "SCR runtime identity fixed generation=%s previous_runtime_ip=%s pod_ip=%s env_keys=%s",
+        generation,
+        previous.pod_ip if previous else "unrecorded",
+        pod_ip,
+        identity.environment_keys,
+    )
+    if os.environ.get("HIPPO_ROLE") and "HIPPO_SLAVE_IP" not in updates:
+        LOGGER.warning(
+            "SCR restore input did not supply HIPPO_SLAVE_IP; "
+            "host identity retained from environment, freshness unverified"
+        )
+    lifecycle.restore_fixup(generation)
+    return identity

--- a/rtp_llm/utils/scr_template_utils.py
+++ b/rtp_llm/utils/scr_template_utils.py
@@ -172,6 +172,11 @@ class _BackendVisitorTemplateHook:
         self.visitor.update_addresses(
             get_dp_addrs_from_world_info(world_info, self.configs.parallelism_config)
         )
+        from rtp_llm.utils.scr_local_comm import current_pod_ip, local_comm_enabled
+
+        if local_comm_enabled():
+            # Request correlation must identify the restored frontend, not its seed.
+            self.visitor.source_ip = current_pod_ip()
 
     def release_template(self, generation: str) -> None:
         return None

--- a/rtp_llm/utils/scr_template_utils.py
+++ b/rtp_llm/utils/scr_template_utils.py
@@ -29,6 +29,10 @@ from dataclasses import dataclass
 from typing import Any, Callable, Iterator, Mapping as TypingMapping, Optional
 
 from rtp_llm.utils.scr_template_lifecycle import get_template_lifecycle
+from rtp_llm.utils.scr_runtime_fixup import (
+    fixup_runtime_after_restore,
+    get_restore_runtime_identity,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -78,7 +82,12 @@ class _NativeKmonitorTemplateHook:
         # identity before native Kmonitor rebuilds its configuration.
         if os.environ.get("HIPPO_ROLE"):
             try:
-                os.environ["RequestedIP"] = socket.gethostbyname(socket.gethostname())
+                identity = get_restore_runtime_identity()
+                os.environ["RequestedIP"] = (
+                    identity.pod_ip
+                    if identity is not None and identity.generation == generation
+                    else socket.gethostbyname(socket.gethostname())
+                )
             except OSError:
                 LOGGER.warning(
                     "Cannot resolve current container IP for native Kmonitor",
@@ -174,8 +183,12 @@ class _BackendVisitorTemplateHook:
         )
         from rtp_llm.utils.scr_local_comm import current_pod_ip, local_comm_enabled
 
-        if local_comm_enabled():
-            # Request correlation must identify the restored frontend, not its seed.
+        # Request correlation must identify the restored frontend in all
+        # topologies. Retain the legacy standalone local hook fallback.
+        identity = get_restore_runtime_identity()
+        if identity is not None and identity.generation == generation:
+            self.visitor.source_ip = identity.pod_ip
+        elif local_comm_enabled():
             self.visitor.source_ip = current_pod_ip()
 
     def release_template(self, generation: str) -> None:
@@ -1495,7 +1508,7 @@ def arrive_scr_template_barrier(
             generation=generation,
             fail_closed=fail_closed,
         )
-        lifecycle.restore_fixup(actual_generation)
+        fixup_runtime_after_restore(actual_generation, lifecycle)
         lifecycle.release_template(actual_generation)
         return result
     except BaseException:

--- a/rtp_llm/utils/scr_template_utils.py
+++ b/rtp_llm/utils/scr_template_utils.py
@@ -204,6 +204,41 @@ def register_backend_visitor_template_hook(visitor: Any, py_env_configs: Any) ->
         _BackendVisitorTemplateHook(visitor, py_env_configs),
     )
 
+
+class _ServerConfigTemplateHook:
+    """Re-derive ``ServerConfig.ip`` from the current Pod on every restore.
+
+    ``ServerConfig.ip`` is a plain attribute copied into consumers at startup
+    (frontend request-id machine bits, log lines). CRIU restores it with the
+    seed value, so refresh it after the unified identity fixup and before the
+    process releases into serving.
+    """
+
+    def __init__(self, py_env_configs: Any) -> None:
+        self.configs = py_env_configs
+
+    def prepare_for_template(self, generation: str) -> None:
+        return None
+
+    def restore_fixup(self, generation: str) -> None:
+        identity = get_restore_runtime_identity()
+        if identity is None or identity.generation != generation:
+            return
+        self.configs.server_config.ip = identity.pod_ip
+
+    def release_template(self, generation: str) -> None:
+        return None
+
+    def abort_template(self, generation: str) -> None:
+        return None
+
+
+def register_server_config_template_hook(py_env_configs: Any) -> None:
+    get_template_lifecycle().register(
+        f"server-config:{id(py_env_configs)}",
+        _ServerConfigTemplateHook(py_env_configs),
+    )
+
 # ``RTPLLM_ENABLE_SCR`` is RTP-LLM's own participation switch.  ``SCR_ENABLE``
 # and ``SCR_PHASE`` are external control-plane inputs and are never derived or
 # mutated here. Checkpoint versus restore is chosen by the controller/platform.

--- a/rtp_llm/utils/scr_template_utils.py
+++ b/rtp_llm/utils/scr_template_utils.py
@@ -20,6 +20,7 @@ import importlib
 import inspect
 import logging
 import os
+import socket
 import sys
 import threading
 import time
@@ -73,6 +74,16 @@ class _NativeKmonitorTemplateHook:
             return
         extension = self._extension()
         resume = getattr(extension, "resume_kmonitor_after_scr", None) if extension else None
+        # CRIU preserves seed environment values. Resolve the current namespace
+        # identity before native Kmonitor rebuilds its configuration.
+        if os.environ.get("HIPPO_ROLE"):
+            try:
+                os.environ["RequestedIP"] = socket.gethostbyname(socket.gethostname())
+            except OSError:
+                LOGGER.warning(
+                    "Cannot resolve current container IP for native Kmonitor",
+                    exc_info=True,
+                )
         if resume is None or not resume():
             raise RuntimeError("native Kmonitor did not resume after SCR")
         self._paused = False

--- a/rtp_llm/utils/scr_template_utils.py
+++ b/rtp_llm/utils/scr_template_utils.py
@@ -159,7 +159,7 @@ class _BackendVisitorTemplateHook:
             self.configs.distribute_config,
             self.configs.parallelism_config,
         )
-        role = getattr(self.configs.pd_sep_config, "role_type", "")
+        role = self.configs.role_config.role_type
         role_name = str(getattr(role, "name", role)).lower()
         world_info = resolve_world_info(
             current,

--- a/rtp_llm/utils/test/scr_advertise_ip_test.py
+++ b/rtp_llm/utils/test/scr_advertise_ip_test.py
@@ -1,0 +1,66 @@
+import os
+import socket
+import unittest
+from types import SimpleNamespace as NS
+from unittest.mock import patch
+
+from rtp_llm.utils.scr_local_comm import cache_store_advertise_ip, current_pod_ip
+
+
+class ScrAdvertiseIpTest(unittest.TestCase):
+    def setUp(self):
+        self.pc = NS(world_size=2, local_world_size=2)
+        self.world = NS(
+            num_nodes=1,
+            self=NS(ip="192.0.2.1"),
+            members=[NS(ip="127.0.0.1", world_rank=i, local_rank=i) for i in range(2)],
+        )
+        self.env = patch.dict(os.environ, {"RTP_LLM_SCR_LOCAL_COMM": "1"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def test_resolves_each_restore_without_using_seed_identity(self):
+        with patch("socket.gethostname", return_value="restored-pod"), patch(
+            "socket.gethostbyname", side_effect=["192.0.2.20", "192.0.2.21"]
+        ) as resolve:
+            self.assertEqual(cache_store_advertise_ip(self.world, self.pc), "192.0.2.20")
+            self.assertEqual(cache_store_advertise_ip(self.world, self.pc), "192.0.2.21")
+        self.assertEqual(resolve.call_count, 2)
+        self.assertEqual(self.world.self.ip, "192.0.2.1")
+        self.assertEqual([m.ip for m in self.world.members], ["127.0.0.1"] * 2)
+
+    def test_disabled_mode_does_not_require_local_topology_or_resolve(self):
+        with patch.dict(os.environ, {"RTP_LLM_SCR_LOCAL_COMM": "0"}), patch(
+            "socket.gethostbyname"
+        ) as resolve:
+            self.assertIsNone(cache_store_advertise_ip(None, None))
+        resolve.assert_not_called()
+
+    def test_explicit_manifest_host_preserved(self):
+        for member in self.world.members:
+            member.ip = "192.0.2.50"
+        with patch("socket.gethostbyname") as resolve:
+            self.assertIsNone(cache_store_advertise_ip(self.world, self.pc))
+        resolve.assert_not_called()
+
+    def test_invalid_topology_rejected_before_resolution(self):
+        self.world.members.pop()
+        with patch("socket.gethostbyname") as resolve, self.assertRaises(ValueError):
+            cache_store_advertise_ip(self.world, self.pc)
+        resolve.assert_not_called()
+
+    def test_unusable_addresses_fail_closed(self):
+        for address in ["127.0.0.1", "127.0.0.2", "0.0.0.0", "224.0.0.1", "::1", "bad"]:
+            with self.subTest(address=address), patch(
+                "socket.gethostbyname", return_value=address
+            ), self.assertRaises(ValueError):
+                current_pod_ip()
+
+    def test_resolution_failure_does_not_fall_back_to_seed(self):
+        with patch("socket.gethostbyname", side_effect=socket.gaierror("no address")):
+            with self.assertRaises(socket.gaierror):
+                cache_store_advertise_ip(self.world, self.pc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/test/scr_endpoint_config_test.py
+++ b/rtp_llm/utils/test/scr_endpoint_config_test.py
@@ -1,0 +1,86 @@
+"""Exercise endpoint restore hooks with the production configuration schema."""
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from rtp_llm.config.py_config_modules import PyEnvConfigs
+from rtp_llm.server.backend_manager import BackendManager
+from rtp_llm.utils.scr_template_utils import _BackendVisitorTemplateHook
+
+
+class ScrEndpointConfigTest(unittest.TestCase):
+    def test_visitor_uses_real_config_and_preserves_endpoint_requirements(self):
+        for role, nodes, phase, required in [
+            ("PREFILL", 1, "restore", True),
+            ("DECODE", 1, "restore", True),
+            ("PDFUSION", 2, "restore", True),
+            ("PDFUSION", 1, "restore", False),
+            ("PREFILL", 1, "checkpoint", False),
+        ]:
+            with self.subTest(role=role, nodes=nodes, phase=phase):
+                configs = PyEnvConfigs()
+                configs.role_config.role_type = role
+                current = SimpleNamespace(num_nodes=nodes)
+                restored = object()
+                visitor = Mock()
+                hook = _BackendVisitorTemplateHook(visitor, configs)
+                with patch.dict(os.environ, {"SCR_PHASE": phase}), patch(
+                    "rtp_llm.distribute.distributed_server.get_world_info", return_value=current
+                ), patch(
+                    "rtp_llm.distribute.distributed_server.get_dp_addrs_from_world_info",
+                    return_value=["192.0.2.20:9001"],
+                ), patch(
+                    "rtp_llm.utils.scr_endpoint_provider.resolve_world_info", return_value=restored
+                ) as resolve:
+                    hook.restore_fixup("generation-2")
+                resolve.assert_called_once_with(
+                    current, generation="generation-2", require_manifest=required,
+                    require_transport=required,
+                )
+                visitor.update_addresses.assert_called_once_with(["192.0.2.20:9001"])
+
+    def test_backend_uses_real_config_and_refreshes_engine_endpoints(self):
+        for role, nodes, phase, required in [
+            ("PREFILL", 1, "restore", True),
+            ("DECODE", 1, "restore", True),
+            ("PDFUSION", 2, "restore", True),
+            ("PDFUSION", 1, "restore", False),
+            ("PREFILL", 1, "checkpoint", False),
+        ]:
+            with self.subTest(role=role, nodes=nodes, phase=phase):
+                configs = PyEnvConfigs()
+                configs.role_config.role_type = role
+                backend = BackendManager.__new__(BackendManager)
+                backend.py_env_configs = configs
+                backend._distributed_server = Mock()
+                backend._engine_config = SimpleNamespace(
+                    runtime_config=object(), parallelism_config=configs.parallelism_config
+                )
+                backend._world_info = object()
+                backend.engine = Mock()
+                current = SimpleNamespace(num_nodes=nodes)
+                restored = object()
+                with patch.dict(os.environ, {"SCR_PHASE": phase}), patch(
+                    "rtp_llm.server.backend_manager.get_world_info", return_value=current
+                ), patch(
+                    "rtp_llm.server.backend_manager.resolve_world_info", return_value=restored
+                ) as resolve, patch(
+                    "rtp_llm.server.backend_manager.update_worker_addrs"
+                ) as update:
+                    backend.restore_fixup("generation-2")
+                resolve.assert_called_once_with(
+                    current, generation="generation-2", require_manifest=required,
+                    require_transport=required,
+                )
+                update.assert_called_once_with(
+                    backend._engine_config.runtime_config, configs.parallelism_config, restored
+                )
+                self.assertIs(backend._world_info, restored)
+                backend.engine.update_runtime_endpoints.assert_called_once_with(
+                    backend._engine_config.runtime_config, restored
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
+++ b/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
@@ -17,6 +17,43 @@ reporters = importlib.import_module(
 
 
 class ScrKmonitorLifecycleTest(unittest.TestCase):
+    def test_native_resume_sees_resolved_ip_with_stale_seed_environment(self):
+        observed = []
+        native = SimpleNamespace(
+            resume_kmonitor_after_scr=lambda: observed.append(
+                os.getenv("RequestedIP")
+            ) or True
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"HIPPO_ROLE": "rtp_role", "RequestedIP": "10.1.0.1"},
+        ), mock.patch.object(
+            socket, "gethostname", return_value="restored-pod"
+        ), mock.patch.object(
+            socket, "gethostbyname", return_value="10.1.0.2"
+        ) as resolve:
+            hook = scr._NativeKmonitorTemplateHook()
+            hook._paused = True
+            with mock.patch.dict(sys.modules, {"libth_transformer": native}):
+                hook.release_template("restored-generation")
+            resolve.assert_called_once_with("restored-pod")
+            self.assertEqual(observed, ["10.1.0.2"])
+
+    def test_native_resume_still_runs_if_hostname_resolution_fails(self):
+        native = SimpleNamespace(resume_kmonitor_after_scr=mock.Mock(return_value=True))
+        with mock.patch.dict(
+            os.environ,
+            {"HIPPO_ROLE": "rtp_role", "RequestedIP": "10.1.0.1"},
+        ), mock.patch.object(
+            socket, "gethostbyname", side_effect=OSError("resolution failed")
+        ):
+            hook = scr._NativeKmonitorTemplateHook()
+            hook._paused = True
+            with mock.patch.dict(sys.modules, {"libth_transformer": native}):
+                hook.release_template("restored-generation")
+            self.assertEqual(os.getenv("RequestedIP"), "10.1.0.1")
+        native.resume_kmonitor_after_scr.assert_called_once_with()
+
     def test_non_scr_hippo_transport_still_starts_eagerly(self):
         with mock.patch.object(
             reporters.HippoHelper, "is_hippo_env", return_value=True

--- a/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
+++ b/rtp_llm/utils/test/scr_kmonitor_lifecycle_test.py
@@ -1,6 +1,7 @@
 """Exercise reporter sockets and both SCR lifecycle hooks without a GPU."""
 
 import importlib
+import os
 import socket
 import sys
 import unittest
@@ -16,6 +17,85 @@ reporters = importlib.import_module(
 
 
 class ScrKmonitorLifecycleTest(unittest.TestCase):
+    def test_non_scr_hippo_transport_still_starts_eagerly(self):
+        with mock.patch.object(
+            reporters.HippoHelper, "is_hippo_env", return_value=True
+        ), mock.patch.object(
+            reporters.HippoHelper,
+            "get_hippo_tags",
+            return_value={"host_ip": "10.0.0.1"},
+        ), mock.patch.object(
+            reporters.HippoHelper, "refresh_runtime_identity"
+        ) as refresh, mock.patch.object(
+            reporters.ReportWorker, "start"
+        ) as start, mock.patch.object(
+            reporters, "FlumeClient"
+        ) as flume_cls, mock.patch.dict(
+            os.environ,
+            {"HIPPO_SLAVE_IP": "10.0.0.1"},
+            clear=True,
+        ):
+            worker = reporters.ReportWorker()
+
+        self.assertFalse(worker._transport_deferred)
+        flume_cls.assert_called_once_with("10.0.0.1", 4141, timeout=1000)
+        start.assert_called_once_with()
+        refresh.assert_not_called()
+
+    def test_scr_defers_transport_and_activates_with_fresh_identity(self):
+        old_tags = {"host_ip": "10.0.0.1", "container_ip": "10.1.0.1"}
+        new_tags = {"host_ip": "10.0.0.2", "container_ip": "10.1.0.2"}
+        with mock.patch.object(
+            reporters.HippoHelper, "is_hippo_env", return_value=True
+        ), mock.patch.object(
+            reporters.HippoHelper, "get_hippo_tags", return_value=old_tags
+        ), mock.patch.object(
+            reporters.HippoHelper,
+            "refresh_runtime_identity",
+            return_value=new_tags,
+        ), mock.patch.object(
+            reporters, "FlumeClient"
+        ) as flume_cls, mock.patch.dict(
+            os.environ,
+            {
+                "RTPLLM_ENABLE_SCR": "1",
+                "SCR_PHASE": "checkpoint",
+                "HIPPO_SLAVE_IP": "10.0.0.2",
+            },
+            clear=False,
+        ):
+            worker = reporters.ReportWorker()
+            self.assertTrue(worker._transport_deferred)
+            self.assertFalse(worker.started)
+            flume_cls.assert_not_called()
+
+            tags_ref = worker.init_tags
+            with mock.patch.object(worker, "start") as start:
+                worker.resume_after_checkpoint(False)
+
+            flume_cls.assert_called_once_with("10.0.0.2", 4141, timeout=1000)
+            self.assertIs(worker.init_tags, tags_ref)
+            self.assertEqual(worker.init_tags["container_ip"], "10.1.0.2")
+            start.assert_called_once_with()
+            event = worker.render_event(
+                "scr.metric",
+                1,
+                reporters.MetricDataPoint(
+                    2,
+                    {
+                        "host_ip": "10.0.0.1",
+                        "container_ip": "10.1.0.1",
+                        "custom": "kept",
+                    },
+                ),
+            )
+            message = event.body.decode("utf-8")
+            self.assertIn("host_ip=10.0.0.2", message)
+            self.assertIn("container_ip=10.1.0.2", message)
+            self.assertIn("custom=kept", message)
+            self.assertNotIn("10.0.0.1", message)
+            self.assertNotIn("10.1.0.1", message)
+
     def test_live_socket_closes_and_reconnects_without_losing_metrics(self):
         with mock.patch.object(
             reporters.HippoHelper, "is_hippo_env", return_value=False

--- a/rtp_llm/utils/test/scr_native_logger_test.py
+++ b/rtp_llm/utils/test/scr_native_logger_test.py
@@ -1,0 +1,164 @@
+"""Compile the real Logger on a CPU host; only alog/autil are test doubles.
+
+This checks prefix state, not alog file descriptors or actual CRIU restore.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+STUBS = {
+    "alog/Logger.h": r"""
+#pragma once
+#include <cstdint>
+#include <iostream>
+#include <mutex>
+#include <string>
+namespace alog {
+enum { LOG_LEVEL_ERROR=1, LOG_LEVEL_WARN=2, LOG_LEVEL_INFO=3,
+       LOG_LEVEL_DEBUG=4, LOG_LEVEL_TRACE1=5 };
+class Logger {
+public:
+    static Logger* getLogger(const char*) { static Logger l; return &l; }
+    void setLevel(uint32_t l) { level=l; }
+    uint32_t getLevel() { return level; }
+    bool isLevelEnabled(int32_t) { return true; }
+    void flush() {}
+    void log(uint32_t, const char*, const char* message) {
+        std::lock_guard<std::mutex> guard(lock);
+        std::cout << message << std::endl;
+    }
+private:
+    uint32_t level=LOG_LEVEL_INFO;
+    std::mutex lock;
+};
+class Configurator { public: static void configureLogger(const char*) {} };
+}
+#define AUTIL_ROOT_LOG_CONFIG() ((void)0)
+#define AUTIL_ROOT_LOG_SETLEVEL(level) ((void)0)
+""",
+    "alog/Appender.h": "#pragma once\nnamespace alog { class FileAppender {}; class ConsoleAppender {}; }\n",
+    "autil/EnvUtil.h": r"""
+#pragma once
+#include <cstdlib>
+namespace autil { struct EnvUtil {
+static int getEnv(const char* key, int fallback) {
+    const char* value=std::getenv(key); return value ? std::atoi(value) : fallback;
+}
+}; }
+""",
+    "autil/TimeUtility.h": "#pragma once\n",
+    "autil/NetUtil.h": r"""
+#pragma once
+#include <string>
+namespace autil { struct NetUtil {
+inline static std::string address="192.0.2.10";
+static bool GetDefaultIp(std::string& out) { out=address; return true; }
+}; }
+""",
+}
+
+
+@unittest.skipUnless(shutil.which("c++"), "C++ compiler required")
+class ScrNativeLoggerTest(unittest.TestCase):
+    def test_existing_and_late_loggers_use_each_restored_ip(self):
+        source = r"""
+#include "rtp_llm/cpp/utils/Logger.h"
+#include "autil/NetUtil.h"
+#include <thread>
+#include <vector>
+int main() {
+    using rtp_llm::Logger;
+    auto& engine = Logger::getEngineLogger();
+    auto& query = Logger::getQueryAccessLogger();
+    engine.log(alog::LOG_LEVEL_INFO, "file", 1, "fn", "seed");
+    for (const auto* ip : {"192.0.2.20", "192.0.2.30"}) {
+        autil::NetUtil::address=ip;
+        // The restored process retains existing Logger instances.
+        Logger::refreshRuntimeIdentity(ip);
+        // A logger instantiated late must use the process override, even if
+        // the constructor's network dependency still supplies a stale value.
+        autil::NetUtil::address="192.0.2.10";
+        engine.log(alog::LOG_LEVEL_INFO, "file", 1, "fn", "restored");
+        query.log(alog::LOG_LEVEL_INFO, "file", 1, "fn", "restored");
+        Logger::getStackTraceLogger().log(alog::LOG_LEVEL_INFO, "file", 1, "fn", "restored");
+        Logger::getAccessLogger().log(alog::LOG_LEVEL_INFO, "file", 1, "fn", "restored");
+    }
+    for (const auto& bad : {std::string(""), std::string("invalid"), std::string("192.0.2.1") + '\0' + "suffix"}) {
+        try { Logger::refreshRuntimeIdentity(bad); return 2; }
+        catch (const std::invalid_argument&) {}
+    }
+    engine.setRank(7);
+    engine.setBaseLevel(alog::LOG_LEVEL_TRACE1);
+    engine.log(alog::LOG_LEVEL_INFO, "file", 1, "fn", "trace-check");
+    std::vector<std::thread> readers;
+    for (int i=0; i<4; ++i) {
+        readers.emplace_back([&engine] {
+            for (int j=0; j<100; ++j)
+                engine.log(alog::LOG_LEVEL_INFO, "file", 1, "fn", "concurrent");
+        });
+    }
+    for (int i=0; i<100; ++i)
+        Logger::refreshRuntimeIdentity(i % 2 ? "192.0.2.20" : "192.0.2.30");
+    for (auto& reader : readers) reader.join();
+}
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            for name, body in STUBS.items():
+                target = temp / name
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(body)
+            (temp / "main.cc").write_text(source)
+            binary = temp / "logger-test"
+            subprocess.run(
+                [
+                    "c++",
+                    "-std=c++17",
+                    "-pthread",
+                    "-I",
+                    str(temp),
+                    "-I",
+                    str(ROOT),
+                    str(ROOT / "rtp_llm/cpp/utils/Logger.cc"),
+                    str(temp / "main.cc"),
+                    "-o",
+                    str(binary),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            env = {
+                key: value for key, value in os.environ.items() if key != "LOG_LEVEL"
+            }
+            output = subprocess.run(
+                [str(binary)], check=True, capture_output=True, text=True, env=env
+            ).stdout.splitlines()
+        self.assertIn("[192.0.2.10]", output[0])
+        for line in output[1:5]:
+            self.assertIn("[192.0.2.20]", line)
+        for line in output[5:9]:
+            self.assertIn("[192.0.2.30]", line)
+        self.assertIn("[RANK 7][192.0.2.30] trace-check", output)
+        concurrent = [line for line in output if line.endswith("concurrent")]
+        self.assertEqual(len(concurrent), 400)
+        self.assertTrue(
+            all(
+                line
+                in {
+                    "[RANK 7][192.0.2.20] concurrent",
+                    "[RANK 7][192.0.2.30] concurrent",
+                }
+                for line in concurrent
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/test/scr_pd_advertisement_test.py
+++ b/rtp_llm/utils/test/scr_pd_advertisement_test.py
@@ -1,0 +1,56 @@
+"""Exercise the real config writer and restore hook with separate PD/control IPs."""
+import os
+import unittest
+from types import SimpleNamespace as NS
+from unittest.mock import Mock, patch
+
+from rtp_llm.config.engine_config import update_worker_addrs
+from rtp_llm.utils.scr_template_utils import _BackendVisitorTemplateHook
+
+
+class ScrPdAdvertisementTest(unittest.TestCase):
+    def setUp(self):
+        self.pc = NS(world_size=2, local_world_size=2, tp_size=2, dp_size=1, dp_rank=0, local_rank=0)
+        self.world = NS(
+            num_nodes=1,
+            members=[NS(ip="127.0.0.1", world_rank=i, local_rank=i,
+                        cache_store_listen_port=18632 + i * 10,
+                        cache_store_rdma_listen_port=18634 + i * 10,
+                        rpc_server_port=18631 + i * 10) for i in range(2)],
+        )
+        self.env = patch.dict(os.environ, {"RTP_LLM_SCR_LOCAL_COMM": "1", "SCR_PHASE": "restore"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def test_prefill_preserves_control_loopback_and_advertises_current_pod(self):
+        runtime = NS()
+        with patch("socket.gethostbyname", side_effect=["192.0.2.20", "192.0.2.21"]):
+            for ip in ["192.0.2.20", "192.0.2.21"]:
+                update_worker_addrs(runtime, self.pc, self.world)
+                self.assertEqual(runtime.worker_addrs, [ip + ":18632:18634", ip + ":18642:18644"])
+                self.assertEqual(runtime.worker_grpc_addrs, ["127.0.0.1:18631", "127.0.0.1:18641"])
+
+    def test_decode_dp_group_filter_is_preserved(self):
+        self.pc.tp_size, self.pc.dp_size, self.pc.dp_rank = 1, 2, 1
+        runtime = NS()
+        with patch("socket.gethostbyname", return_value="192.0.2.30"):
+            update_worker_addrs(runtime, self.pc, self.world)
+        self.assertEqual(runtime.worker_addrs, ["192.0.2.30:18642:18644"])
+        self.assertEqual(runtime.worker_grpc_addrs, ["127.0.0.1:18641"])
+
+    def test_frontend_identity_refreshes_without_publishing_loopback(self):
+        configs = NS(server_config=object(), distribute_config=object(),
+                     parallelism_config=self.pc, role_config=NS(role_type="PREFILL"))
+        visitor = Mock(source_ip="192.0.2.1")
+        with patch("rtp_llm.distribute.distributed_server.get_world_info", return_value=self.world), patch(
+            "rtp_llm.utils.scr_endpoint_provider.resolve_world_info", return_value=self.world
+        ), patch("rtp_llm.distribute.distributed_server.get_dp_addrs_from_world_info", return_value=["127.0.0.1:18631"]), patch(
+            "socket.gethostbyname", return_value="192.0.2.20"
+        ):
+            _BackendVisitorTemplateHook(visitor, configs).restore_fixup("generation-2")
+        self.assertEqual(visitor.source_ip, "192.0.2.20")
+        visitor.update_addresses.assert_called_once_with(["127.0.0.1:18631"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/test/scr_restore_env_file_test.py
+++ b/rtp_llm/utils/test/scr_restore_env_file_test.py
@@ -1,0 +1,207 @@
+"""Verify the optional platform file through the real SCR release boundary."""
+
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from rtp_llm.utils import scr_runtime_fixup as runtime
+from rtp_llm.utils import scr_template_utils as scr
+from rtp_llm.utils.scr_template_lifecycle import CallbackHook, TemplateLifecycle
+
+
+class ScrRestoreEnvFileTest(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.path = Path(directory.name) / "envs.json"
+        for context in (
+            patch.object(runtime, "RESTORE_ENV_FILE", str(self.path)),
+            patch.object(runtime, "_restore_env_provider", None),
+            patch.object(runtime, "_runtime_identity", None),
+            patch.dict(
+                os.environ,
+                {"RequestedIP": "192.0.2.10", "HIPPO_SLAVE_IP": "192.0.2.100"},
+            ),
+            patch.dict(
+                sys.modules,
+                {
+                    "libth_transformer": None,
+                    "rtp_llm.aios.kmonitor.python_client.kmonitor.utils.hippo_helper": None,
+                },
+            ),
+        ):
+            context.start()
+            self.addCleanup(context.stop)
+
+    def publish(self, values):
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(values), encoding="utf-8")
+        temporary.replace(self.path)
+
+    def barrier(self, events, after_barrier=None):
+        lifecycle = TemplateLifecycle()
+        lifecycle.register(
+            "component",
+            CallbackHook(
+                prepare=lambda g: events.append("prepare"),
+                fixup=lambda g: events.append(("fixup", os.environ["RequestedIP"])),
+                release=lambda g: events.append("release"),
+                abort=lambda g: events.append("abort"),
+            ),
+        )
+
+        def arrive(**kwargs):
+            events.append("barrier")
+            if after_barrier:
+                after_barrier()
+            return 0
+
+        with patch.object(
+            scr, "is_scr_template_phase_active", return_value=True
+        ), patch.object(
+            scr, "get_template_lifecycle", return_value=lifecycle
+        ), patch.object(
+            scr, "arrive_scr_checkpoint_barrier", side_effect=arrive
+        ):
+            return scr.arrive_scr_template_barrier(
+                worker_id=0, worker_num=1, generation="same-seed"
+            )
+
+    def test_missing_file_falls_back_and_releases(self):
+        events = []
+        with patch.object(runtime, "current_pod_ip", return_value="192.0.2.20"):
+            self.assertEqual(self.barrier(events), 0)
+        self.assertEqual(
+            events, ["prepare", "barrier", ("fixup", "192.0.2.20"), "release"]
+        )
+        self.assertEqual(os.environ["HIPPO_SLAVE_IP"], "192.0.2.100")
+        self.assertEqual(runtime.get_restore_runtime_identity().environment_keys, ())
+
+    def test_file_is_read_after_barrier_and_before_components(self):
+        # The seed-side bytes are invalid; only the newly published input may be read.
+        self.path.write_text("not-json", encoding="utf-8")
+        events = []
+        with patch.object(
+            runtime, "current_pod_ip", side_effect=AssertionError("file supplies IP")
+        ):
+            self.barrier(
+                events,
+                lambda: self.publish(
+                    {"RequestedIP": "192.0.2.20", "HIPPO_SLAVE_IP": "192.0.2.200"}
+                ),
+            )
+        self.assertEqual(events[-2:], [("fixup", "192.0.2.20"), "release"])
+        self.assertEqual(os.environ["HIPPO_SLAVE_IP"], "192.0.2.200")
+
+    def test_repeated_restore_rereads_atomically_replaced_file(self):
+        for address in ("192.0.2.20", "192.0.2.30"):
+            self.publish({"RequestedIP": address})
+            self.barrier([])
+            self.assertEqual(runtime.get_restore_runtime_identity().pod_ip, address)
+
+    def test_file_removed_after_previous_restore_uses_fallback(self):
+        self.publish({"RequestedIP": "192.0.2.20", "HIPPO_SLAVE_IP": "192.0.2.200"})
+        self.barrier([])
+        self.path.unlink()
+        with patch.object(runtime, "current_pod_ip", return_value="192.0.2.30"):
+            self.barrier([])
+        self.assertEqual(os.environ["RequestedIP"], "192.0.2.30")
+        self.assertEqual(os.environ["HIPPO_SLAVE_IP"], "192.0.2.200")
+        self.assertEqual(runtime.get_restore_runtime_identity().environment_keys, ())
+
+    def test_full_environment_only_updates_supported_fields(self):
+        self.publish(
+            {"RequestedIP": "192.0.2.20", "kmonitorPort": "4141", "TP_SIZE": "99"}
+        )
+        with patch.dict(os.environ, {"TP_SIZE": "2"}):
+            self.barrier([])
+            self.assertEqual(os.environ["TP_SIZE"], "2")
+            self.assertEqual(os.environ["kmonitorPort"], "4141")
+        self.assertEqual(
+            runtime.get_restore_runtime_identity().environment_keys,
+            ("RequestedIP", "kmonitorPort"),
+        )
+
+    def test_null_removes_seed_value_and_rediscovers_pod_ip(self):
+        self.publish({"RequestedIP": None, "HIPPO_ROLE_SHORT_NAME": None})
+        with patch.dict(
+            os.environ, {"HIPPO_ROLE_SHORT_NAME": "seed-role"}
+        ), patch.object(runtime, "current_pod_ip", return_value="192.0.2.30"):
+            self.barrier([])
+            self.assertNotIn("HIPPO_ROLE_SHORT_NAME", os.environ)
+            self.assertEqual(os.environ["RequestedIP"], "192.0.2.30")
+
+    def test_empty_object_preserves_discovery_fallback(self):
+        self.publish({})
+        with patch.object(runtime, "current_pod_ip", return_value="192.0.2.30"):
+            self.barrier([])
+        self.assertEqual(os.environ["RequestedIP"], "192.0.2.30")
+
+    def test_invalid_files_abort_without_mutating_environment(self):
+        for data in (
+            b"",
+            b"{",
+            b"\xff",
+            b"[]",
+            b"null",
+            b'"string"',
+            b'{"RequestedIP":"192.0.2.20","HIPPO_ROLE":42}',
+            b'{"RequestedIP":"127.0.0.1"}',
+        ):
+            with self.subTest(data=data):
+                self.path.write_bytes(data)
+                events = []
+                with self.assertRaises(ValueError):
+                    self.barrier(events)
+                self.assertEqual(events, ["prepare", "barrier", "abort"])
+                self.assertEqual(os.environ["RequestedIP"], "192.0.2.10")
+                self.assertIsNone(runtime.get_restore_runtime_identity())
+
+    def test_permission_error_is_not_treated_as_absent(self):
+        events = []
+        with patch(
+            "builtins.open", side_effect=PermissionError("denied")
+        ), self.assertRaises(PermissionError):
+            self.barrier(events)
+        self.assertEqual(events, ["prepare", "barrier", "abort"])
+
+    def test_custom_provider_overrides_file_and_none_restores_default(self):
+        self.publish({"RequestedIP": "192.0.2.30"})
+        provider = Mock(return_value={"RequestedIP": "192.0.2.20"})
+        runtime.register_restore_env_provider(provider)
+        self.barrier([])
+        self.assertEqual(os.environ["RequestedIP"], "192.0.2.20")
+        provider.assert_called_once_with("same-seed")
+        runtime.register_restore_env_provider(None)
+        self.barrier([])
+        self.assertEqual(os.environ["RequestedIP"], "192.0.2.30")
+
+    def test_explicit_input_overrides_provider_and_file(self):
+        self.path.write_text("not-json", encoding="utf-8")
+        provider = Mock(side_effect=AssertionError("explicit input wins"))
+        runtime.register_restore_env_provider(provider)
+        runtime.fixup_runtime_after_restore(
+            "same-seed", Mock(), restore_env={"RequestedIP": "192.0.2.40"}
+        )
+        self.assertEqual(os.environ["RequestedIP"], "192.0.2.40")
+        provider.assert_not_called()
+
+    def test_normal_startup_does_not_read_file(self):
+        self.path.write_text("not-json", encoding="utf-8")
+        with patch.object(
+            scr, "is_scr_template_phase_active", return_value=False
+        ), patch.object(
+            scr, "arrive_scr_checkpoint_barrier", return_value=None
+        ), patch.object(
+            runtime, "_read_restore_env_file"
+        ) as reader:
+            scr.arrive_scr_template_barrier(worker_id=0, worker_num=1)
+        reader.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/test/scr_runtime_fixup_test.py
+++ b/rtp_llm/utils/test/scr_runtime_fixup_test.py
@@ -226,6 +226,29 @@ class ScrRuntimeFixupTest(unittest.TestCase):
             endpoint_module.resolve_world_info.call_args.kwargs["require_manifest"]
         )
 
+    def test_server_config_ip_follows_restored_pod_identity(self):
+        configs = NS(server_config=NS(ip="192.0.2.10"))
+        observed = []
+        lifecycle = TemplateLifecycle()
+        lifecycle.register("server-config", scr._ServerConfigTemplateHook(configs))
+        # A hook registered afterwards must observe the refreshed value.
+        lifecycle.register(
+            "consumer",
+            CallbackHook(fixup=lambda _g: observed.append(configs.server_config.ip)),
+        )
+        lifecycle.prepare_for_template("g1", "restore")
+        runtime.fixup_runtime_after_restore(
+            "g1", lifecycle, restore_env={"RequestedIP": "192.0.2.20"}
+        )
+        self.assertEqual(configs.server_config.ip, "192.0.2.20")
+        self.assertEqual(observed, ["192.0.2.20"])
+        # A repeat restore of the same generation must re-read the new Pod IP.
+        lifecycle.prepare_for_template("g1", "restore")
+        runtime.fixup_runtime_after_restore(
+            "g1", lifecycle, restore_env={"RequestedIP": "192.0.2.30"}
+        )
+        self.assertEqual(configs.server_config.ip, "192.0.2.30")
+
     def test_native_or_component_fixup_failure_blocks_normal_release(self):
         for fail_native in (True, False):
             with self.subTest(fail_native=fail_native):

--- a/rtp_llm/utils/test/scr_runtime_fixup_test.py
+++ b/rtp_llm/utils/test/scr_runtime_fixup_test.py
@@ -1,0 +1,325 @@
+"""Exercise restore input, native bridge and lifecycle order without a GPU."""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace as NS
+from unittest.mock import Mock, patch
+
+from rtp_llm.utils import scr_runtime_fixup as runtime
+from rtp_llm.utils import scr_template_utils as scr
+from rtp_llm.utils.scr_local_comm import cache_store_advertise_ip
+from rtp_llm.utils.scr_template_lifecycle import CallbackHook, TemplateLifecycle
+
+
+class ScrRuntimeFixupTest(unittest.TestCase):
+    def setUp(self):
+        for context in (
+            patch.object(runtime, "_runtime_identity", None),
+            patch.object(runtime, "_restore_env_provider", None),
+            patch.dict(os.environ, {"RequestedIP": "192.0.2.10"}),
+            patch.dict(sys.modules, {"libth_transformer": None}),
+        ):
+            context.start()
+            self.addCleanup(context.stop)
+        # The helper is an import-time cache; isolate it too when another
+        # selected test module has already imported the metrics stack.
+        module = sys.modules.get(
+            "rtp_llm.aios.kmonitor.python_client.kmonitor.utils.hippo_helper"
+        )
+        if module is not None:
+            for name in (
+                "host_ip",
+                "container_ip",
+                "role",
+                "app",
+                "group",
+                "app_workdir",
+            ):
+                context = patch.object(
+                    module.HippoHelper, name, getattr(module.HippoHelper, name)
+                )
+                context.start()
+                self.addCleanup(context.stop)
+
+    def lifecycle(self, events):
+        lifecycle = TemplateLifecycle()
+        lifecycle.register(
+            "component",
+            CallbackHook(
+                prepare=lambda g: events.append("prepare"),
+                fixup=lambda g: events.append(("component", os.environ["RequestedIP"])),
+                release=lambda g: events.append("release"),
+                abort=lambda g: events.append("abort"),
+            ),
+        )
+        return lifecycle
+
+    def test_real_barrier_wrapper_orders_identity_before_components_and_release(self):
+        events = []
+        lifecycle = self.lifecycle(events)
+        native = NS(refresh_logger_after_scr=lambda ip: events.append(("logger", ip)))
+        runtime.register_restore_env_provider(
+            lambda g: events.append(("read-env", g)) or {"RequestedIP": "192.0.2.20"}
+        )
+        with patch.dict(sys.modules, {"libth_transformer": native}), patch.object(
+            scr, "is_scr_template_phase_active", return_value=True
+        ), patch.object(
+            scr, "get_template_lifecycle", return_value=lifecycle
+        ), patch.object(
+            scr,
+            "arrive_scr_checkpoint_barrier",
+            side_effect=lambda **kw: events.append("barrier") or 0,
+        ):
+            self.assertEqual(
+                scr.arrive_scr_template_barrier(
+                    worker_id=0, worker_num=1, generation="g1"
+                ),
+                0,
+            )
+        self.assertEqual(
+            events,
+            [
+                "prepare",
+                "barrier",
+                ("read-env", "g1"),
+                ("logger", "192.0.2.20"),
+                ("component", "192.0.2.20"),
+                "release",
+            ],
+        )
+
+    def test_repeated_restore_rereads_provider_even_with_same_checkpoint_generation(
+        self,
+    ):
+        provider = Mock(
+            side_effect=[{"RequestedIP": "192.0.2.20"}, {"RequestedIP": "192.0.2.30"}]
+        )
+        runtime.register_restore_env_provider(provider)
+        events = []
+        lifecycle = self.lifecycle(events)
+        for ip in ("192.0.2.20", "192.0.2.30"):
+            lifecycle.prepare_for_template("same-seed", "restore")
+            identity = runtime.fixup_runtime_after_restore("same-seed", lifecycle)
+            self.assertEqual(identity.pod_ip, ip)
+            lifecycle.release_template("same-seed")
+        self.assertEqual(provider.call_count, 2)
+
+    def test_without_provider_ignores_seed_environment_and_previous_snapshot(self):
+        lifecycle = self.lifecycle([])
+        lifecycle.prepare_for_template("g1", "checkpoint")
+        with patch.object(
+            runtime, "current_pod_ip", side_effect=["192.0.2.20", "192.0.2.30"]
+        ):
+            for expected in ("192.0.2.20", "192.0.2.30"):
+                self.assertEqual(
+                    runtime.fixup_runtime_after_restore("g1", lifecycle).pod_ip,
+                    expected,
+                )
+
+    def test_env_validation_and_discovery_fail_before_mutation_or_component_fixup(self):
+        lifecycle = Mock()
+        invalid = [
+            {"TP_SIZE": "4"},
+            {"SCR_PHASE": "restore"},
+            {"RequestedIP": "127.0.0.1"},
+            {"RequestedIP": "bad"},
+            {"HIPPO_ROLE": "x\ny"},
+            {"HIPPO_ROLE": 3},
+            {"RequestedIP": "0.0.0.0"},
+            {"RequestedIP": "224.0.0.1"},
+            {"RequestedIP": "::1"},
+            {"RequestedIP": "192.0.2.1\0suffix"},
+            {"RequestedIP": ""},
+        ]
+        for values in invalid:
+            with self.subTest(values=values), self.assertRaises(
+                (ValueError, TypeError)
+            ):
+                runtime.fixup_runtime_after_restore("g1", lifecycle, restore_env=values)
+            self.assertEqual(os.environ["RequestedIP"], "192.0.2.10")
+        with patch.object(
+            runtime, "current_pod_ip", side_effect=OSError("no route")
+        ), self.assertRaises(OSError):
+            runtime.fixup_runtime_after_restore("g1", lifecycle)
+        lifecycle.restore_fixup.assert_not_called()
+        self.assertIsNone(runtime.get_restore_runtime_identity())
+
+    def test_old_loaded_native_library_blocks_release(self):
+        events = []
+        lifecycle = self.lifecycle(events)
+        with patch.dict(sys.modules, {"libth_transformer": NS()}), patch.object(
+            runtime, "current_pod_ip", return_value="192.0.2.20"
+        ), patch.object(
+            scr, "is_scr_template_phase_active", return_value=True
+        ), patch.object(
+            scr, "get_template_lifecycle", return_value=lifecycle
+        ), patch.object(
+            scr, "arrive_scr_checkpoint_barrier", return_value=0
+        ):
+            with self.assertRaisesRegex(RuntimeError, "lacks SCR Logger fixup"):
+                scr.arrive_scr_template_barrier(
+                    worker_id=0, worker_num=1, generation="g1"
+                )
+        self.assertEqual(events, ["prepare", "abort"])
+        self.assertEqual(os.environ["RequestedIP"], "192.0.2.10")
+
+    def test_failed_provider_does_not_release(self):
+        events = []
+        lifecycle = self.lifecycle(events)
+        runtime.register_restore_env_provider(
+            Mock(side_effect=ValueError("stale generation"))
+        )
+        with patch.object(
+            scr, "is_scr_template_phase_active", return_value=True
+        ), patch.object(
+            scr, "get_template_lifecycle", return_value=lifecycle
+        ), patch.object(
+            scr, "arrive_scr_checkpoint_barrier", return_value=0
+        ):
+            with self.assertRaisesRegex(ValueError, "stale generation"):
+                scr.arrive_scr_template_barrier(
+                    worker_id=0, worker_num=1, generation="g1"
+                )
+        self.assertEqual(events, ["prepare", "abort"])
+
+    def test_normal_startup_does_not_read_restore_input(self):
+        provider = Mock(side_effect=AssertionError("unexpected read"))
+        runtime.register_restore_env_provider(provider)
+        with patch.object(
+            scr, "is_scr_template_phase_active", return_value=False
+        ), patch.object(scr, "arrive_scr_checkpoint_barrier", return_value=None):
+            scr.arrive_scr_template_barrier(worker_id=0, worker_num=1)
+        provider.assert_not_called()
+
+    def test_frontend_identity_updates_outside_loopback_mode(self):
+        visitor = Mock(source_ip="192.0.2.10")
+        configs = NS(
+            server_config=NS(),
+            distribute_config=NS(),
+            parallelism_config=NS(),
+            role_config=NS(role_type="PREFILL"),
+        )
+        endpoint_module = NS(resolve_world_info=Mock(return_value=NS()))
+        distributed_module = NS(
+            get_world_info=Mock(return_value=NS(num_nodes=1)),
+            get_dp_addrs_from_world_info=Mock(return_value=["192.0.2.40:9000"]),
+        )
+        lifecycle = TemplateLifecycle()
+        lifecycle.register("visitor", scr._BackendVisitorTemplateHook(visitor, configs))
+        lifecycle.prepare_for_template("g1", "restore")
+        with patch.dict(
+            os.environ, {"RTP_LLM_SCR_LOCAL_COMM": "0", "SCR_PHASE": "restore"}
+        ), patch.dict(
+            sys.modules,
+            {
+                "rtp_llm.distribute.distributed_server": distributed_module,
+                "rtp_llm.utils.scr_endpoint_provider": endpoint_module,
+            },
+        ):
+            runtime.fixup_runtime_after_restore(
+                "g1", lifecycle, restore_env={"RequestedIP": "192.0.2.20"}
+            )
+        self.assertEqual(visitor.source_ip, "192.0.2.20")
+        visitor.update_addresses.assert_called_once_with(["192.0.2.40:9000"])
+        self.assertTrue(
+            endpoint_module.resolve_world_info.call_args.kwargs["require_manifest"]
+        )
+
+    def test_native_or_component_fixup_failure_blocks_normal_release(self):
+        for fail_native in (True, False):
+            with self.subTest(fail_native=fail_native):
+                events = []
+                lifecycle = self.lifecycle(events)
+                refresh = Mock(
+                    side_effect=RuntimeError("native failed") if fail_native else None
+                )
+                if not fail_native:
+                    lifecycle.register(
+                        "broken",
+                        CallbackHook(
+                            fixup=Mock(side_effect=RuntimeError("component failed"))
+                        ),
+                    )
+                with patch.dict(
+                    sys.modules,
+                    {"libth_transformer": NS(refresh_logger_after_scr=refresh)},
+                ), patch.object(
+                    runtime, "current_pod_ip", return_value="192.0.2.20"
+                ), patch.object(
+                    scr, "is_scr_template_phase_active", return_value=True
+                ), patch.object(
+                    scr, "get_template_lifecycle", return_value=lifecycle
+                ), patch.object(
+                    scr, "arrive_scr_checkpoint_barrier", return_value=0
+                ):
+                    with self.assertRaises(RuntimeError):
+                        scr.arrive_scr_template_barrier(
+                            worker_id=0, worker_num=1, generation="g1"
+                        )
+                self.assertNotIn("release", events)
+                self.assertIn("abort", events)
+
+    def test_metrics_and_kv_advertisement_share_explicit_fresh_identity(self):
+        from rtp_llm.aios.kmonitor.python_client.kmonitor.utils.hippo_helper import (
+            HippoHelper,
+        )
+
+        cached_names = (
+            "host_ip",
+            "container_ip",
+            "role",
+            "app",
+            "group",
+            "app_workdir",
+        )
+        for name in cached_names:
+            context = patch.object(HippoHelper, name, getattr(HippoHelper, name))
+            context.start()
+            self.addCleanup(context.stop)
+        lifecycle = self.lifecycle([])
+        lifecycle.prepare_for_template("g1", "restore")
+        with patch.dict(
+            os.environ,
+            {"HIPPO_ROLE_SHORT_NAME": "seed-role", "RTP_LLM_SCR_LOCAL_COMM": "1"},
+        ):
+            runtime.fixup_runtime_after_restore(
+                "g1",
+                lifecycle,
+                restore_env={
+                    "RequestedIP": "192.0.2.20",
+                    "HIPPO_SLAVE_IP": "192.0.2.200",
+                    "HIPPO_ROLE": "restored-role",
+                    "HIPPO_ROLE_SHORT_NAME": None,
+                },
+            )
+            with patch(
+                "socket.gethostbyname",
+                side_effect=AssertionError("must reuse fresh identity"),
+            ):
+                tags = HippoHelper.refresh_runtime_identity()
+                native = NS(resume_kmonitor_after_scr=Mock(return_value=True))
+                with patch.dict(sys.modules, {"libth_transformer": native}):
+                    hook = scr._NativeKmonitorTemplateHook()
+                    hook._paused = True
+                    hook.release_template("g1")
+                world = NS(
+                    num_nodes=1,
+                    members=[
+                        NS(ip="127.0.0.1", local_rank=i, world_rank=i) for i in range(2)
+                    ],
+                )
+                self.assertEqual(
+                    cache_store_advertise_ip(
+                        world, NS(world_size=2, local_world_size=2)
+                    ),
+                    "192.0.2.20",
+                )
+            self.assertEqual(tags["container_ip"], "192.0.2.20")
+            self.assertEqual(tags["host_ip"], "192.0.2.200")
+            self.assertEqual(tags["hippo_role"], "restored-role")
+            self.assertEqual([m.ip for m in world.members], ["127.0.0.1"] * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
SCR templates must defer computation as well as network listeners. The engine loop now starts only after template release on every rank, while ordinary serving retains immediate startup and cleanup handles an engine that was never started.

After single-Pod SCR restore, local control endpoints use loopback. Passing those same addresses to a remote Decode peer caused its KV fetch to connect to itself. Cache-store advertisements now resolve the restored Pod IP, keep control RPC addresses on loopback, preserve explicit routable manifest endpoints, and refresh frontend request identity. Invalid external addresses fail fixup instead of reusing seed identity.

This branch also carries the rebased monitoring lifecycle and runtime-identity fixes, kernel API compatibility shim, and role configuration fix.

Validation: a newly built complete image, with no runtime source overlays, passed Normal PD and Prefill-only, Decode-only, and both-restored PD requests. Both roles completed GPU/CPU dump, cross-node restore, three additional same-node Pod restores, and a same-Pod worker-kill second restore. Each attempt binds current Pod/container identity, request output and RDMA evidence, archive overwrite before CPU restore completion, and current log file descriptors. Both-restored acceptance ran across two nodes. All 11 requested restore scenarios passed the evidence review.

The candidate CI executed 22 Python tests successfully; existing assertions were unchanged. CUDA lifecycle targets compiled successfully, but GPU unit tests were not executed. Known limitation: C++ Logger retains the seed IP in its prefix after restore. Original strict log checks remain recorded; evidence review binds that prefix to the immutable seed while independently checking current network addresses and container identities. This draft does not claim a performance benchmark, production deployment, or merge.
