### PR TITLE
fix(fp8): split packed UE8M0 scales for tensor parallelism

### DIFF
--- a/rtp_llm/model_loader/per_block_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_block_fp8_quant_weight.py
@@ -96,6 +96,56 @@ def ceil_div(a, b):
     return (a + b - 1) // b
 
 
+def _unpack_ue8m0_scale_bytes(
+    scale: torch.Tensor, k: int, group_size: int
+) -> torch.Tensor:
+    """Unpack per-weight-row UE8M0 exponent bytes along the K dimension."""
+    shifts = torch.arange(0, 32, 8, dtype=torch.int32, device=scale.device)
+    unpacked = ((scale.unsqueeze(-1) >> shifts) & 0xFF).flatten(-2)
+    return unpacked[..., : ceil_div(k, group_size)]
+
+
+def _pack_ue8m0_scale_bytes(scale: torch.Tensor) -> torch.Tensor:
+    """Pack per-weight-row exponent bytes into DeepGEMM's TMA layout."""
+    check_with_info(scale.dim() == 2, "packed UE8M0 scale must be 2D")
+    padding = (-scale.shape[-1]) % 4
+    if padding:
+        scale = torch.cat(
+            [
+                scale,
+                torch.zeros(
+                    (scale.shape[0], padding),
+                    dtype=scale.dtype,
+                    device=scale.device,
+                ),
+            ],
+            dim=-1,
+        )
+    groups = scale.to(torch.int32).reshape(scale.shape[0], -1, 4)
+    packed = (
+        groups[..., 0]
+        | (groups[..., 1] << 8)
+        | (groups[..., 2] << 16)
+        | (groups[..., 3] << 24)
+    )
+
+    # DeepGEMM consumes packed scales through TMA.  Keep the logical shape,
+    # but pad the underlying column-major storage to its required MN stride.
+    import deep_gemm
+
+    aligned_mn = deep_gemm.get_tma_aligned_size(
+        packed.shape[0], packed.element_size()
+    )
+    packed_storage = torch.zeros(
+        (packed.shape[1], aligned_mn),
+        dtype=packed.dtype,
+        device=packed.device,
+    )
+    packed_aligned = packed_storage.T[: packed.shape[0]]
+    packed_aligned.copy_(packed)
+    return packed_aligned
+
+
 def cast_to_fp8(x: torch.Tensor):
     return x.to(torch.float8_e4m3fn)
 
@@ -895,6 +945,59 @@ class LoadQuantPerBlockFp8Weight(PerBlockFp8Weight):
         )
         self.kernel = kernel
         self.scale = scale
+
+    def _split(
+        self,
+        tensor: Union[torch.Tensor, Dict[str, torch.Tensor]],
+        load_config: LoadConfig,
+    ):
+        if (
+            not isinstance(tensor, dict)
+            or self.scale is None
+            or (
+                load_config.tp_size <= 1
+                and load_config.dp_size <= 1
+                and load_config.ep_size <= 1
+            )
+        ):
+            return super()._split(tensor, load_config)
+
+        kernel = tensor.get(self.kernel.name)
+        scale = tensor.get(self.scale.name)
+        if (
+            kernel is None
+            or scale is None
+            or kernel.dim() != 2
+            or scale.dim() != 2
+            or scale.dtype != torch.int32
+        ):
+            return super()._split(tensor, load_config)
+
+        # Packed UE8M0 stores four K-block scales in each int32 and repeats
+        # every logical MN-block scale for its physical weight rows.  Splitting
+        # the expanded rows preserves non-block-aligned sp_0 boundaries.
+        expanded_scale = _unpack_ue8m0_scale_bytes(
+            scale, kernel.shape[-1], self.group_size
+        )
+        local_kernel = self.kernel._split(kernel, load_config)[self.kernel.name]
+
+        if self.scale.name == W.attn_qkv_s:
+            # The QKV scale splitter addresses heads in 128-row blocks.
+            block_scale = expanded_scale[:: self.group_size]
+            local_scale = self.scale._split(block_scale, load_config)[
+                self.scale.name
+            ]
+            local_scale = local_scale.repeat_interleave(
+                self.group_size, dim=-2
+            )[: local_kernel.shape[-2]]
+        else:
+            local_scale = self.scale._split(expanded_scale, load_config)[
+                self.scale.name
+            ]
+        return {
+            self.kernel.name: local_kernel,
+            self.scale.name: _pack_ue8m0_scale_bytes(local_scale),
+        }
 
     def _load_raw_tensor(
         self,

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_deepgemm_linear_sm120_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_deepgemm_linear_sm120_test.py
@@ -26,9 +26,58 @@ from rtp_llm.models_py.modules.factory.linear.impl.cuda.test.fp8_linear_test imp
     init_quant_config,
 )
 from rtp_llm.models_py.utils.arch import is_sm12x
