### PR TITLE
fix(renderer): NameError in StreamStatusSync.update_output_sync — reference undefined `output`

### DIFF
--- a/rtp_llm/openai/renderers/custom_renderer.py
+++ b/rtp_llm/openai/renderers/custom_renderer.py
@@ -193,7 +193,7 @@ class StreamStatusSync:
         remove_stop_word_ids_func,
     ):
         self.index += 1
-        delta_output_ids = output.output_ids.cpu().flatten().tolist()
+        delta_output_ids = output_ids.cpu().flatten().tolist()
         self.output_ids_list = copy.deepcopy(self.output_ids_list + delta_output_ids)
         self.finish_reason = check_finish_func(self.output_ids_list, input_len)
         self.output_ids = remove_stop_word_ids_func(


### PR DESCRIPTION
### What

`StreamStatusSync.update_output_sync` dereferences a name that does not exist in its scope:

```python
def update_output_sync(
    self,
    output_ids,          # <-- parameter is named output_ids
    input_len,
    check_finish_func,
    remove_stop_word_ids_func,
):
    self.index += 1
    delta_output_ids = output.output_ids.cpu().flatten().tolist()   # NameError: 'output'
```

There is no `output` parameter, no `self.output` assignment in this method, and no enclosing/global `output`, so **every** call to `update_output_sync` raises `NameError: name 'output' is not defined`.

This is a copy/rename leftover from the async twin `StreamStatus.update_output`, which *does* take a `GenerateOutput` named `output` and stores `self.output = output`. When the method was adapted for the sync path, the parameter was renamed to `output_ids` (and `self.output` was dropped, `input_len` passed explicitly instead), but this line was not updated.

### Why `output_ids` is the correct reference

The callers pass the token tensor directly, not a `GenerateOutput`:

```python
# custom_renderer.py:1296 and qwen_renderer.py:612
#   the caller's own signature declares:  output_ids: torch.Tensor
status.update_output_sync(
    output_ids,
    input_len,
    functools.partial(self._check_finish_reason, max_new_tokens=max_new_tokens),
    self._remove_stop_word_ids,
)
```

Since `output_ids` is already the `torch.Tensor`, the intended expression is `output_ids.cpu().flatten().tolist()` — dropping the stale `output.` prefix. (The identical-looking line in the async `update_output` at L123 is correct there, because `output` really is that method's parameter; it is left untouched.)

### Fix

```diff
-        delta_output_ids = output.output_ids.cpu().flatten().tolist()
+        delta_output_ids = output_ids.cpu().flatten().tolist()
```

### Repro (scope only, no model needed)

```python
class T:
    def cpu(self): return self
    def flatten(self): return self
    def tolist(self): return [1, 2, 3]

def update_output_sync(output_ids):
    return output.output_ids.cpu().flatten().tolist()   # current code

update_output_sync(T())
# NameError: name 'output' is not defined
```

After the change the same call returns `[1, 2, 3]`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