+from rtp_llm.utils.model_weight import (
+    W,
+    sp_0,
+    sp_head_gemm_a8,
+    sp_head_s_gemm_a8_block,
+    sp_neg1,
+)
 
 
 class CudaFp8DeepGEMMLinearSM120Test(CudaFp8GEMMLinearTestBase, unittest.TestCase):
+    def _split_online_weight(
+        self,
+        kernel,
+        scale,
+        kernel_split_func,
+        scale_split_func,
+        load_config,
+        scale_name="test_dense_scale",
+    ):
+        def split(tensor, split_func):
+            return split_func(
+                t=tensor,
+                tp=load_config.tp_size,
+                tp_rank=load_config.tp_rank,
+                ep=1,
+                ep_rank=0,
+                dp=1,
+                dp_rank=0,
+                ffn_tp_size=load_config.tp_size,
+                ffn_tp_rank=load_config.tp_rank,
+                head_num=getattr(load_config, "head_num", 0),
+                head_num_kv=getattr(load_config, "head_num_kv", 0),
+                size_per_head=getattr(load_config, "size_per_head", 0),
+            ).contiguous()
+
+        loader = object.__new__(LoadQuantPerBlockFp8Weight)
+        loader.group_size = 128
+        loader.kernel = Mock(name="kernel")
+        loader.kernel.name = "test_dense_weight"
+        loader.kernel._split.side_effect = lambda tensor, _: {
+            loader.kernel.name: split(tensor, kernel_split_func)
+        }
+        loader.scale = Mock(name="scale")
+        loader.scale.name = scale_name
+        loader.scale._get_split_func.return_value = scale_split_func
+        loader.scale._split.side_effect = lambda tensor, _: {
+            loader.scale.name: split(tensor, scale_split_func)
+        }
+        return loader._split(
+            {loader.kernel.name: kernel, loader.scale.name: scale}, load_config
+        )
+
     def test_sm120(self):
         self.assertTrue(is_sm12x())
         self.assertTrue(has_deep_gemm())
@@ -134,6 +183,118 @@ class CudaFp8DeepGEMMLinearSM120Test(CudaFp8GEMMLinearTestBase, unittest.TestCas
                 device="cuda",
                 load_config=Mock(),
             )
+
+    def test_online_loader_splits_unaligned_packed_scale(self):
+        torch.manual_seed(20260910)
+        weight = torch.randn((256, 13824), device="cuda", dtype=torch.bfloat16)
+        kernel, scale = quant_weight_ue8m0_packed(weight)
+        self.assertEqual(tuple(scale.shape), (256, 27))
+        for rank in range(2):
+            with self.subTest(rank=rank):
+                k_start = rank * 6912
+                actual = self._split_online_weight(
+                    kernel,
+                    scale,
+                    sp_neg1,
+                    sp_neg1,
+                    SimpleNamespace(
+                        tp_size=2,
+                        tp_rank=rank,
+                        dp_size=1,
+                        ep_size=1,
+                    ),
+                )
+                _, expected_scale = quant_weight_ue8m0_packed(
+                    weight[:, k_start : k_start + 6912]
+                )
+
+                self.assertEqual(tuple(actual["test_dense_scale"].shape), (256, 14))
+                self.assertEqual(
+                    actual["test_dense_scale"].stride(), expected_scale.stride()
+                )
+                self.assertTrue(torch.equal(actual["test_dense_scale"], expected_scale))
+
+    def test_online_loader_splits_non_block_aligned_output_rows(self):
+        from deep_gemm.utils.layout import (
+            get_mn_major_tma_aligned_packed_ue8m0_tensor,
+        )
+
+        torch.manual_seed(20260910)
+        weight = torch.randn((1376, 256), device="cuda", dtype=torch.bfloat16)
+        kernel, scale = quant_weight_ue8m0_packed(weight)
+        _, block_scale = per_block_cast_to_fp8(weight, use_ue8m0=True)
+        expanded_scale = block_scale.index_select(
+            0, torch.arange(weight.shape[0], device="cuda") // 128
+        )
+
+        for rank in range(2):
+            with self.subTest(rank=rank):
+                load_config = SimpleNamespace(
+                    tp_size=2,
+                    tp_rank=rank,
+                    dp_size=1,
+                    ep_size=1,
+                )
+                actual = self._split_online_weight(
+                    kernel, scale, sp_0, sp_0, load_config
+                )
+                expected_scale = get_mn_major_tma_aligned_packed_ue8m0_tensor(
+                    sp_0(expanded_scale, 2, rank).contiguous()
+                )
+
+                self.assertEqual(tuple(actual["test_dense_weight"].shape), (688, 256))
+                self.assertEqual(tuple(actual["test_dense_scale"].shape), (688, 1))
+                self.assertEqual(
+                    actual["test_dense_scale"].stride(), expected_scale.stride()
+                )
+                self.assertTrue(torch.equal(actual["test_dense_scale"], expected_scale))
+
+    def test_online_loader_splits_qkv_heads(self):
+        torch.manual_seed(20260910)
+        weight = torch.randn((1024, 256), device="cuda", dtype=torch.bfloat16)
+        kernel, scale = quant_weight_ue8m0_packed(weight)
+
+        def split(tensor, split_func, rank):
+            return split_func(
+                t=tensor,
+                tp=2,
+                tp_rank=rank,
+                head_num=4,
+                head_num_kv=2,
+                size_per_head=128,
+            ).contiguous()
+
+        for rank in range(2):
+            with self.subTest(rank=rank):
+                load_config = SimpleNamespace(
+                    tp_size=2,
+                    tp_rank=rank,
+                    dp_size=1,
+                    ep_size=1,
+                    head_num=4,
+                    head_num_kv=2,
+                    size_per_head=128,
+                )
+                actual = self._split_online_weight(
+                    kernel,
+                    scale,
+                    sp_head_gemm_a8,
+                    sp_head_s_gemm_a8_block,
+                    load_config,
+                    W.attn_qkv_s,
+                )
+                local_weight = split(weight, sp_head_gemm_a8, rank)
+                expected_kernel, expected_scale = quant_weight_ue8m0_packed(
+                    local_weight
+                )
+
+                self.assertTrue(
+                    torch.equal(actual["test_dense_weight"], expected_kernel)
+                )
+                self.assertEqual(
+                    actual[W.attn_qkv_s].stride(), expected_scale.stride()
+                )
+                self.assertTrue(torch.equal(actual[W.attn_qkv_s], expected_scale))
 
     def test_direct_weight_runs_sm120_deepgemm(self):
         torch.manual_seed(20260811)


### PR DESCRIPTION
## 背景

本 PR 修复 Qwen3-14B 在 SM100/SM120 上从 BF16 checkpoint 在线量化为 `FP8_PER_BLOCK` 时，TP2 无法正常加载或执行首个 prefill 的问题。

影响范围为：

- SM100/SM120 DeepGEMM packed UE8M0 路径；
- BF16/FP16 checkpoint 在线量化为 `FP8_PER_BLOCK`；
- dense weight 且 `TP > 1`。

BF16、`FP8_DYNAMIC_PER_TENSOR`、TP1、未使用 packed UE8M0 的路径不受影响。

## 根因

问题由 [fix(fp8): quantize Blackwell weights directly to UE8M0](https://github.com/alibaba/rtp-llm/commit/843f839b3174e8a48a6bbcda57bf53cc49460469) 引入。该提交将在线 per-block FP8 量化调整为在 TP 分片前直接生成 packed UE8M0 scale，但后续 TP splitter 仍按原来的 float block-scale 布局处理：

```text
修改前：生成 float block scale -> TP 分片 -> packed UE8M0
修改后：直接生成 packed UE8M0 -> 原有 TP 分片
```

packed UE8M0 会将 4 个逻辑 scale byte 存入一个 `int32`，并使用 DeepGEMM 所需的 MN-major 物理布局。直接复用旧 splitter 会产生以下问题：

- scale 被按错误的逻辑维度切分，导致 weight/scale shape 不匹配，模型加载失败；
- 通用分片中的 contiguous 转换会破坏 MN-major stride，导致首个 prefill 失败；
- 当 rank 边界落在 packed `int32` 中间时，无法直接对物理 tensor 做等分。

[feat: enable DeepGEMM FP8 paths on SM120](https://github.com/alibaba/rtp-llm/commit/de901fbc4275bc73a066c27cb5c6e8ca16142013) 是该问题的前置条件，但没有改变在线量化与 TP 分片的先后顺序，因此不是直接引入问题的提交。

仓库另一条历史中的 [83ad108efe](https://github.com/alibaba/rtp-llm/commit/83ad108efe3178400a4b8d63ac9f76a0922e035b) 与 `843f839b31` 具有相同 patch-id；当前 `develop/pro5000-opt` 基线包含的是 `843f839b31`。

## 修复方法

在线量化产生二维 packed UE8M0 scale 且需要并行分片时：

1. 将 packed `int32` 无损解包为逻辑 UE8M0 scale byte；
2. 恢复 block-scale grid，并复用现有 QKV/FFN TP 策略完成 rank-local 分片；
3. 将本 rank 的 scale 重新打包为 UE8M0 `int32`；
4. 恢复 DeepGEMM 要求的 MN-major stride。

该过程只重新组织 scale byte，不重新计算 scale，也不对 weight 进行二次量化。

修改限定在在线 `FP8_PER_BLOCK` loader 中，没有修改通用 TP splitter、DeepGEMM kernel、模型结构或配置接口。预量化 float scale、BF16、dynamic FP8 和 TP1 继续使用原有路径。

## 验证结果

### 实机验证

所有 case 均完成模型启动及 128-token prefill，`success_rate=1.0`。

| 模型 | 执行路径 | 配置 | 结果 |
|---|---|---|---|
| Qwen3-14B BF16 checkpoint | BF16 | TP1 / TP2 | 通过 |
| Qwen3-14B BF16 checkpoint | `FP8_DYNAMIC_PER_TENSOR` | TP1 / TP2 | 通过 |
| Qwen3-14B BF16 checkpoint | `FP8_PER_BLOCK` | TP1 / TP2 | 通过 |

### 回归测试

- 新增 packed scale 的 TP rank 0/rank 1 分片覆盖；
- 覆盖 TP 边界位于 packed `int32` 中间的非对齐场景；
- 验证重新打包后的 rank-local scale 与对 rank-local weight 独立量化得到的 scale 逐 bit 相同；
- 完整 SM120 FP8 测试结果：`26 passed, 1 skipped`。

## 修改范围

- `rtp_llm/model_loader/per_block_fp8_quant_weight.py`
- `rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_deepgemm_linear_sm120_test.py`
