### PR TITLE
feat(rocm): support DSpARK on ROCm

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -202,11 +202,25 @@ cc_binary(
     srcs = [
         ":rtp_compute_ops",
     ],
+    additional_linker_inputs = [
+        ":rtp_compute_ops",
+    ],
     copts = copts(),
     linkopts = [
         "-Wl,-rpath='$$ORIGIN'",
         # "-Wl,--exclude-libs,ALL",  # 添加这行，隐藏静态库符号
-    ],
+    ] + select({
+        # ROCm keeps process-wide execution state in librtp_compute_ops.so.
+        # The generated link line lists the srcs entry before the engine objects
+        # that reference it, so the default --as-needed drops its DT_NEEDED.
+        # Repeat the library after the objects as an additional linker input.
+        ":using_rocm": [
+            "-Wl,--no-as-needed",
+            "-lrtp_compute_ops",
+            "-Wl,--as-needed",
+        ],
+        "//conditions:default": [],
+    }),
     linkshared = 1,
     visibility = ["//visibility:public"],
     deps = [

--- a/rtp_llm/config/model_config.py
+++ b/rtp_llm/config/model_config.py
@@ -42,13 +42,39 @@ def kv_cache_dtype_to_torch_dtype(
 
 def ssm_state_dtype_str_to_data_type(ssm_state_dtype: str) -> DataType:
     ssm_state_dtype = ssm_state_dtype.lower()
-    if ssm_state_dtype == "bf16":
+    if ssm_state_dtype in ("bf16", "bfloat16"):
         return DataType.TYPE_BF16
-    if ssm_state_dtype == "fp16":
+    if ssm_state_dtype in ("fp16", "float16"):
         return DataType.TYPE_FP16
-    if ssm_state_dtype == "fp32":
+    if ssm_state_dtype in ("fp32", "float32"):
         return DataType.TYPE_FP32
     raise ValueError(f"Unsupported ssm_state_dtype: {ssm_state_dtype}")
+
+
+def resolve_ssm_state_dtype(
+    configured_ssm_state_dtype: str,
+    model_ssm_state_dtype: DataType,
+    enable_remote_cache: bool,
+) -> DataType:
+    configured_ssm_state_dtype = configured_ssm_state_dtype.lower()
+    if configured_ssm_state_dtype != "auto":
+        return ssm_state_dtype_str_to_data_type(configured_ssm_state_dtype)
+
+    # The legacy remote connector addresses KV cache through one contiguous
+    # BlockPool. A model-declared recurrent-state dtype that differs from the
+    # attention cache dtype requires independent physical pools, which that
+    # connector explicitly rejects. Keep ``auto`` backward compatible for this
+    # connector while preserving an explicit user override for fail-fast
+    # validation once independent pools are requested deliberately.
+    if enable_remote_cache and model_ssm_state_dtype != DataType.TYPE_BF16:
+        logging.warning(
+            "SSM_STATE_DTYPE=auto resolved to %s, but remote cache requires a "
+            "contiguous shared KV cache pool; falling back to bf16",
+            model_ssm_state_dtype,
+        )
+        return DataType.TYPE_BF16
+
+    return model_ssm_state_dtype
 
 
 class ModelConfig(CppModelConfig):
@@ -58,6 +84,7 @@ class ModelConfig(CppModelConfig):
         "dspark_noise_token_id",
         "dspark_target_layer_ids",
         "dspark_markov_rank",
+        "dspark_sample_from_anchor",
         "capture_aux_hidden_layer_ids",
         "normalize_lm_head_weight",
         "enable_fp32_lm_head",
@@ -542,6 +569,7 @@ class ModelConfig(CppModelConfig):
         self.dspark_noise_token_id: Optional[int] = None
         self.dspark_target_layer_ids: Optional[list[int]] = None
         self.dspark_markov_rank: Optional[int] = None
+        self.dspark_sample_from_anchor: bool = True
         # Target-side decoder layer outputs exported to the DSpARK draft.
         self.capture_aux_hidden_layer_ids: Optional[list[int]] = None
         self.normalize_lm_head_weight: bool = False
@@ -926,8 +954,10 @@ def build_model_config(
         if kv_cache_config.kernel_seq_size_per_block > 0
         else kv_cache_config.seq_size_per_block
     )
-    model_config.linear_attention_config.ssm_state_dtype = (
-        ssm_state_dtype_str_to_data_type(kv_cache_config.ssm_state_dtype)
+    model_config.linear_attention_config.ssm_state_dtype = resolve_ssm_state_dtype(
+        kv_cache_config.ssm_state_dtype,
+        model_config.linear_attention_config.ssm_state_dtype,
+        kv_cache_config.enable_remote_cache,
     )
     model_config.linear_attention_config.conv_state_dtype = model_config.data_type
 

--- a/rtp_llm/cpp/cache/BUILD
+++ b/rtp_llm/cpp/cache/BUILD
@@ -194,6 +194,10 @@ cc_library(
             "@local_config_cuda//cuda:cuda_headers",
             "@local_config_cuda//cuda:cudart",
         ],
+        "@//:using_rocm": [
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:hip",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/rtp_llm/cpp/cache/BlockPool.cc
+++ b/rtp_llm/cpp/cache/BlockPool.cc
@@ -20,6 +20,8 @@
 
 #if USING_CUDA
 #include <cuda_runtime.h>
+#elif USING_ROCM
+#include <hip/hip_runtime.h>
 #endif
 
 namespace rtp_llm {
@@ -51,12 +53,18 @@ const char* memoryTypeName(MemoryType memory_type) {
 }
 
 const char*
-requestedBackingName(AllocationType allocation_type, bool use_pinned_cpu_backing, bool use_cuda_malloc_backing) {
+requestedBackingName(AllocationType allocation_type, bool use_pinned_cpu_backing, bool use_device_malloc_backing) {
     if (allocation_type == AllocationType::HOST) {
         return shouldPinHostBlockPool() ? "CPU_PINNED_OR_CPU_FALLBACK" : "CPU";
     }
-    if (use_cuda_malloc_backing) {
+    if (use_device_malloc_backing) {
+#if USING_CUDA
         return "GPU_CUDA_MALLOC";
+#elif USING_ROCM
+        return "GPU_HIP_MALLOC";
+#else
+        return "GPU_DEVICE_MALLOC";
+#endif
     }
     return use_pinned_cpu_backing ? "CPU_PINNED" : "GPU";
 }
@@ -120,19 +128,19 @@ void markHostBlockPoolDontDump(const char* pool_name, void* ptr, size_t size) {
 BlockPool::BlockPool(const BlockPoolConfig& config,
                      AllocationType         allocation_type,
                      bool                   use_pinned_cpu_backing,
-                     bool                   use_cuda_malloc_backing):
+                     bool                   use_device_malloc_backing):
     config_(config),
     allocation_type_(allocation_type),
     use_pinned_cpu_backing_(use_pinned_cpu_backing),
-    use_cuda_malloc_backing_(use_cuda_malloc_backing) {}
+    use_device_malloc_backing_(use_device_malloc_backing) {}
 
 BlockPool::~BlockPool() {
     cache_aligned_buffer_ = torch::Tensor();
 }
 
 void BlockPool::validateConfig() const {
-    RTP_LLM_CHECK_WITH_INFO(!(use_pinned_cpu_backing_ && use_cuda_malloc_backing_),
-                            "BlockPool cannot use both pinned CPU backing and cudaMalloc backing");
+    RTP_LLM_CHECK_WITH_INFO(!(use_pinned_cpu_backing_ && use_device_malloc_backing_),
+                            "BlockPool cannot use both pinned CPU backing and raw device malloc backing");
     RTP_LLM_CHECK_WITH_INFO(!config_.memory_layouts.empty(), "BlockPoolConfig.memory_layouts must not be empty");
     RTP_LLM_CHECK_WITH_INFO(config_.block_num > 0, "BlockPoolConfig.block_num must be > 0");
 
@@ -181,8 +189,8 @@ void BlockPool::initializeCacheBuffer() {
             config_.pool_name.c_str(), cache_aligned_buffer_.data_ptr(), config_.total_size_bytes);
     } else if (use_pinned_cpu_backing_) {
         initializePinnedCpuBuffer("device block pool pinned CPU backing");
-    } else if (use_cuda_malloc_backing_) {
-        initializeCudaMallocBuffer();
+    } else if (use_device_malloc_backing_) {
+        initializeDeviceMallocBuffer();
     } else {
         cache_aligned_buffer_ = torch::empty({static_cast<int64_t>(config_.total_size_bytes)},
                                              torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
@@ -197,7 +205,7 @@ void BlockPool::initializeCacheBuffer() {
                      "block_num=%u memory_layouts=%zu",
                      config_.pool_name.c_str(),
                      allocationTypeName(allocation_type_),
-                     requestedBackingName(allocation_type_, use_pinned_cpu_backing_, use_cuda_malloc_backing_),
+                     requestedBackingName(allocation_type_, use_pinned_cpu_backing_, use_device_malloc_backing_),
                      memoryTypeName(where()),
                      is_cuda,
                      is_pinned,
@@ -224,11 +232,12 @@ void BlockPool::initializePinnedCpuBuffer(const char* log_context) {
     }
 }
 
-void BlockPool::initializeCudaMallocBuffer() {
+void BlockPool::initializeDeviceMallocBuffer() {
 #if USING_CUDA
     RTP_LLM_CHECK_WITH_INFO(allocation_type_ == AllocationType::DEVICE,
-                            "cudaMalloc block pool backing requires DEVICE allocation");
-    RTP_LLM_CHECK_WITH_INFO(config_.total_size_bytes > 0, "cudaMalloc block pool total_size_bytes must be > 0");
+                            "raw device malloc block pool backing requires DEVICE allocation");
+    RTP_LLM_CHECK_WITH_INFO(config_.total_size_bytes > 0,
+                            "raw device malloc block pool total_size_bytes must be > 0");
 
     int  device_id  = -1;
     auto device_err = cudaGetDevice(&device_id);
@@ -267,8 +276,51 @@ void BlockPool::initializeCudaMallocBuffer() {
                      ptr,
                      config_.total_size_bytes,
                      device_id);
+#elif USING_ROCM
+    RTP_LLM_CHECK_WITH_INFO(allocation_type_ == AllocationType::DEVICE,
+                            "raw device malloc block pool backing requires DEVICE allocation");
+    RTP_LLM_CHECK_WITH_INFO(config_.total_size_bytes > 0,
+                            "raw device malloc block pool total_size_bytes must be > 0");
+
+    int  device_id  = -1;
+    auto device_err = hipGetDevice(&device_id);
+    RTP_LLM_CHECK_WITH_INFO(device_err == hipSuccess,
+                            "hipGetDevice failed before hipMalloc block pool allocation, error=%s",
+                            hipGetErrorString(device_err));
+
+    void*      ptr = nullptr;
+    const auto err = hipMalloc(&ptr, config_.total_size_bytes);
+    RTP_LLM_CHECK_WITH_INFO(err == hipSuccess,
+                            "hipMalloc block pool failed, pool_name=%s, total_size=%zu bytes, error=%s",
+                            config_.pool_name.c_str(),
+                            config_.total_size_bytes,
+                            hipGetErrorString(err));
+
+    auto deleter = [device_id](void* p) {
+        if (p == nullptr) {
+            return;
+        }
+        int current_device = -1;
+        if (hipGetDevice(&current_device) == hipSuccess && current_device != device_id) {
+            (void)hipSetDevice(device_id);
+            (void)hipFree(p);
+            (void)hipSetDevice(current_device);
+            return;
+        }
+        (void)hipFree(p);
+    };
+    cache_aligned_buffer_ =
+        torch::from_blob(ptr,
+                         {static_cast<int64_t>(config_.total_size_bytes)},
+                         std::move(deleter),
+                         torch::TensorOptions().dtype(torch::kUInt8).device(torch::Device(torch::kCUDA, device_id)));
+    RTP_LLM_LOG_INFO("hipMalloc block pool backing allocated, pool_name=%s, ptr=%p, total_size=%zu bytes, device=%d",
+                     config_.pool_name.c_str(),
+                     ptr,
+                     config_.total_size_bytes,
+                     device_id);
 #else
-    RTP_LLM_FAIL("cudaMalloc block pool backing requested but this binary was not built with CUDA, pool_name=%s",
+    RTP_LLM_FAIL("raw device malloc block pool backing requires a CUDA or ROCm build, pool_name=%s",
                  config_.pool_name.c_str());
 #endif
 }

--- a/rtp_llm/cpp/cache/BlockPool.h
+++ b/rtp_llm/cpp/cache/BlockPool.h
@@ -24,9 +24,9 @@ class CacheStore;
 class BlockPool {
 public:
     BlockPool(const BlockPoolConfig& config,
-              AllocationType         allocation_type         = AllocationType::DEVICE,
-              bool                   use_pinned_cpu_backing  = false,
-              bool                   use_cuda_malloc_backing = false);
+              AllocationType         allocation_type           = AllocationType::DEVICE,
+              bool                   use_pinned_cpu_backing    = false,
+              bool                   use_device_malloc_backing = false);
     ~BlockPool();
 
     bool init();
@@ -92,7 +92,7 @@ private:
     void validateConfig() const;
     void initializeCacheBuffer();
     void initializePinnedCpuBuffer(const char* log_context);
-    void initializeCudaMallocBuffer();
+    void initializeDeviceMallocBuffer();
     void initializeLayerMappings();
     void initializeLayoutStrategies();
 
@@ -137,7 +137,7 @@ private:
 
     AllocationType allocation_type_;
     bool           use_pinned_cpu_backing_;
-    bool           use_cuda_malloc_backing_;
+    bool           use_device_malloc_backing_;
 
     BlockCachePtr block_cache_;
 

--- a/rtp_llm/cpp/cache/HybridPoolConfigCreator.cc
+++ b/rtp_llm/cpp/cache/HybridPoolConfigCreator.cc
@@ -230,10 +230,14 @@ void setupIndependentPoolSizes(CacheConfig& config, bool is_mtp) {
     for (size_t gid = 0; gid < group_num; ++gid) {
         const auto& spec = config.specForGroup(gid);
         RTP_LLM_CHECK_WITH_INFO(spec != nullptr, "cache_specs[%zu] is null", gid);
-        const auto   layer_count         = static_cast<uint32_t>(config.layerIdsForGroup(gid).size());
-        const size_t kernel_kv_stride    = spec->block_size_bytes();
-        const auto   kernel_scale        = spec->scale_block_size_bytes();
-        const size_t group_bpk           = config.kernelBlocksPerKvBlockForGroup(gid);
+        const auto   layer_count      = static_cast<uint32_t>(config.layerIdsForGroup(gid).size());
+        const size_t kernel_kv_stride = spec->block_size_bytes();
+        const auto   kernel_scale     = spec->scale_block_size_bytes();
+        // MHA/MLA specs already describe one physical block. Compressed
+        // OpaqueKV specs describe one kernel block and must be repeated to
+        // fill the physical block.
+        const size_t group_bpk =
+            spec->type == KVCacheSpecType::OpaqueKV ? config.kernelBlocksPerKvBlockForGroup(gid) : 1;
         const size_t kv_stride           = kernel_kv_stride * group_bpk;
         const size_t scale_stride        = kernel_scale * group_bpk;
         group_kv_block_stride_bytes[gid] = kv_stride;

--- a/rtp_llm/cpp/cache/HybridPoolKVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/HybridPoolKVCacheAllocator.cc
@@ -107,15 +107,14 @@ bool HybridPoolKVCacheAllocator::doInit() {
         const auto  group_type  = config_.typeForGroup(static_cast<size_t>(gid));
         const auto  policy      = config_.policyForGroup(static_cast<size_t>(gid));
 
-        // BlockPool::validateConfig() rejects pinned-CPU and cudaMalloc backing
-        // together, so a HOST_PINNED pool must opt out of cudaMalloc backing even
-        // when the allocator-wide flag is on.
+        // Raw device allocation only applies to DEVICE pools. Host and pinned-host
+        // pools keep their existing backing even when the allocator-wide flag is on.
         const bool use_pinned_cpu_backing = pinnedCpuBackingForPlacement(policy.memory_placement);
-        auto       group_pool =
-            std::make_shared<BlockPool>(pool_config,
-                                        allocationTypeForPlacement(policy.memory_placement, allocation_type_),
-                                        use_pinned_cpu_backing,
-                                        use_cuda_malloc_block_pool_ && !use_pinned_cpu_backing);
+        const auto pool_allocation_type = allocationTypeForPlacement(policy.memory_placement, allocation_type_);
+        const bool use_device_malloc_backing =
+            pool_allocation_type == AllocationType::DEVICE && use_device_malloc_block_pool_;
+        auto group_pool = std::make_shared<BlockPool>(
+            pool_config, pool_allocation_type, use_pinned_cpu_backing, use_device_malloc_backing);
         RTP_LLM_CHECK_WITH_INFO(
             group_pool->init(), "Failed to initialize block pool %s(group %d)", pool_config.pool_name.c_str(), gid);
 

--- a/rtp_llm/cpp/cache/HybridPoolKVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/HybridPoolKVCacheAllocator.cc
@@ -580,8 +580,8 @@ KVCacheTokenCapacity HybridPoolKVCacheAllocator::tokenCapacity(size_t default_se
 std::vector<KVCachePoolMetricsSnapshot> HybridPoolKVCacheAllocator::poolMetricsSnapshots() const {
     std::vector<KVCachePoolMetricsSnapshot> snapshots;
     snapshots.reserve(group_block_pools_.size());
-    const size_t reserve_blocks                    = reserveBlocksNum();
-    const size_t total_reservable_available_blocks = totalReservableAvailableBlocks();
+    const size_t reserve_blocks          = reserveBlocksNum();
+    const size_t total_reservable_blocks = totalReservableBlocks();
     for (size_t gid = 0; gid < group_block_pools_.size(); ++gid) {
         const auto& pool = group_block_pools_[gid];
         if (!pool) {
@@ -595,7 +595,7 @@ std::vector<KVCachePoolMetricsSnapshot> HybridPoolKVCacheAllocator::poolMetricsS
         snapshot.free_blocks          = pool->freeBlocksNum();
         snapshot.request_ref_blocks   = pool->requestRefBlocksNum();
         snapshot.connector_ref_blocks = pool->connectorRefBlocksNum();
-        snapshot.reserve_blocks       = reserveBlocksForPool(gid, reserve_blocks, total_reservable_available_blocks);
+        snapshot.reserve_blocks       = reserveBlocksForPool(gid, reserve_blocks, total_reservable_blocks);
         snapshot.used_ratio           = (snapshot.total_blocks == 0) ?
                                             0.0f :
                                             static_cast<float>(100.0 * (snapshot.total_blocks - snapshot.available_blocks)
@@ -630,18 +630,34 @@ size_t HybridPoolKVCacheAllocator::totalReservableAvailableBlocks() const {
     return total;
 }
 
+size_t HybridPoolKVCacheAllocator::totalReservableBlocks() const {
+    size_t total = 0;
+    for (size_t gid = 0; gid < group_block_pools_.size(); ++gid) {
+        if (!group_block_pools_[gid] || config_.usesExplicitIndependentBlocks(gid)) {
+            continue;
+        }
+        total += group_block_pools_[gid]->totalBlocksNum();
+    }
+    return total;
+}
+
 size_t HybridPoolKVCacheAllocator::reservableAvailableBlocksNum() const {
     return totalReservableAvailableBlocks();
 }
 
 size_t HybridPoolKVCacheAllocator::reserveBlocksForPool(size_t gid,
                                                         size_t reserve_blocks,
-                                                        size_t total_reservable_available_blocks) const {
+                                                        size_t total_reservable_blocks) const {
     if (gid >= group_block_pools_.size() || !group_block_pools_[gid] || config_.usesExplicitIndependentBlocks(gid)
-        || total_reservable_available_blocks == 0) {
+        || total_reservable_blocks == 0) {
         return 0;
     }
-    return reserve_blocks * group_block_pools_[gid]->availableBlocksNum() / total_reservable_available_blocks;
+    // Reserve is forward-progress headroom. Its share must not collapse as a
+    // pool becomes the bottleneck: weighting by current availability moved the
+    // nominal reserve into idle recurrent pools and let new admissions consume
+    // the final FULL-attention block. Keep the share fixed to physical capacity;
+    // incremental decode can consume it, while new admissions cannot erase it.
+    return reserve_blocks * group_block_pools_[gid]->totalBlocksNum() / total_reservable_blocks;
 }
 
 MallocStatus HybridPoolKVCacheAllocator::evaluateInitCapacity(const MallocInfo& malloc_info,
@@ -658,24 +674,13 @@ MallocStatus HybridPoolKVCacheAllocator::evaluateInitCapacity(const MallocInfo& 
     const int   reserve_step       = malloc_info.complete_token_ids->getReserveStep();
     const bool  reuse_enabled      = malloc_info.reuse_cache;
 
-    const size_t total_reservable_available_blocks = totalReservableAvailableBlocks();
-    // The "can this ever fit" verdict must not depend on transient availability,
-    // so the reserve share for the total-capacity test is prorated by each pool's
-    // total size instead.
-    size_t total_reservable_blocks = 0;
-    for (size_t gid = 0; gid < group_block_pools_.size(); ++gid) {
-        if (!group_block_pools_[gid] || config_.usesExplicitIndependentBlocks(gid)) {
-            continue;
-        }
-        total_reservable_blocks += group_block_pools_[gid]->totalBlocksNum();
-    }
+    const size_t total_reservable_blocks = totalReservableBlocks();
 
     MallocStatus status = MallocStatus::NONE;
     for (int gid = 0; gid < static_cast<int>(kv_cache_groups_.size()); ++gid) {
-        const size_t group_index = static_cast<size_t>(gid);
-        const int    group_common_seq =
-            cpEffectiveSeqLenForReserve(cp_mapper, config_, group_index, raw_common_seq_len);
-        const int  group_seq_len = cpEffectiveSeqLenForReserve(cp_mapper, config_, group_index, raw_seq_len);
+        const size_t group_index    = static_cast<size_t>(gid);
+        const int  group_common_seq = cpEffectiveSeqLenForReserve(cp_mapper, config_, group_index, raw_common_seq_len);
+        const int  group_seq_len    = cpEffectiveSeqLenForReserve(cp_mapper, config_, group_index, raw_seq_len);
         const int  group_reuse_blocks_len = reuse_enabled ? malloc_info.batch_kv_cache_resource->blocksNum(0, gid) : 0;
         const auto need                   = kv_cache_groups_[group_index]->getNeedBlocks(
             group_common_seq, group_seq_len, reserve_step, group_reuse_blocks_len, reuse_enabled);
@@ -712,8 +717,7 @@ MallocStatus HybridPoolKVCacheAllocator::evaluateInitCapacity(const MallocInfo& 
         if (mode != InitCapacityMode::TOTAL_AND_AVAILABLE || status != MallocStatus::NONE) {
             continue;
         }
-        const size_t group_reserve_blocks =
-            reserveBlocksForPool(group_index, reserve_blocks, total_reservable_available_blocks);
+        const size_t group_reserve_blocks = reserveBlocksForPool(group_index, reserve_blocks, total_reservable_blocks);
         if (available_blocks < required_blocks + group_reserve_blocks) {
             if (malloc_info.verbose) {
                 RTP_LLM_LOG_INFO("HybridPool initMalloc rejected by reserve blocks: request_id=%ld pool_name=%s "
@@ -766,7 +770,7 @@ void HybridPoolKVCacheAllocator::logMallocFailure(const MallocInfo& malloc_info,
     const int   planning_raw_seq_len = !incremental && !reserve_admission ? raw_common_len : raw_seq_len;
     const auto  reserve_blocks       = reserveBlocksNum();
 
-    const size_t total_reservable_available_blocks = totalReservableAvailableBlocks();
+    const size_t total_reservable_blocks = totalReservableBlocks();
 
     RTP_LLM_LOG_WARNING("HybridPool malloc failure: error_code=602 request_id=%ld phase=%s failed_batch=%d "
                         "failed_group=%d incremental=%d batch_size=%d seq_len=%d common_seq_len=%d total_seq_len=%d "
@@ -828,9 +832,7 @@ void HybridPoolKVCacheAllocator::logMallocFailure(const MallocInfo& malloc_info,
         const auto&  pool      = group_block_pools_[group_index];
         const size_t available = pool->availableBlocksNum();
         const size_t group_reserve =
-            reserve_admission ?
-                reserveBlocksForPool(group_index, reserve_blocks, total_reservable_available_blocks) :
-                0;
+            reserve_admission ? reserveBlocksForPool(group_index, reserve_blocks, total_reservable_blocks) : 0;
         const long long required_available = need_blocks < 0 ? -1 : static_cast<long long>(need_blocks + group_reserve);
         const long long shortfall =
             required_available < 0 ? -1 : std::max(required_available - static_cast<long long>(available), 0LL);

--- a/rtp_llm/cpp/cache/HybridPoolKVCacheAllocator.h
+++ b/rtp_llm/cpp/cache/HybridPoolKVCacheAllocator.h
@@ -78,8 +78,9 @@ private:
     int    validateGroupIdForLayer(int layer_id, int group_id) const;
     int    defaultGroupIdForLayer(int layer_id) const;
     size_t minTokenCapacity(bool use_available_blocks, bool full_groups_only) const;
+    size_t totalReservableBlocks() const;
     size_t totalReservableAvailableBlocks() const;
-    size_t reserveBlocksForPool(size_t gid, size_t reserve_blocks, size_t total_reservable_available_blocks) const;
+    size_t reserveBlocksForPool(size_t gid, size_t reserve_blocks, size_t total_reservable_blocks) const;
 
     std::vector<BlockPoolPtr> group_block_pools_;
     RoleType                  role_type_{RoleType::PDFUSION};

--- a/rtp_llm/cpp/cache/HybridTypeKVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/HybridTypeKVCacheAllocator.cc
@@ -28,8 +28,10 @@ bool HybridTypeKVCacheAllocator::doInit() {
     }
 
     auto pool_config = BlockPoolConfigHelper::createConfig(config_);
-    block_pool_      = std::make_shared<BlockPool>(
-        pool_config, allocation_type_, /*use_pinned_cpu_backing=*/false, use_cuda_malloc_block_pool_);
+    const bool use_device_malloc_backing =
+        allocation_type_ == AllocationType::DEVICE && use_device_malloc_block_pool_;
+    block_pool_ = std::make_shared<BlockPool>(
+        pool_config, allocation_type_, /*use_pinned_cpu_backing=*/false, use_device_malloc_backing);
     RTP_LLM_CHECK_WITH_INFO(block_pool_->init(), "Failed to initialize block pool for HybridTypeKVCacheAllocator");
 
     const int group_nums = config_.groupNums();

--- a/rtp_llm/cpp/cache/KVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/KVCacheAllocator.cc
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <limits>
 #include <unordered_set>
+#include <utility>
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/models_py/bindings/core/OpData.h"
@@ -12,6 +13,28 @@
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
 
 namespace rtp_llm {
+
+std::shared_ptr<KVCacheResource>
+KVCacheAllocator::incrKVCacheRefWithReleaseCallback(const KVCacheResource& kvcache_resource,
+                                                    const CacheKeysType&   cache_keys,
+                                                    bool                   is_connector,
+                                                    std::function<void()>  release_callback) {
+    auto resource = incrKVCacheRef(kvcache_resource, cache_keys, is_connector);
+    if (!resource || !release_callback) {
+        return resource;
+    }
+
+    // Keep the allocator-owned resource as the inner owner. Releasing the outer
+    // handle first runs the allocator's custom deleter, then publishes the
+    // resulting capacity change. The callback owns no KVCacheManager lifetime.
+    auto* resource_ptr = resource.get();
+    return std::shared_ptr<KVCacheResource>(
+        resource_ptr,
+        [resource = std::move(resource), release_callback = std::move(release_callback)](KVCacheResource*) mutable {
+            resource.reset();
+            release_callback();
+        });
+}
 
 bool KVCacheAllocator::init() {
     RTP_LLM_CHECK_WITH_INFO(doInit(), "init failed");
@@ -116,6 +139,12 @@ MallocStatus KVCacheAllocator::evaluateInitCapacity(const MallocInfo& malloc_inf
 }
 
 MallocResult KVCacheAllocator::malloc(const MallocInfo& malloc_info) {
+    // Keep capacity classification and the physical allocations it authorizes
+    // in one transaction.  Decode-side P/D admission invokes this entry point
+    // from concurrent RPC threads, while running streams can allocate from the
+    // engine thread at the same time.
+    std::lock_guard<std::mutex> lock(malloc_mutex_);
+
     if (!malloc_info.batch_kv_cache_resource) {
         RTP_LLM_LOG_ERROR("BatchKVCacheResource is null");
         return {false, 0};

--- a/rtp_llm/cpp/cache/KVCacheAllocator.h
+++ b/rtp_llm/cpp/cache/KVCacheAllocator.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <string>
@@ -65,6 +66,11 @@ public:
     virtual std::shared_ptr<KVCacheResource> incrKVCacheRef(const KVCacheResource& kvcache_resource,
                                                             const CacheKeysType&   cache_keys,
                                                             bool                   is_connector = false) = 0;
+    std::shared_ptr<KVCacheResource>
+    incrKVCacheRefWithReleaseCallback(const KVCacheResource& kvcache_resource,
+                                      const CacheKeysType&   cache_keys,
+                                      bool                   is_connector,
+                                      std::function<void()>  release_callback);
 
     virtual GroupedCacheLayerLayout allLayerCacheBase() const                                           = 0;
     virtual bool                    updateKVBlock(const BatchKVCacheResourcePtr&  batch_kv_cache_resource,
@@ -199,6 +205,13 @@ protected:
 
     size_t  reserve_block_num_{0};
     int64_t reserve_block_ratio_{0};
+
+    // One allocation spans capacity preflight, optional cache matching and one
+    // or more BlockPool allocations.  BlockPool makes each individual
+    // operation thread-safe, but without this transaction lock concurrent
+    // init-malloc callers can all pass the same reserve check and collectively
+    // consume the forward-progress reserve before any one of them allocates.
+    std::mutex malloc_mutex_;
 };
 
 using KVCacheAllocatorPtr = std::shared_ptr<KVCacheAllocator>;

--- a/rtp_llm/cpp/cache/KVCacheAllocator.h
+++ b/rtp_llm/cpp/cache/KVCacheAllocator.h
@@ -109,8 +109,8 @@ public:
         shared_block_cache_ = std::move(shared_block_cache);
     }
 
-    void setUseCudaMallocBlockPool(bool use_cuda_malloc_block_pool) {
-        use_cuda_malloc_block_pool_ = use_cuda_malloc_block_pool;
+    void setUseDeviceMallocBlockPool(bool use_device_malloc_block_pool) {
+        use_device_malloc_block_pool_ = use_device_malloc_block_pool;
     }
 
     void setCPSlotMapper(std::shared_ptr<CPSlotMapper> cp_slot_mapper) {
@@ -201,7 +201,7 @@ protected:
     SharedBlockCachePtr                shared_block_cache_;
     std::shared_ptr<CPSlotMapper>      cp_slot_mapper_;
     const kmonitor::MetricsReporterPtr metrics_reporter_           = nullptr;
-    bool                               use_cuda_malloc_block_pool_ = false;
+    bool                               use_device_malloc_block_pool_ = false;
 
     size_t  reserve_block_num_{0};
     int64_t reserve_block_ratio_{0};

--- a/rtp_llm/cpp/cache/KVCacheManager.cc
+++ b/rtp_llm/cpp/cache/KVCacheManager.cc
@@ -203,7 +203,7 @@ KVCacheManager::KVCacheManager(const CacheConfig&                 config,
                                const SpeculativeExecutionConfig&  sp_config,
                                const PDSepConfig&                 pd_sep_config,
                                const CacheStoreConfig&            cache_store_config,
-                               bool                               use_cuda_malloc_block_pool):
+                               bool                               use_device_malloc_block_pool):
     config_(config),
     metrics_reporter_(metrics_reporter),
     kv_cache_config_(kv_cache_config),
@@ -212,7 +212,7 @@ KVCacheManager::KVCacheManager(const CacheConfig&                 config,
     sp_config_(sp_config),
     pd_sep_config_(pd_sep_config),
     cache_store_config_(cache_store_config),
-    use_cuda_malloc_block_pool_(use_cuda_malloc_block_pool),
+    use_device_malloc_block_pool_(use_device_malloc_block_pool),
     warmup_(warmup),
     allocation_wait_state_(std::make_shared<KVCacheAllocationWaitState>()) {
     if (warmup) {
@@ -292,9 +292,9 @@ bool KVCacheManager::init() {
             config_, AllocationType::DEVICE, metrics_reporter_, kv_cache_config_.reserve_block_ratio);
     }
 
-    if (use_cuda_malloc_block_pool_) {
-        RTP_LLM_LOG_INFO("RDMA cache store enabled for PD role, use cudaMalloc KV cache block-pool backing");
-        allocator_->setUseCudaMallocBlockPool(true);
+    if (use_device_malloc_block_pool_) {
+        RTP_LLM_LOG_INFO("RDMA cache store enabled for PD role, use raw device malloc KV cache block-pool backing");
+        allocator_->setUseDeviceMallocBlockPool(true);
     }
 
     allocator_->setCPSlotMapper(cp_slot_mapper_);

--- a/rtp_llm/cpp/cache/KVCacheManager.cc
+++ b/rtp_llm/cpp/cache/KVCacheManager.cc
@@ -30,7 +30,29 @@
 
 namespace rtp_llm {
 
+class KVCacheAllocationWaitState {
+public:
+    std::atomic<uint64_t>   generation{0};
+    std::atomic<bool>       stopped{false};
+    std::mutex              mutex;
+    std::condition_variable cv;
+};
+
 namespace {
+
+void notifyAllocationChangeState(const std::shared_ptr<KVCacheAllocationWaitState>& state) {
+    if (!state) {
+        return;
+    }
+    {
+        // Coordinate the predicate update with wait_for()'s unlock-and-wait
+        // transition. Without this lock a notify can race between the final
+        // predicate check and actually enqueueing the waiter.
+        std::lock_guard<std::mutex> lock(state->mutex);
+        state->generation.fetch_add(1, std::memory_order_release);
+    }
+    state->cv.notify_all();
+}
 
 std::string resolveKVCacheEventInstanceGroup(const std::string& event_group, const std::string& reco_group) {
     return event_group.empty() ? reco_group : event_group;
@@ -191,7 +213,8 @@ KVCacheManager::KVCacheManager(const CacheConfig&                 config,
     pd_sep_config_(pd_sep_config),
     cache_store_config_(cache_store_config),
     use_cuda_malloc_block_pool_(use_cuda_malloc_block_pool),
-    warmup_(warmup) {
+    warmup_(warmup),
+    allocation_wait_state_(std::make_shared<KVCacheAllocationWaitState>()) {
     if (warmup) {
         config_.finalizeBlockNums(/*global_block_num=*/1, runtime_config_);
     } else {
@@ -228,6 +251,11 @@ KVCacheManager::KVCacheManager(const CacheConfig&                 config,
 
 KVCacheManager::~KVCacheManager() {
     stop_.store(true, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lock(allocation_wait_state_->mutex);
+        allocation_wait_state_->stopped.store(true, std::memory_order_release);
+    }
+    allocation_wait_state_->cv.notify_all();
     if (metrics_reporter_thread_.joinable()) {
         metrics_reporter_thread_.join();
     }
@@ -353,6 +381,41 @@ void KVCacheManager::free(const FreeInfo& free_info) {
     RTP_LLM_PROFILE_FUNCTION();
     RTP_LLM_CHECK(free_info.batch_kv_cache_resource && free_info.complete_token_ids);
     allocator_->free(free_info);
+    notifyAllocationChange();
+}
+
+uint64_t KVCacheManager::allocationGeneration() const {
+    return allocation_wait_state_->generation.load(std::memory_order_acquire);
+}
+
+bool KVCacheManager::waitForAllocationChange(uint64_t observed_generation, int64_t timeout_ms) {
+    const auto state = allocation_wait_state_;
+    if (state->generation.load(std::memory_order_acquire) != observed_generation) {
+        return true;
+    }
+    if (timeout_ms <= 0) {
+        return false;
+    }
+
+    std::unique_lock<std::mutex> lock(state->mutex);
+    state->cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [state, observed_generation] {
+        return state->stopped.load(std::memory_order_acquire)
+               || state->generation.load(std::memory_order_acquire) != observed_generation;
+    });
+    return state->generation.load(std::memory_order_acquire) != observed_generation;
+}
+
+void KVCacheManager::notifyAllocationChange() {
+    notifyAllocationChangeState(allocation_wait_state_);
+}
+
+std::function<void()> KVCacheManager::allocationChangeCallback() const {
+    std::weak_ptr<KVCacheAllocationWaitState> weak_state = allocation_wait_state_;
+    return [weak_state]() {
+        if (const auto state = weak_state.lock()) {
+            notifyAllocationChangeState(state);
+        }
+    };
 }
 
 void KVCacheManager::insertIntoCache(const InsertInfo& insert_info) {
@@ -411,7 +474,12 @@ bool KVCacheManager::updateKVBlock(const BatchKVCacheResourcePtr&  batch_kv_cach
                                    bool                            copy_last_block,
                                    std::vector<TaggedBlockIdPair>& block_update_mapping) {
     RTP_LLM_PROFILE_FUNCTION();
-    return allocator_->updateKVBlock(batch_kv_cache_resource, block_src_batch, copy_last_block, block_update_mapping);
+    const bool updated =
+        allocator_->updateKVBlock(batch_kv_cache_resource, block_src_batch, copy_last_block, block_update_mapping);
+    // updateKVBlock may release dropped batch rows (including on a partial
+    // failure), so always wake admission waiters to re-evaluate capacity.
+    notifyAllocationChange();
+    return updated;
 }
 
 // 地址转换和缓冲区访问
@@ -525,6 +593,7 @@ BatchKVCacheResourcePtr KVCacheManager::popBlocksFromCache(size_t min_blocks_to_
 
 void KVCacheManager::blockCacheFree(const BatchKVCacheResourcePtr& batch_kv_cache_resource) {
     allocator_->blockCacheFree(batch_kv_cache_resource);
+    notifyAllocationChange();
 }
 
 size_t KVCacheManager::availableTokensNum() const {
@@ -628,7 +697,8 @@ bool KVCacheManager::hasActiveConnectors() const {
 // PD separation: increment KV cache reference count
 std::shared_ptr<KVCacheResource>
 KVCacheManager::incrKVCacheRef(const KVCacheResource& resource, const CacheKeysType& cache_keys, bool is_connector) {
-    return allocator_->incrKVCacheRef(resource, cache_keys, is_connector);
+    return allocator_->incrKVCacheRefWithReleaseCallback(
+        resource, cache_keys, is_connector, allocationChangeCallback());
 }
 
 bool KVCacheManager::hasP2PConnector() const {
@@ -672,7 +742,8 @@ void KVCacheManager::initConnectorCoordinator() {
                                                                  allocator_,
                                                                  metrics_reporter_,
                                                                  pd_sep_config_,
-                                                                 cache_store_config_);
+                                                                 cache_store_config_,
+                                                                 allocationChangeCallback());
     RTP_LLM_CHECK_WITH_INFO(coordinator_->init(), "connector coordinator init failed");
 }
 

--- a/rtp_llm/cpp/cache/KVCacheManager.h
+++ b/rtp_llm/cpp/cache/KVCacheManager.h
@@ -40,7 +40,7 @@ public:
                    const SpeculativeExecutionConfig&  sp_config                  = SpeculativeExecutionConfig{},
                    const PDSepConfig&                 pd_sep_config              = PDSepConfig{},
                    const CacheStoreConfig&            cache_store_config         = CacheStoreConfig{},
-                   bool                               use_cuda_malloc_block_pool = false);
+                   bool                               use_device_malloc_block_pool = false);
     ~KVCacheManager();
 
     // 初始化和配置相关
@@ -200,7 +200,7 @@ private:
     const SpeculativeExecutionConfig   sp_config_;
     const PDSepConfig                  pd_sep_config_;
     const CacheStoreConfig             cache_store_config_;
-    const bool                         use_cuda_malloc_block_pool_;
+    const bool                         use_device_malloc_block_pool_;
     const bool                         warmup_;
 
     std::shared_ptr<CPSlotMapper>                   cp_slot_mapper_;

--- a/rtp_llm/cpp/cache/KVCacheManager.h
+++ b/rtp_llm/cpp/cache/KVCacheManager.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -26,6 +27,7 @@ class CacheStore;
 class KVCacheConnectorCoordinator;
 class KVCacheConnectorReadWriteContext;
 class PrefillCacheHitMetricsReporter;
+class KVCacheAllocationWaitState;
 
 class KVCacheManager {
 public:
@@ -54,6 +56,13 @@ public:
     MallocResult malloc(const MallocInfo& malloc_info);
     void         free(const FreeInfo& free_info);
     void         insertIntoCache(const InsertInfo& insert_info);
+
+    // Decode-side P/D admission allocates destination blocks before cache handoff.  When pools are
+    // temporarily full, waiters use this generation instead of polling malloc in a tight loop.
+    // Capture the generation before an allocation attempt; waitForAllocationChange() then cannot
+    // miss a release racing with that attempt.
+    uint64_t allocationGeneration() const;
+    bool     waitForAllocationChange(uint64_t observed_generation, int64_t timeout_ms);
 
     int
     singleBatchNeedBlocks(const BatchKVCacheResourcePtr& batch_kv_cache_resource, int seq_len, int reserve_step) const;
@@ -177,6 +186,8 @@ private:
     void allocateAndSync();
     void reportMetricsLoop();
     void reportPrefillCacheHitMetrics(const MallocInfo& malloc_info, bool is_first_malloc);
+    void notifyAllocationChange();
+    std::function<void()> allocationChangeCallback() const;
 
     // 成员变量
     CacheConfig         config_;
@@ -197,6 +208,8 @@ private:
 
     std::atomic<bool> stop_{false};
     std::thread       metrics_reporter_thread_;
+
+    std::shared_ptr<KVCacheAllocationWaitState> allocation_wait_state_;
 
     std::shared_ptr<KVCacheConnectorCoordinator> coordinator_;
 

--- a/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.cc
+++ b/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.cc
@@ -25,7 +25,8 @@ KVCacheConnectorCoordinator::KVCacheConnectorCoordinator(const CacheConfig&     
                                                          const std::shared_ptr<KVCacheAllocator>& allocator,
                                                          const kmonitor::MetricsReporterPtr&      metrics_reporter,
                                                          const PDSepConfig&                       pd_sep_config,
-                                                         const CacheStoreConfig&                  cache_store_config):
+                                                         const CacheStoreConfig&                  cache_store_config,
+                                                         std::function<void()>                    capacity_release_callback):
     cache_config_(cache_config),
     kv_cache_config_(kv_cache_config),
     runtime_config_(runtime_config),
@@ -34,7 +35,8 @@ KVCacheConnectorCoordinator::KVCacheConnectorCoordinator(const CacheConfig&     
     allocator_(allocator),
     metrics_reporter_(metrics_reporter),
     pd_sep_config_(pd_sep_config),
-    cache_store_config_(cache_store_config) {}
+    cache_store_config_(cache_store_config),
+    capacity_release_callback_(std::move(capacity_release_callback)) {}
 
 KVCacheConnectorCoordinator::~KVCacheConnectorCoordinator() {
     stop_.store(true);
@@ -133,7 +135,8 @@ KVCacheConnectorCoordinator::asyncRead(const std::shared_ptr<KVCacheConnectorRea
         ref_resource = mapper.projectConnectorResource(kvcache_resource, cache_config_, ref_keys);
         ref_keys     = ref_resource.cacheKeys();
     }
-    auto resource = allocator_->incrKVCacheRef(ref_resource, ref_keys, true);
+    auto resource = allocator_->incrKVCacheRefWithReleaseCallback(
+        ref_resource, ref_keys, true, capacity_release_callback_);
     if (!resource) {
         RTP_LLM_LOG_WARNING("async read failed, incr kvcache ref failed, resource: [%s]",
                             kvcache_resource.debugString().c_str());
@@ -183,7 +186,8 @@ KVCacheConnectorCoordinator::asyncWrite(const std::shared_ptr<KVCacheConnectorRe
         ref_resource = mapper.projectConnectorResource(kvcache_resource, cache_config_, ref_keys);
         ref_keys     = ref_resource.cacheKeys();
     }
-    auto resource = allocator_->incrKVCacheRef(ref_resource, ref_keys, true);
+    auto resource = allocator_->incrKVCacheRefWithReleaseCallback(
+        ref_resource, ref_keys, true, capacity_release_callback_);
     if (!resource) {
         RTP_LLM_LOG_WARNING("async write failed, incr kvcache ref failed, resource: [%s]",
                             kvcache_resource.debugString().c_str());

--- a/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.h
+++ b/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.h
@@ -34,7 +34,8 @@ public:
                                 const std::shared_ptr<KVCacheAllocator>& allocator,
                                 const kmonitor::MetricsReporterPtr&      metrics_reporter   = nullptr,
                                 const PDSepConfig&                       pd_sep_config      = PDSepConfig{},
-                                const CacheStoreConfig&                  cache_store_config = CacheStoreConfig{});
+                                const CacheStoreConfig&                  cache_store_config = CacheStoreConfig{},
+                                std::function<void()>                    capacity_release_callback = nullptr);
     virtual ~KVCacheConnectorCoordinator();
 
 public:
@@ -88,6 +89,7 @@ private:
     kmonitor::MetricsReporterPtr      metrics_reporter_;
     PDSepConfig                       pd_sep_config_;
     CacheStoreConfig                  cache_store_config_;
+    std::function<void()>             capacity_release_callback_;
 
     std::vector<std::shared_ptr<KVCacheConnector>>    connectors_;
     std::shared_ptr<KVCacheMemoryConnector>           memory_connector_;

--- a/rtp_llm/cpp/cache/test/BUILD
+++ b/rtp_llm/cpp/cache/test/BUILD
@@ -61,6 +61,25 @@ cc_library(
 )
 
 cc_test(
+    name = "hybrid_pool_config_creator_test",
+    srcs = ["HybridPoolConfigCreatorTest.cc"],
+    copts = test_copts,
+    deps = [
+        ":cache_config_test_utils",
+        "//rtp_llm/cpp/cache:cache_core",
+        "//rtp_llm/models_py/bindings/core:exec_ctx_ops",
+        "//rtp_llm/models_py/bindings/core:exec_ctx_state",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+    env = {},
+    exec_properties = select({
+        "@//:using_rocm": {"gpu": "MI308X-ROCM7"},
+        "//conditions:default": {"gpu": "A10"},
+    }),
+)
+
+cc_test(
     name = "cache_topology_test",
     srcs = ["CacheTopologyTest.cc"],
     copts = test_copts,

--- a/rtp_llm/cpp/cache/test/BUILD
+++ b/rtp_llm/cpp/cache/test/BUILD
@@ -232,6 +232,37 @@ cc_test(
 )
 
 cc_test(
+    name = "block_pool_device_malloc_test",
+    srcs = [
+        "BlockPoolDeviceMallocTest.cc",
+    ],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/cache:block_pool",
+        "//rtp_llm/cpp/disaggregate/cache_store:cache_store_interface",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ] + torch_deps() + select({
+        "@//:using_cuda": [
+            "//rtp_llm/models_py/bindings/cuda/ops:cuda_impl",
+            "@local_config_cuda//cuda:cuda_headers",
+            "@local_config_cuda//cuda:cudart",
+        ],
+        "@//:using_rocm": [
+            "//rtp_llm/models_py/bindings/core:exec_ctx_rocm",
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:hip",
+        ],
+        "//conditions:default": [],
+    }),
+    exec_properties = select({
+        "@//:using_cuda": {"gpu": "H20"},
+        "@//:using_rocm": {"gpu": "MI308X-ROCM7"},
+        "//conditions:default": {},
+    }),
+)
+
+cc_test(
     name = "memory_layout_strategy_test",
     srcs = [
         "MemoryLayoutStrategyTest.cc",

--- a/rtp_llm/cpp/cache/test/BlockPoolDeviceMallocTest.cc
+++ b/rtp_llm/cpp/cache/test/BlockPoolDeviceMallocTest.cc
@@ -1,0 +1,278 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "rtp_llm/cpp/cache/BlockPool.h"
+#include "rtp_llm/cpp/cache/BlockPoolConfigHelper.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/CacheStore.h"
+
+#if USING_CUDA
+#include <cuda_runtime.h>
+#elif USING_ROCM
+#include <hip/hip_runtime.h>
+#endif
+
+namespace rtp_llm {
+namespace test {
+namespace {
+
+#if USING_CUDA || USING_ROCM
+class RecordingMemoryUtil: public MemoryUtil {
+public:
+    bool regUserMr(void* buf, uint64_t size, bool gpu, uint64_t aligned_size) override {
+        reg_calls.push_back({buf, size, gpu, aligned_size});
+        return true;
+    }
+
+    bool deregUserMr(void* buf, bool gpu) override {
+        dereg_calls.push_back({buf, gpu});
+        return true;
+    }
+
+    bool isMemoryMr(void*, uint64_t, bool, bool) override {
+        return false;
+    }
+
+    bool findMemoryMr(void*, void*, uint64_t, bool, bool) override {
+        return false;
+    }
+
+    bool isRdmaMode() override {
+        return true;
+    }
+
+    struct RegCall {
+        void*    buf;
+        uint64_t size;
+        bool     gpu;
+        uint64_t aligned_size;
+    };
+
+    struct DeregCall {
+        void* buf;
+        bool  gpu;
+    };
+
+    std::vector<RegCall>   reg_calls;
+    std::vector<DeregCall> dereg_calls;
+};
+
+class RecordingCacheStore: public CacheStore {
+public:
+    explicit RecordingCacheStore(std::shared_ptr<MemoryUtil> memory_util): memory_util_(std::move(memory_util)) {}
+
+    void store(const std::shared_ptr<RequestBlockBuffer>&, CacheStoreStoreDoneCallback callback) override {
+        if (callback) {
+            callback(false, CacheStoreErrorCode::InvalidParams);
+        }
+    }
+
+    void load(const std::shared_ptr<RequestBlockBuffer>&,
+              CacheStoreLoadDoneCallback callback,
+              const std::string&,
+              uint32_t,
+              uint32_t,
+              uint32_t,
+              int,
+              int) override {
+        if (callback) {
+            callback(false, CacheStoreErrorCode::InvalidParams);
+        }
+    }
+
+    std::shared_ptr<LoadContext> loadBuffers(const std::vector<std::shared_ptr<RequestBlockBuffer>>&,
+                                             const std::string&,
+                                             uint32_t,
+                                             uint32_t,
+                                             int64_t,
+                                             LoadContext::CheckCancelFunc,
+                                             int,
+                                             int) override {
+        return nullptr;
+    }
+
+    std::shared_ptr<StoreContext> storeBuffers(const std::vector<std::shared_ptr<RequestBlockBuffer>>&,
+                                               int64_t) override {
+        return nullptr;
+    }
+
+    std::shared_ptr<RemoteStoreTask>
+    submitRemoteStoreTask(const std::shared_ptr<RemoteStoreRequest>&,
+                          const std::shared_ptr<CacheStoreRemoteStoreMetricsCollector>&,
+                          RemoteStoreTask::CheckCancelFunc) override {
+        return nullptr;
+    }
+
+    void releaseRemoteStoreTask(const std::shared_ptr<RemoteStoreTask>&) override {}
+
+    bool regUserBuffers(const std::vector<std::shared_ptr<BlockBuffer>>&) override {
+        return true;
+    }
+
+    std::shared_ptr<BlockBuffer> findUserBuffer(const std::string&) override {
+        return nullptr;
+    }
+
+    const std::shared_ptr<MemoryUtil>& getMemoryUtil() const override {
+        return memory_util_;
+    }
+
+    void debugInfo() override {}
+
+private:
+    std::shared_ptr<MemoryUtil> memory_util_;
+};
+
+int deviceCount() {
+#if USING_CUDA
+    int count = 0;
+    return cudaGetDeviceCount(&count) == cudaSuccess ? count : 0;
+#elif USING_ROCM
+    int count = 0;
+    return hipGetDeviceCount(&count) == hipSuccess ? count : 0;
+#else
+    return 0;
+#endif
+}
+
+bool getDevice(int* device) {
+#if USING_CUDA
+    return cudaGetDevice(device) == cudaSuccess;
+#elif USING_ROCM
+    return hipGetDevice(device) == hipSuccess;
+#else
+    (void)device;
+    return false;
+#endif
+}
+
+bool setDevice(int device) {
+#if USING_CUDA
+    return cudaSetDevice(device) == cudaSuccess;
+#elif USING_ROCM
+    return hipSetDevice(device) == hipSuccess;
+#else
+    (void)device;
+    return false;
+#endif
+}
+
+bool synchronizeDevice() {
+#if USING_CUDA
+    return cudaDeviceSynchronize() == cudaSuccess;
+#elif USING_ROCM
+    return hipDeviceSynchronize() == hipSuccess;
+#else
+    return false;
+#endif
+}
+
+BlockPoolConfig makeSmallBlockPoolConfig() {
+    constexpr uint32_t kLayerNum        = 1;
+    constexpr uint32_t kBlockNum        = 4;
+    constexpr size_t   kBlockSizeBytes = 256;
+    auto config = BlockPoolConfigHelper::createConfig(kLayerNum, kBlockNum, kBlockSizeBytes, DataType::TYPE_FP16);
+    config.pool_name = "raw_device_malloc_test";
+    return config;
+}
+#endif
+
+}  // namespace
+
+TEST(BlockPoolDeviceMallocTest, AllocatesUsableGpuBacking) {
+#if USING_CUDA || USING_ROCM
+    if (deviceCount() == 0) {
+        GTEST_SKIP() << "No GPU is visible";
+    }
+
+    auto config = makeSmallBlockPoolConfig();
+    auto pool   = std::make_shared<BlockPool>(config,
+                                            AllocationType::DEVICE,
+                                            /*use_pinned_cpu_backing=*/false,
+                                            /*use_device_malloc_backing=*/true);
+    ASSERT_TRUE(pool->init());
+    ASSERT_NE(pool->getBaseAddress(), nullptr);
+    EXPECT_EQ(pool->where(), MemoryType::MEMORY_GPU);
+
+    auto layer_tensors = pool->allLayerCacheBase();
+    ASSERT_EQ(layer_tensors.size(), 1u);
+    EXPECT_TRUE(layer_tensors[0].is_cuda());
+    EXPECT_EQ(static_cast<size_t>(layer_tensors[0].nbytes()), config.total_size_bytes);
+    EXPECT_NO_THROW(layer_tensors[0].fill_(7));
+    EXPECT_TRUE(synchronizeDevice());
+
+    auto block = pool->convertIndexToBuffer(/*layer_id=*/0, /*block_id=*/1);
+    ASSERT_EQ(block.size(), 1u);
+    EXPECT_TRUE(block[0].is_cuda);
+    EXPECT_EQ(block[0].size_bytes, config.memory_layouts[0].kv_block_stride_bytes);
+#else
+    GTEST_SKIP() << "Raw device allocation is only supported in CUDA and ROCm builds";
+#endif
+}
+
+TEST(BlockPoolDeviceMallocTest, PassesGpuBackingToMemoryRegistrationBoundary) {
+#if USING_CUDA || USING_ROCM
+    if (deviceCount() == 0) {
+        GTEST_SKIP() << "No GPU is visible";
+    }
+
+    auto config = makeSmallBlockPoolConfig();
+    auto pool   = std::make_shared<BlockPool>(config,
+                                            AllocationType::DEVICE,
+                                            /*use_pinned_cpu_backing=*/false,
+                                            /*use_device_malloc_backing=*/true);
+    ASSERT_TRUE(pool->init());
+
+    const auto& layout      = config.memory_layouts[0];
+    auto        memory_util = std::make_shared<RecordingMemoryUtil>();
+    auto        cache_store = std::make_shared<RecordingCacheStore>(memory_util);
+    pool->regUserMr(/*model_id=*/0, cache_store);
+
+    ASSERT_EQ(memory_util->reg_calls.size(), 1u);
+    EXPECT_EQ(memory_util->reg_calls[0].buf, pool->getBaseAddress());
+    EXPECT_EQ(memory_util->reg_calls[0].size, layout.kv_block_pool_size_bytes);
+    EXPECT_TRUE(memory_util->reg_calls[0].gpu);
+    EXPECT_EQ(memory_util->reg_calls[0].aligned_size, layout.kv_block_stride_bytes);
+
+    pool->deregUserMr();
+    ASSERT_EQ(memory_util->dereg_calls.size(), 1u);
+    EXPECT_EQ(memory_util->dereg_calls[0].buf, pool->getBaseAddress());
+    EXPECT_TRUE(memory_util->dereg_calls[0].gpu);
+#else
+    GTEST_SKIP() << "Raw device allocation is only supported in CUDA and ROCm builds";
+#endif
+}
+
+TEST(BlockPoolDeviceMallocTest, DestructionRestoresCurrentDevice) {
+#if USING_CUDA || USING_ROCM
+    if (deviceCount() < 2) {
+        GTEST_SKIP() << "At least two visible GPUs are required";
+    }
+
+    int original_device = -1;
+    ASSERT_TRUE(getDevice(&original_device));
+    ASSERT_TRUE(setDevice(0));
+
+    auto pool = std::make_shared<BlockPool>(makeSmallBlockPoolConfig(),
+                                            AllocationType::DEVICE,
+                                            /*use_pinned_cpu_backing=*/false,
+                                            /*use_device_malloc_backing=*/true);
+    ASSERT_TRUE(pool->init());
+
+    ASSERT_TRUE(setDevice(1));
+    pool.reset();
+
+    int current_device = -1;
+    EXPECT_TRUE(getDevice(&current_device));
+    EXPECT_EQ(current_device, 1);
+    EXPECT_TRUE(setDevice(original_device));
+#else
+    GTEST_SKIP() << "Raw device allocation is only supported in CUDA and ROCm builds";
+#endif
+}
+
+}  // namespace test
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/test/HybridPoolConfigCreatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridPoolConfigCreatorTest.cc
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include "rtp_llm/cpp/cache/HybridPoolConfigCreator.h"
+#include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
+
+namespace rtp_llm::test {
+namespace {
+
+ModelConfig makeHybridAttentionModelConfig() {
+    ModelConfig model_config;
+    model_config.num_layers                                                = 4;
+    model_config.hidden_size                                               = 128;
+    model_config.attn_config.head_num                                      = 4;
+    model_config.attn_config.kv_head_num                                   = 2;
+    model_config.attn_config.size_per_head                                 = 16;
+    model_config.attn_config.tokens_per_block                              = 8;
+    model_config.hybrid_attention_config.enable_hybrid_attention           = true;
+    model_config.hybrid_attention_config.enable_independent_kv_cache_pools = true;
+    model_config.hybrid_attention_config.hybrid_attention_types            = {
+        HybridAttentionType::LINEAR, HybridAttentionType::NONE, HybridAttentionType::LINEAR, HybridAttentionType::NONE};
+    model_config.linear_attention_config.linear_conv_kernel_dim = 4;
+    model_config.linear_attention_config.linear_key_head_dim    = 16;
+    model_config.linear_attention_config.linear_value_head_dim  = 16;
+    model_config.linear_attention_config.linear_num_key_heads   = 2;
+    model_config.linear_attention_config.linear_num_value_heads = 2;
+    setHybridAttentionKvCacheSpecs(model_config);
+    return model_config;
+}
+
+TEST(HybridPoolConfigCreatorTest, MhaPhysicalStrideIsNotRepeatedPerKernelBlock) {
+    auto model_config = makeHybridAttentionModelConfig();
+
+    ParallelismConfig parallelism_config;
+    parallelism_config.tp_size = 2;
+
+    KVCacheConfig kv_cache_config;
+    kv_cache_config.seq_size_per_block        = 8;
+    kv_cache_config.kernel_seq_size_per_block = 2;
+    auto config = HybridPoolConfigCreator::createConfig(model_config, parallelism_config, kv_cache_config, false, 0);
+
+    const auto full_gid = config.groupIdForTag("full");
+    ASSERT_EQ(config.specForGroup(full_gid)->type, KVCacheSpecType::MultiHeadAttention);
+    EXPECT_EQ(config.kernelBlocksPerKvBlockForGroup(full_gid), 4u);
+    EXPECT_EQ(config.kvBlockStrideBytesForGroup(full_gid), config.specForGroup(full_gid)->block_size_bytes());
+}
+
+}  // namespace
+}  // namespace rtp_llm::test

--- a/rtp_llm/cpp/cache/test/HybridPoolKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridPoolKVCacheAllocatorTest.cc
@@ -139,6 +139,14 @@ static CacheConfig makeDSV4HybridPoolConfig(uint32_t block_num = 200) {
     return config;
 }
 
+static CacheConfig makeTinyDSV4HybridPoolConfig(uint32_t block_num = 8) {
+    auto              mc = makeTinyDSV4ModelConfig();
+    ParallelismConfig pc;
+    auto              config = CacheConfigCreator::createBasicConfig(mc, pc, false, 0);
+    config.finalizeBlockNums(block_num, RuntimeConfig{});
+    return config;
+}
+
 static void setExplicitBlocksForGroup(CacheConfig& config, size_t group_id, uint32_t block_num) {
     ASSERT_LT(group_id, static_cast<size_t>(config.groupNums()));
     std::vector<CacheGroupPolicy> policies;
@@ -1079,7 +1087,10 @@ TEST_F(HybridPoolKVCacheAllocatorTest, DSV4FixedTagPoolsUseGpuBacking) {
 // memory_placement=HOST_PINNED must move only the opted-in pools off HBM; every other pool of
 // the same DSV4 config stays on the device.
 TEST_F(HybridPoolKVCacheAllocatorTest, DSV4FixedTagPoolsUsePinnedHostBackingWhenPlacementIsHostPinned) {
-    auto       config      = makeDSV4HybridPoolConfig(/*block_num=*/200);
+    // This test validates residency routing, not production-size capacity.
+    // Use the seven-pool tiny DSV4 topology so CI does not need to pin the
+    // Pro model's multi-GiB HCA-state pool merely to inspect MemoryType.
+    auto       config      = makeTinyDSV4HybridPoolConfig();
     const auto pinned_gids = setPinnedHostPlacementForExplicitIndependentGroups(config);
     ASSERT_FALSE(pinned_gids.empty());
     ASSERT_LT(pinned_gids.size(), static_cast<size_t>(config.groupNums()));

--- a/rtp_llm/cpp/cache/test/HybridPoolKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridPoolKVCacheAllocatorTest.cc
@@ -1,9 +1,12 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
@@ -802,12 +805,90 @@ TEST_F(HybridPoolKVCacheAllocatorTest, PoolMetricsSnapshotsReportReserveBlocks) 
     EXPECT_EQ("linear", snapshots[0].pool_name);
     EXPECT_EQ("full", snapshots[1].pool_name);
 
-    const size_t total_reservable_available_blocks = snapshots[0].available_blocks + snapshots[1].available_blocks;
-    ASSERT_GT(total_reservable_available_blocks, 0u);
-    EXPECT_EQ(reserve_blocks * snapshots[0].available_blocks / total_reservable_available_blocks,
-              snapshots[0].reserve_blocks);
-    EXPECT_EQ(reserve_blocks * snapshots[1].available_blocks / total_reservable_available_blocks,
-              snapshots[1].reserve_blocks);
+    const size_t total_reservable_blocks = snapshots[0].total_blocks + snapshots[1].total_blocks;
+    ASSERT_GT(total_reservable_blocks, 0u);
+    EXPECT_EQ(reserve_blocks * snapshots[0].total_blocks / total_reservable_blocks, snapshots[0].reserve_blocks);
+    EXPECT_EQ(reserve_blocks * snapshots[1].total_blocks / total_reservable_blocks, snapshots[1].reserve_blocks);
+}
+
+TEST_F(HybridPoolKVCacheAllocatorTest, ReserveShareDoesNotCollapseForDepletedPool) {
+    auto config    = makeTinyMultiPoolHybridConfig(/*linear_block_num=*/20, /*full_block_num=*/8);
+    auto allocator = makeAllocator(config);
+    ASSERT_TRUE(allocator->init());
+
+    constexpr size_t reserve_blocks = 10;
+    allocator->setReserveBlocksNum(reserve_blocks);
+    const auto before = allocator->poolMetricsSnapshots();
+    ASSERT_EQ(before.size(), 2u);
+
+    // Consume the FULL pool more aggressively than the LINEAR pool. The safety
+    // share is a property of configured capacity and must remain stable instead
+    // of migrating into the idle LINEAR pool.
+    auto batch_res = makeBatchResource(/*batch_size=*/1, config);
+    batch_res->setBatchCacheKeys(0, CacheKeysType{100, 101, 102});
+    auto       token_ids = makeCompleteTokenIds(/*batch_size=*/1, /*seq_length=*/12, /*seq_size_per_block=*/4);
+    MallocInfo malloc_info{batch_res, token_ids};
+    malloc_info.enable_device_cache = false;
+    malloc_info.reuse_cache         = false;
+    ASSERT_TRUE(allocator->malloc(malloc_info).success);
+
+    const auto after = allocator->poolMetricsSnapshots();
+    ASSERT_EQ(after.size(), before.size());
+    EXPECT_LT(after[1].available_blocks, before[1].available_blocks);
+    EXPECT_EQ(after[0].reserve_blocks, before[0].reserve_blocks);
+    EXPECT_EQ(after[1].reserve_blocks, before[1].reserve_blocks);
+}
+
+TEST_F(HybridPoolKVCacheAllocatorTest, ConcurrentInitMallocCannotOverrunReserve) {
+    auto config    = makeTinyMultiPoolHybridConfig(/*linear_block_num=*/40, /*full_block_num=*/40);
+    auto allocator = makeAllocator(config);
+    ASSERT_TRUE(allocator->init());
+
+    constexpr size_t reserve_blocks = 20;
+    constexpr int    thread_count   = 32;
+    allocator->setReserveBlocksNum(reserve_blocks);
+
+    std::vector<BatchKVCacheResourcePtr> resources;
+    std::vector<CompleteTokenIdsPtr>     token_ids;
+    resources.reserve(thread_count);
+    token_ids.reserve(thread_count);
+    for (int i = 0; i < thread_count; ++i) {
+        auto resource = makeBatchResource(/*batch_size=*/1, config);
+        resource->setBatchCacheKeys(0, CacheKeysType{static_cast<int64_t>(100 + i)});
+        resources.push_back(std::move(resource));
+        token_ids.push_back(makeCompleteTokenIds(/*batch_size=*/1, /*seq_length=*/4, /*seq_size_per_block=*/4));
+    }
+
+    std::atomic<bool>        start{false};
+    // vector<bool> packs bits, so writes to distinct indices may still race on
+    // the same storage word. Give each worker an independent byte instead.
+    std::vector<uint8_t>     successes(static_cast<size_t>(thread_count), 0);
+    std::vector<std::thread> threads;
+    threads.reserve(thread_count);
+    for (int i = 0; i < thread_count; ++i) {
+        threads.emplace_back([&, i] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            MallocInfo info{resources[static_cast<size_t>(i)], token_ids[static_cast<size_t>(i)]};
+            info.enable_device_cache          = false;
+            info.reuse_cache                  = false;
+            info.verbose                      = false;
+            successes[static_cast<size_t>(i)] = allocator->malloc(info).success ? 1 : 0;
+        });
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    const auto snapshots = allocator->poolMetricsSnapshots();
+    ASSERT_EQ(snapshots.size(), 2u);
+    for (const auto& snapshot : snapshots) {
+        EXPECT_GE(snapshot.available_blocks, snapshot.reserve_blocks) << "pool=" << snapshot.pool_name;
+    }
+    EXPECT_GT(std::count(successes.begin(), successes.end(), uint8_t{1}), 0);
+    EXPECT_LT(std::count(successes.begin(), successes.end(), uint8_t{1}), thread_count);
 }
 
 TEST_F(HybridPoolKVCacheAllocatorTest, ReserveBlocksUseCPShardedFullGroupNeed) {

--- a/rtp_llm/cpp/cache/test/KVCacheManagerTest.cc
+++ b/rtp_llm/cpp/cache/test/KVCacheManagerTest.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <future>
 #include <memory>
 #include <optional>
 #include <algorithm>
@@ -267,13 +268,15 @@ static BatchKVCacheResourcePtr makeDSV4BatchResource(const CacheConfig& config) 
     return res;
 }
 
-static CompleteTokenIdsPtr makeDSV4CompleteTokenIds(int initial_seq_len, int max_seq_len, int seq_size_per_block) {
+static CompleteTokenIdsPtr
+makeDSV4CompleteTokenIds(int initial_seq_len, int max_seq_len, int seq_size_per_block, int batch_size = 1) {
     auto input_ids      = torch::arange(max_seq_len, torch::kInt32);
     auto gi             = std::make_shared<GenerateInput>();
     gi->input_ids       = input_ids;
     gi->generate_config = std::make_shared<GenerateConfig>();
 
-    auto complete_token_ids = std::make_shared<CompleteTokenIds>(1, 1, max_seq_len + 16, seq_size_per_block);
+    auto complete_token_ids =
+        std::make_shared<CompleteTokenIds>(batch_size, batch_size, max_seq_len + 16, seq_size_per_block);
     complete_token_ids->init(gi);
     complete_token_ids->setSeqLength(initial_seq_len);
     return complete_token_ids;
@@ -394,6 +397,100 @@ TEST_F(KVCacheManagerTest, MetricsThreadSmoke) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
 
     cache_manager.reset();
+}
+
+TEST_F(KVCacheManagerTest, AllocationWaitObservesReleaseGeneration) {
+    auto cache_config = makeSimpleMhaCacheConfig(
+        /*layer_num=*/1, /*block_num=*/4, /*tokens_per_block=*/2, rtp_llm::DataType::TYPE_INT8);
+    auto cache_manager = std::make_shared<KVCacheManager>(cache_config, /*warmup=*/false);
+    ASSERT_TRUE(cache_manager->init());
+
+    const auto generation_before_release = cache_manager->allocationGeneration();
+    cache_manager->notifyAllocationChange();
+    EXPECT_TRUE(cache_manager->waitForAllocationChange(generation_before_release, /*timeout_ms=*/1));
+
+    const auto generation_before_wait = cache_manager->allocationGeneration();
+    std::promise<void> waiter_started;
+    auto               waiter_ready = waiter_started.get_future();
+    auto waiter = std::async(std::launch::async, [cache_manager, generation_before_wait, &waiter_started] {
+        waiter_started.set_value();
+        return cache_manager->waitForAllocationChange(generation_before_wait, /*timeout_ms=*/1000);
+    });
+    waiter_ready.get();
+    EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
+    cache_manager->notifyAllocationChange();
+    EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(100)), std::future_status::ready);
+    EXPECT_TRUE(waiter.get());
+}
+
+TEST_F(KVCacheManagerTest, ConnectorReferenceReleaseWakesAllocationWaiter) {
+    auto cache_config = makeSimpleMhaCacheConfig(
+        /*layer_num=*/1, /*block_num=*/4, /*tokens_per_block=*/2, rtp_llm::DataType::TYPE_INT8);
+    auto cache_manager = std::make_shared<KVCacheManager>(cache_config, /*warmup=*/false);
+    ASSERT_TRUE(cache_manager->init());
+
+    auto resource = std::make_shared<BatchKVCacheResource>();
+    resource->resetBatchSize(1);
+    resource->initGroups(cache_config.topologyPtr());
+    auto tokens = makeDSV4CompleteTokenIds(/*initial_seq_len=*/2, /*max_seq_len=*/4, /*seq_size_per_block=*/2);
+
+    MallocInfo malloc_info{resource, tokens};
+    malloc_info.reuse_cache         = false;
+    malloc_info.enable_device_cache = false;
+    ASSERT_TRUE(cache_manager->malloc(malloc_info).success);
+
+    auto connector_ref = cache_manager->incrKVCacheRef(
+        resource->cacheResource(0), resource->cacheKeys(0), /*is_connector=*/true);
+    ASSERT_NE(connector_ref, nullptr);
+    cache_manager->free(FreeInfo{resource, tokens});
+
+    const auto generation_before_release = cache_manager->allocationGeneration();
+    std::promise<void> waiter_started;
+    auto               waiter_ready = waiter_started.get_future();
+    auto waiter = std::async(std::launch::async, [cache_manager, generation_before_release, &waiter_started] {
+        waiter_started.set_value();
+        return cache_manager->waitForAllocationChange(generation_before_release, /*timeout_ms=*/1000);
+    });
+    waiter_ready.get();
+    EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
+
+    connector_ref.reset();
+    EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(100)), std::future_status::ready);
+    EXPECT_TRUE(waiter.get());
+}
+
+TEST_F(KVCacheManagerTest, UpdateKVBlockReleaseWakesAllocationWaiter) {
+    auto cache_config = makeSimpleMhaCacheConfig(
+        /*layer_num=*/1, /*block_num=*/6, /*tokens_per_block=*/2, rtp_llm::DataType::TYPE_INT8);
+    auto cache_manager = std::make_shared<KVCacheManager>(cache_config, /*warmup=*/false);
+    ASSERT_TRUE(cache_manager->init());
+
+    auto resource = std::make_shared<BatchKVCacheResource>();
+    resource->resetBatchSize(2);
+    resource->initGroups(cache_config.topologyPtr());
+    auto tokens = makeDSV4CompleteTokenIds(
+        /*initial_seq_len=*/2, /*max_seq_len=*/4, /*seq_size_per_block=*/2, /*batch_size=*/2);
+
+    MallocInfo malloc_info{resource, tokens};
+    malloc_info.reuse_cache         = false;
+    malloc_info.enable_device_cache = false;
+    ASSERT_TRUE(cache_manager->malloc(malloc_info).success);
+
+    const auto generation_before_release = cache_manager->allocationGeneration();
+    std::promise<void> waiter_started;
+    auto               waiter_ready = waiter_started.get_future();
+    auto waiter = std::async(std::launch::async, [cache_manager, generation_before_release, &waiter_started] {
+        waiter_started.set_value();
+        return cache_manager->waitForAllocationChange(generation_before_release, /*timeout_ms=*/1000);
+    });
+    waiter_ready.get();
+    EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
+
+    std::vector<TaggedBlockIdPair> block_update_mapping;
+    ASSERT_TRUE(cache_manager->updateKVBlock(
+        resource, /*block_src_batch=*/{0}, /*copy_last_block=*/false, block_update_mapping));
+    EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(100)), std::future_status::ready);
+    EXPECT_TRUE(waiter.get());
 }
 
 TEST_F(KVCacheManagerTest, SetKVBlockValueAndBlockCopy) {

--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -311,7 +311,8 @@ std::string SpeculativeExecutionConfig::to_string() const {
         << "force_score_context_attention: " << force_score_context_attention << "\n"
         << "quantization: " << quantization << "\n"
         << "checkpoint_path: " << checkpoint_path << "\n"
-        << "sp_dspark_mask_token_id: " << sp_dspark_mask_token_id;
+        << "sp_dspark_mask_token_id: " << sp_dspark_mask_token_id << ", "
+        << "sp_dspark_sample_from_anchor: " << sp_dspark_sample_from_anchor;
     return oss.str();
 }
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -171,7 +171,11 @@ struct KVCacheConfig {
     int                                     linear_step                       = 1;  // for linear attention cache reuse
     // Fields merged from PyKvCacheConfig
     int         fp8_kv_cache              = 0;
-    std::string ssm_state_dtype           = "bf16";
+    // "auto" preserves a model-declared recurrent-state dtype. Models
+    // without such a declaration keep LinearAttentionConfig's BF16 default;
+    // the legacy remote connector falls back to BF16 because it requires one
+    // contiguous shared cache pool.
+    std::string ssm_state_dtype           = "auto";
     int64_t     kv_cache_mem_mb           = -1;
     int         seq_size_per_block        = 64;
     int         kernel_seq_size_per_block = 0;
@@ -334,6 +338,9 @@ struct SpeculativeExecutionConfig {
     // DSpARK noise/mask token used to build each fixed-width draft block.
     // Filled from the draft checkpoint by ModelFactory.
     int64_t     sp_dspark_mask_token_id = -1;
+    // True: gamma query rows, including the anchor prediction. False:
+    // one conditioning anchor followed by gamma prediction rows.
+    bool        sp_dspark_sample_from_anchor = true;
     std::string to_string() const;
 
     // Helper functions for enum conversion

--- a/rtp_llm/cpp/cuda_graph/BUILD
+++ b/rtp_llm/cpp/cuda_graph/BUILD
@@ -18,6 +18,12 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+cc_library(
+    name = "prepared_attention_inputs_guard",
+    hdrs = ["prepared_attention_inputs_guard.h"],
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "cuda_graph_srcs",
     srcs = [
@@ -36,6 +42,7 @@ filegroup(
         "cuda_graph_base.h",
         "combo_position_ids_validation.h",
         "cuda_graph_device_shims.h",
+        "prepared_attention_inputs_guard.h",
         "cuda_graph_utils.h",
         "cuda_graph_runner.h",
     ],
@@ -74,6 +81,7 @@ cc_library(
     deps = torch_deps() + [
         ":cuda_graph_base",
         ":combo_position_ids_validation",
+        ":prepared_attention_inputs_guard",
         ":cuda_graph_hdrs_lib",
         "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/cpp/utils:core_utils",

--- a/rtp_llm/cpp/cuda_graph/BUILD
+++ b/rtp_llm/cpp/cuda_graph/BUILD
@@ -97,6 +97,7 @@ cc_library(
             "//rtp_llm/models_py/bindings/cuda/kernels:cuda_graph_prepare",
         ],
         "@//:using_rocm": [
+            "//rtp_llm/models_py/bindings/cuda/kernels:cuda_graph_prepare",
             "@local_config_rocm//rocm:rocm_headers",
             "@local_config_rocm//rocm:rocm",
         ],

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_device_shims.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_device_shims.cc
@@ -23,10 +23,13 @@ inline void graphCheck(cudaError_t result, const char* call_expr) {
 }  // namespace
 
 #if USING_ROCM
-py::module_& getGraphCaptureModule() {
+py::module_ getGraphCaptureModule() {
     RTP_LLM_CHECK_WITH_INFO(PyGILState_Check(), "getGraphCaptureModule requires GIL to be held");
-    static py::module_ graph_capture_module = py::module_::import("rtp_llm.models_py.distributed.rocm_rccl");
-    return graph_capture_module;
+    // Do not retain a process-static py::module_. C++ static destruction runs
+    // after Py_Finalize in Python test binaries, where its DECREF would access
+    // already-finalized interpreter state. Python caches imports in sys.modules,
+    // so acquiring a scoped reference here does not reload the module.
+    return py::module_::import("rtp_llm.models_py.distributed.rocm_rccl");
 }
 #endif
 
@@ -35,7 +38,7 @@ void register_graph_capture_nccl_comm(void* nccl_comm, int world_size, int rank)
     py::gil_scoped_acquire gil;
     if (world_size <= 1) {
         try {
-            py::module_& graph_capture = getGraphCaptureModule();
+            py::module_ graph_capture = getGraphCaptureModule();
             graph_capture.attr("set_graph_capture_nccl_comm")(static_cast<uintptr_t>(0), 0, rank);
         } catch (const py::error_already_set& e) {
             RTP_LLM_LOG_WARNING("Failed to clear NCCL comm for graph capture: %s", e.what());
@@ -48,7 +51,7 @@ void register_graph_capture_nccl_comm(void* nccl_comm, int world_size, int rank)
         return;
     }
     try {
-        py::module_& graph_capture = getGraphCaptureModule();
+        py::module_ graph_capture = getGraphCaptureModule();
         graph_capture.attr("set_graph_capture_nccl_comm")(reinterpret_cast<uintptr_t>(nccl_comm), world_size, rank);
         RTP_LLM_LOG_INFO("Registered NCCL comm for graph capture (rank=%d, world_size=%d)", rank, world_size);
     } catch (const py::error_already_set& e) {
@@ -72,7 +75,7 @@ void enter_graph_capture(GraphNcclCaptureContext* ctx) {
     py::gil_scoped_acquire gil;
     rocm::setHipGraphCaptureEnabled(true);
     try {
-        py::module_& graph_capture = getGraphCaptureModule();
+        py::module_ graph_capture = getGraphCaptureModule();
         if (ctx && ctx->comm_handle != 0) {
             graph_capture.attr("enter_graph_capture_mode")(ctx->comm_handle, ctx->world_size, ctx->rank);
         } else {
@@ -82,7 +85,7 @@ void enter_graph_capture(GraphNcclCaptureContext* ctx) {
         rocm::setHipGraphCaptureEnabled(false);
         const int rank = ctx ? ctx->rank : -1;
         try {
-            py::module_& graph_capture = getGraphCaptureModule();
+            py::module_ graph_capture = getGraphCaptureModule();
             graph_capture.attr("set_graph_capture_nccl_comm")(static_cast<uintptr_t>(0), 0, rank);
         } catch (const py::error_already_set& clear_e) {
             RTP_LLM_LOG_WARNING("Failed to clear NCCL comm after enter_graph_capture failure: %s", clear_e.what());
@@ -104,7 +107,7 @@ void exit_graph_capture(GraphNcclCaptureContext* ctx) {
     // function, regardless of success or failure.
     py::gil_scoped_acquire gil;
     try {
-        py::module_& graph_capture = getGraphCaptureModule();
+        py::module_ graph_capture = getGraphCaptureModule();
         graph_capture.attr("exit_graph_capture_mode")();
     } catch (const py::error_already_set& e) {
         const unsigned long long comm_handle = ctx ? static_cast<unsigned long long>(ctx->comm_handle) : 0ULL;
@@ -116,7 +119,7 @@ void exit_graph_capture(GraphNcclCaptureContext* ctx) {
                             world_size,
                             e.what());
         try {
-            py::module_& graph_capture = getGraphCaptureModule();
+            py::module_ graph_capture = getGraphCaptureModule();
             graph_capture.attr("set_graph_capture_nccl_comm")(static_cast<uintptr_t>(0), 0, rank);
         } catch (const py::error_already_set& clear_e) {
             RTP_LLM_LOG_WARNING("Failed to clear NCCL comm after exit_graph_capture failure: %s", clear_e.what());
@@ -210,7 +213,7 @@ void finish_capture_session() {
 #if USING_ROCM
     py::gil_scoped_acquire gil;
     try {
-        py::module_& graph_capture = getGraphCaptureModule();
+        py::module_ graph_capture = getGraphCaptureModule();
         graph_capture.attr("finish_hipgraph_capture_session")();
     } catch (const py::error_already_set& e) {
         RTP_LLM_LOG_WARNING("Failed to finish capture session: %s", e.what());

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -13,7 +13,7 @@
 #include "rtp_llm/cpp/utils/TorchCudaOom.h"
 #include "torch/csrc/autograd/generated/variable_factories.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
-#if USING_CUDA
+#if USING_CUDA || USING_ROCM
 #include "rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.h"
 #endif
 using namespace torch_ext;
@@ -100,14 +100,15 @@ void callPrepareCudaGraph(py::object attn_pyobj, PyModelInputs& inputs) {
     }
 }
 
-#if USING_CUDA
+#if USING_CUDA || USING_ROCM
 void addCudaGraphPrepareFillRegion(
     CudaGraphPrepareFillParams& params, torch::Tensor& tensor, int64_t start, int64_t end, int32_t value) {
     if (!tensor.defined() || !tensor.is_cuda() || end <= start) {
         return;
     }
-    RTP_LLM_CHECK_WITH_INFO(tensor.scalar_type() == torch::kInt32, "cuda graph prepare fill expects int32 CUDA tensor");
-    RTP_LLM_CHECK_WITH_INFO(tensor.is_contiguous(), "cuda graph prepare fill expects contiguous tensor");
+    RTP_LLM_CHECK_WITH_INFO(tensor.scalar_type() == torch::kInt32,
+                            "cuda graph prepare fill expects int32 CUDA/HIP tensor");
+    RTP_LLM_CHECK_WITH_INFO(tensor.is_contiguous(), "cuda graph prepare fill expects contiguous CUDA/HIP tensor");
     RTP_LLM_CHECK_WITH_INFO(start >= 0 && end <= tensor.numel(),
                             "cuda graph prepare fill range [%ld, %ld) exceeds tensor numel %ld",
                             start,
@@ -138,7 +139,7 @@ void addCudaGraphPrepareFillRegionFromDevice(CudaGraphPrepareFillParams& params,
     RTP_LLM_CHECK_WITH_INFO(value_tensor.defined() && value_tensor.is_cuda()
                                 && value_tensor.scalar_type() == torch::kInt32 && value_index >= 0
                                 && value_index < value_tensor.numel(),
-                            "cuda graph prepare fill source must be a valid CUDA int32 element");
+                            "cuda graph prepare fill source must be a valid CUDA/HIP int32 element");
     auto& region        = params.regions[params.region_count - 1];
     region.value_ptr    = value_tensor.data_ptr<int32_t>() + value_index;
     region.value_offset = value_offset;
@@ -430,7 +431,7 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
     };
 
     // Clear stale device ranges in one launch before copying the live portions.
-#if USING_CUDA
+#if USING_CUDA || USING_ROCM
     {
         RTP_LLM_PROFILE_SCOPE("cuda_graph.prepareAttentionInputs(fused_fill)");
         CudaGraphPrepareFillParams fill_params;
@@ -773,7 +774,7 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
     };
 
     // Keep the host mirrors consistent with the device-side replay contract.
-    // CUDA device tails were already prepared by the single fused launch above.
+    // CUDA/HIP device tails were already prepared by the single fused launch above.
     if (has_padded_rows && is_target_verify_) {
         py_model_inputs_.attention_inputs.prefix_lengths.slice(0, state.current_batch_size, selected_graph_batch_size)
             .fill_(0);
@@ -784,7 +785,7 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
                                 selected_graph_batch_size,
                                 state.seq_len_sum,
                                 num_tokens_per_bs_);
-#if !USING_CUDA
+#if !USING_CUDA && !USING_ROCM
         py_model_inputs_.attention_inputs.prefix_lengths_device
             .slice(0, state.current_batch_size, selected_graph_batch_size)
             .fill_(0);
@@ -813,7 +814,7 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
         py_model_inputs_.attention_inputs.cu_seqlens
             .slice(0, state.current_batch_size + 1, selected_graph_batch_size + 1)
             .fill_(state.current_seq_len);
-#if !USING_CUDA
+#if !USING_CUDA && !USING_ROCM
         py_model_inputs_.attention_inputs.prefix_lengths_device
             .slice(0, state.current_batch_size, selected_graph_batch_size)
             .fill_(0);

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -1,5 +1,6 @@
 #include "rtp_llm/cpp/cuda_graph/cuda_graph_runner.h"
 #include "rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h"
+#include "rtp_llm/cpp/cuda_graph/prepared_attention_inputs_guard.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -126,7 +127,9 @@ void addCudaGraphPrepareFillRegionFromDevice(CudaGraphPrepareFillParams& params,
                                              int64_t                     start,
                                              int64_t                     end,
                                              const torch::Tensor&        value_tensor,
-                                             int64_t                     value_index) {
+                                             int64_t                     value_index,
+                                             int32_t                     value_offset = 0,
+                                             int32_t                     step         = 0) {
     const int32_t old_region_count = params.region_count;
     addCudaGraphPrepareFillRegion(params, tensor, start, end, 0);
     if (params.region_count == old_region_count) {
@@ -136,8 +139,25 @@ void addCudaGraphPrepareFillRegionFromDevice(CudaGraphPrepareFillParams& params,
                                 && value_tensor.scalar_type() == torch::kInt32 && value_index >= 0
                                 && value_index < value_tensor.numel(),
                             "cuda graph prepare fill source must be a valid CUDA int32 element");
-    params.regions[params.region_count - 1].value_ptr = value_tensor.data_ptr<int32_t>() + value_index;
+    auto& region        = params.regions[params.region_count - 1];
+    region.value_ptr    = value_tensor.data_ptr<int32_t>() + value_index;
+    region.value_offset = value_offset;
+    region.step         = step;
 }
+
+void addCudaGraphPrepareIotaRegion(CudaGraphPrepareFillParams& params,
+                                   torch::Tensor&              tensor,
+                                   int64_t                     start,
+                                   int64_t                     end,
+                                   int32_t                     first_value,
+                                   int32_t                     step) {
+    const int32_t old_region_count = params.region_count;
+    addCudaGraphPrepareFillRegion(params, tensor, start, end, first_value);
+    if (params.region_count != old_region_count) {
+        params.regions[params.region_count - 1].step = step;
+    }
+}
+
 #endif
 
 int inferTotalTokensNoSync(const PyModelInputs& inputs) {
@@ -145,6 +165,37 @@ int inferTotalTokensNoSync(const PyModelInputs& inputs) {
         return static_cast<int>(inputs.input_ids.size(0));
     }
     return inputs.attention_inputs.total_tokens > 0 ? inputs.attention_inputs.total_tokens : 0;
+}
+
+struct BlockTableCopyGeometry {
+    int64_t rows = 0;
+    int64_t cols = 0;
+};
+
+// Hybrid cache groups may expose a common staging row width even though a
+// selected graph stores a narrower model-local table.  The graph buffers are
+// cleared before every replay, so copying the intersection is both sufficient
+// and prevents a wider live staging table from overwriting adjacent storage.
+BlockTableCopyGeometry blockTableCopyGeometry(const torch::Tensor& src, const torch::Tensor& dst) {
+    RTP_LLM_CHECK_WITH_INFO(src.defined() && dst.defined(), "CUDA graph block-table copy requires defined tensors");
+    RTP_LLM_CHECK_WITH_INFO(src.scalar_type() == dst.scalar_type(),
+                            "CUDA graph block-table dtype mismatch: %s != %s",
+                            src.dtype().name(),
+                            dst.dtype().name());
+    if (src.dim() < 2) {
+        RTP_LLM_CHECK_WITH_INFO(
+            dst.dim() < 2, "CUDA graph block-table rank mismatch: src_dim=%ld dst_dim=%ld", src.dim(), dst.dim());
+        return {1, std::min<int64_t>(src.numel(), dst.numel())};
+    }
+    RTP_LLM_CHECK_WITH_INFO(src.dim() == 2 && dst.dim() == 2,
+                            "CUDA graph block tables must be 1-D or 2-D, got src_dim=%ld dst_dim=%ld",
+                            src.dim(),
+                            dst.dim());
+    RTP_LLM_CHECK_WITH_INFO(src.size(0) <= dst.size(0),
+                            "CUDA graph block-table batch exceeds selected graph: %ld > %ld",
+                            src.size(0),
+                            dst.size(0));
+    return {src.size(0), std::min<int64_t>(src.size(1), dst.size(1))};
 }
 
 }  // namespace
@@ -199,6 +250,10 @@ void CudaGraphRunner::prepareInputData(const PyModelInputs& inputs, CudaGraphSta
     auto& py_model_inputs = graph_instances_[graph_idx].mem_hold_.py_model_inputs_;
     const int token_num   = is_prefill_cuda_graph_mode_ ? state.current_seq_len : inputs.input_ids.size(0);
 
+    RTP_LLM_CHECK_WITH_INFO(token_num <= py_model_inputs.input_ids.numel(),
+                            "input_ids exceed selected CUDA graph capacity: %d > %ld",
+                            token_num,
+                            py_model_inputs.input_ids.numel());
     optimizedCopyAsync(inputs.input_ids, py_model_inputs.input_ids, token_num * sizeof(int));
 
     // check size and dtype. The copy below is a raw byte memcpy into the captured
@@ -235,6 +290,7 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
                                              CudaGraphState&      state,
                                              bool                 skip_forward_event_sync) {
     RTP_LLM_PROFILE_SCOPE("cuda_graph.prepareAttentionInputs");
+    PreparedAttentionInputsGuard prepared_guard(prepared_attention_inputs_);
     // 1. non spec cuda graph:
     // is_prefill_cuda_graph_mode_ is set true only when use embedding model
     // 2. spec cuda graph:
@@ -250,13 +306,27 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
         RTP_LLM_PROFILE_SCOPE("cuda_graph.prepareAttentionInputs(wait_forward_event)");
         forward_event_.synchronize();
     }
-    prepared_attention_inputs_.store(true, std::memory_order_release);
-
     const size_t graph_idx =
         is_prefill_cuda_graph_mode_ ? state.current_real_graph_seq_len : state.current_real_graph_bs;
     auto&      py_model_inputs_ = graph_instances_[graph_idx].mem_hold_.py_model_inputs_;
     auto       attn_pyobj       = graph_instances_[graph_idx].mem_hold_.attn_pyobj_;
     const bool has_tagged_cache = !inputs.attention_inputs_by_tag.empty();
+    const int  selected_graph_batch_size =
+        is_prefill_cuda_graph_mode_ ? static_cast<int>(max_bs_) : state.current_real_graph_bs;
+    const bool has_padded_rows = state.current_batch_size < selected_graph_batch_size;
+
+    // These values are ordinary host scalars, not captured tensor storage. A
+    // replay can keep the same graph shape while prefix reuse changes the total
+    // KV length, so refresh them for every cache group before replanning. Dummy
+    // graph rows are an implementation detail and must not contribute to the
+    // request-level totals.
+    py_model_inputs_.attention_inputs.context_total_kv_length = inputs.attention_inputs.context_total_kv_length;
+    py_model_inputs_.attention_inputs.total_tokens            = inputs.attention_inputs.total_tokens;
+    for (auto& [tag, tagged_inputs] : py_model_inputs_.attention_inputs_by_tag) {
+        (void)tag;
+        tagged_inputs.context_total_kv_length = inputs.attention_inputs.context_total_kv_length;
+        tagged_inputs.total_tokens            = inputs.attention_inputs.total_tokens;
+    }
 
     // Per-launch capacity contract: see fuse_copy_util.h sizing rationale.
     // Worst case here is ~8 contiguous + (1 + group_count) strided copies,
@@ -277,14 +347,18 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
     auto tryAddStridedD2DCopy = [&strided_d2d_copies, &d2d_copies](const torch::Tensor& src, torch::Tensor& dst) {
         if (!src.defined() || src.numel() <= 0)
             return;
+        const auto geometry = blockTableCopyGeometry(src, dst);
+        if (geometry.cols == 0) {
+            return;
+        }
         if (src.dim() < 2) {
-            d2d_copies.add(src.data_ptr(), dst.data_ptr(), src.numel() * src.element_size());
+            d2d_copies.add(src.data_ptr(), dst.data_ptr(), geometry.cols * src.element_size());
             return;
         }
         strided_d2d_copies.add(src.data_ptr(),
                                dst.data_ptr(),
-                               src.size(0),
-                               src.size(1) * src.element_size(),
+                               geometry.rows,
+                               geometry.cols * src.element_size(),
                                src.stride(0) * src.element_size(),
                                dst.stride(0) * dst.element_size());
     };
@@ -297,26 +371,55 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
     // async strided D2H copy that the pre-callPrepareCudaGraph synchronize below
     // waits for; host sources keep main's synchronous row-by-row memcpy.
     bool pending_host_mirror_d2h = false;
-    auto stridedCopyHost = [&pending_host_mirror_d2h](const torch::Tensor& src, torch::Tensor& dst) {
-        if (!src.defined() || src.numel() <= 0 || !dst.defined() || dst.is_cuda())
+    auto stridedCopyHost         = [&pending_host_mirror_d2h](const torch::Tensor& src, torch::Tensor& dst) {
+        if (!dst.defined() || dst.is_cuda()) {
             return;
+        }
+        if (!src.defined() || src.numel() <= 0) {
+            dst.zero_();
+            return;
+        }
+        const auto geometry = blockTableCopyGeometry(src, dst);
+        // The graph instance is reused across batch sizes. Clear exactly the
+        // part not overwritten by this replay so a request that left the batch
+        // cannot survive in the host-pinned page table consumed by the next
+        // FlashInfer/TRT-LLM plan. Device tables have the same contract above.
+        if (dst.dim() < 2) {
+            if (geometry.cols < dst.numel()) {
+                dst.view({-1}).narrow(0, geometry.cols, dst.numel() - geometry.cols).zero_();
+            }
+        } else {
+            if (geometry.cols < dst.size(1)) {
+                dst.narrow(1, geometry.cols, dst.size(1) - geometry.cols).zero_();
+            }
+            if (geometry.rows < dst.size(0)) {
+                dst.narrow(0, geometry.rows, dst.size(0) - geometry.rows).zero_();
+            }
+        }
+        if (geometry.cols == 0) {
+            return;
+        }
         if (src.is_cuda()) {
             RTP_LLM_PROFILE_SCOPE("stridedCopyHost(D2H)");
             if (src.dim() < 2) {
-                dst.view({-1}).narrow(0, 0, src.numel()).copy_(src, /*non_blocking=*/true);
+                dst.view({-1})
+                    .narrow(0, 0, geometry.cols)
+                    .copy_(src.view({-1}).narrow(0, 0, geometry.cols), /*non_blocking=*/true);
             } else {
-                dst.narrow(0, 0, src.size(0)).narrow(1, 0, src.size(1)).copy_(src, /*non_blocking=*/true);
+                dst.narrow(0, 0, geometry.rows)
+                    .narrow(1, 0, geometry.cols)
+                    .copy_(src.narrow(0, 0, geometry.rows).narrow(1, 0, geometry.cols), /*non_blocking=*/true);
             }
             pending_host_mirror_d2h = true;
             return;
         }
         RTP_LLM_PROFILE_SCOPE("stridedCopyHost");
         if (src.dim() < 2) {
-            memcpy(dst.data_ptr(), src.data_ptr(), src.numel() * src.element_size());
+            memcpy(dst.data_ptr(), src.data_ptr(), geometry.cols * src.element_size());
             return;
         }
-        const size_t nrows      = src.size(0);
-        const size_t row_bytes  = src.size(1) * src.element_size();
+        const size_t nrows      = geometry.rows;
+        const size_t row_bytes  = geometry.cols * src.element_size();
         const size_t src_stride = src.stride(0) * src.element_size();
         const size_t dst_stride = dst.stride(0) * dst.element_size();
         const char*  src_ptr    = reinterpret_cast<const char*>(src.data_ptr());
@@ -325,9 +428,6 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
             memcpy(dst_ptr + r * dst_stride, src_ptr + r * src_stride, row_bytes);
         }
     };
-
-    const int selected_graph_batch_size =
-        is_prefill_cuda_graph_mode_ ? static_cast<int>(max_bs_) : state.current_real_graph_bs;
 
     // Clear stale device ranges in one launch before copying the live portions.
 #if USING_CUDA
@@ -350,7 +450,44 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
                                               0);
             }
         }
-        if (is_prefill_cuda_graph_mode_) {
+        if (is_target_verify_ && has_padded_rows) {
+            // Multi-token graphs capture a fixed number of Q/K/V rows per
+            // batch. Their replay metadata must describe the same geometry:
+            // KVCacheWriteOp consumes the static K/V tensor size and cannot
+            // represent a zero-token tail. Execute rounded rows as deterministic
+            // dummy requests against reserved cache block 0; their outputs are
+            // discarded. This keeps attention, KV write and recurrent-state
+            // kernels on one coherent contract after a batch shrinks.
+            addCudaGraphPrepareFillRegion(fill_params,
+                                          py_model_inputs_.attention_inputs.prefix_lengths_device,
+                                          state.current_batch_size,
+                                          selected_graph_batch_size,
+                                          0);
+            addCudaGraphPrepareFillRegion(fill_params,
+                                          py_model_inputs_.attention_inputs.input_lengths_device,
+                                          state.current_batch_size,
+                                          selected_graph_batch_size,
+                                          num_tokens_per_bs_);
+            addCudaGraphPrepareIotaRegion(fill_params,
+                                          py_model_inputs_.attention_inputs.cu_seqlens_device,
+                                          state.current_batch_size + 1,
+                                          selected_graph_batch_size + 1,
+                                          state.seq_len_sum + num_tokens_per_bs_,
+                                          num_tokens_per_bs_);
+            addCudaGraphPrepareFillRegionFromDevice(fill_params,
+                                                    py_model_inputs_.attention_inputs.cu_kv_seqlens_device,
+                                                    state.current_batch_size + 1,
+                                                    selected_graph_batch_size + 1,
+                                                    inputs.attention_inputs.cu_kv_seqlens_device,
+                                                    state.current_batch_size,
+                                                    num_tokens_per_bs_,
+                                                    num_tokens_per_bs_);
+            addCudaGraphPrepareFillRegion(fill_params,
+                                          py_model_inputs_.attention_inputs.sequence_lengths_plus_1_device,
+                                          state.current_batch_size,
+                                          selected_graph_batch_size,
+                                          num_tokens_per_bs_);
+        } else if (is_prefill_cuda_graph_mode_) {
             addCudaGraphPrepareFillRegion(fill_params,
                                           py_model_inputs_.attention_inputs.prefix_lengths_device,
                                           state.current_batch_size,
@@ -372,10 +509,40 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
                                                     max_bs_ + 1,
                                                     inputs.attention_inputs.cu_kv_seqlens_device,
                                                     state.current_batch_size);
+        } else if (has_padded_rows) {
+            // Plain decode also captures one query per graph row. Point its
+            // rounded rows at position 0 of reserved block 0.
+            addCudaGraphPrepareFillRegion(fill_params,
+                                          py_model_inputs_.attention_inputs.sequence_lengths_plus_1_device,
+                                          state.current_batch_size,
+                                          selected_graph_batch_size,
+                                          1);
         }
-        // Target-verify padding (input_lengths / prefix_lengths / cu_*) is cleared by
-        // the shared tail block below, which covers both the host mirrors and the
-        // device buffers in one place.
+        if (position_id_len_factor_ > 0) {
+            const int64_t live_position_numel =
+                static_cast<int64_t>(is_prefill_cuda_graph_mode_ ? state.current_seq_len : state.seq_len_sum)
+                * position_id_len_factor_;
+            addCudaGraphPrepareFillRegion(fill_params,
+                                          py_model_inputs_.combo_position_ids,
+                                          live_position_numel,
+                                          py_model_inputs_.combo_position_ids.numel(),
+                                          0);
+        }
+        // Static graph inputs outlive the requests occupying their rows. Clear
+        // every uncovered token row before replay: attention masks make the
+        // row logically empty, while dense/recurrent layers still execute over
+        // the captured shape and must not observe a departed request's hidden
+        // state. input_ids share the fused metadata fill below; hidden states
+        // use PyTorch's native async memset for their actual dtype.
+        const int64_t live_input_tokens = is_prefill_cuda_graph_mode_ ? state.current_seq_len : state.seq_len_sum;
+        addCudaGraphPrepareFillRegion(
+            fill_params, py_model_inputs_.input_ids, live_input_tokens, py_model_inputs_.input_ids.numel(), 0);
+        if (py_model_inputs_.input_hiddens.defined() && py_model_inputs_.input_hiddens.dim() > 0
+            && live_input_tokens < py_model_inputs_.input_hiddens.size(0)) {
+            py_model_inputs_.input_hiddens
+                .narrow(0, live_input_tokens, py_model_inputs_.input_hiddens.size(0) - live_input_tokens)
+                .zero_();
+        }
         invokeCudaGraphPrepareFill(fill_params, cuda_graph::graphGetCurrentStream().stream());
     }
 #else
@@ -590,37 +757,76 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
         }
     }
 
-    // Prefill attention consumes cumulative Q/KV lengths. Target verify uses the
-    // same attention path even though it is replayed by the decode graph runner;
-    // it is covered by num_tokens_per_bs_ > 1 (a verify step always scores
-    // gen_num_per_cycle + 1 tokens per request), which is also the condition under
-    // which initCaptureAttentionInputs allocated prefix_lengths{,_device} at all.
-    // Clear graph padding so rounded-up batch slots do not retain capture-time
-    // max sequence lengths and trigger unnecessary attention work.
-    if ((is_prefill_cuda_graph_mode_ || num_tokens_per_bs_ > 1)
-        && state.current_batch_size < selected_graph_batch_size) {
+    auto fillCumulativeDummyRows = [](torch::Tensor& tensor,
+                                      int            live_batch_size,
+                                      int            graph_batch_size,
+                                      int32_t        live_total,
+                                      int32_t        tokens_per_row) {
+        if (!tensor.defined() || tensor.numel() < graph_batch_size + 1 || tensor.is_cuda()
+            || tensor.scalar_type() != torch::kInt32) {
+            return;
+        }
+        auto* values = tensor.data_ptr<int32_t>();
+        for (int row = live_batch_size + 1; row <= graph_batch_size; ++row) {
+            values[row] = live_total + (row - live_batch_size) * tokens_per_row;
+        }
+    };
+
+    // Keep the host mirrors consistent with the device-side replay contract.
+    // CUDA device tails were already prepared by the single fused launch above.
+    if (has_padded_rows && is_target_verify_) {
+        py_model_inputs_.attention_inputs.prefix_lengths.slice(0, state.current_batch_size, selected_graph_batch_size)
+            .fill_(0);
+        py_model_inputs_.attention_inputs.input_lengths.slice(0, state.current_batch_size, selected_graph_batch_size)
+            .fill_(num_tokens_per_bs_);
+        fillCumulativeDummyRows(py_model_inputs_.attention_inputs.cu_seqlens,
+                                state.current_batch_size,
+                                selected_graph_batch_size,
+                                state.seq_len_sum,
+                                num_tokens_per_bs_);
+#if !USING_CUDA
+        py_model_inputs_.attention_inputs.prefix_lengths_device
+            .slice(0, state.current_batch_size, selected_graph_batch_size)
+            .fill_(0);
+        py_model_inputs_.attention_inputs.input_lengths_device
+            .slice(0, state.current_batch_size, selected_graph_batch_size)
+            .fill_(num_tokens_per_bs_);
+        fillCumulativeDummyRows(py_model_inputs_.attention_inputs.cu_seqlens_device,
+                                state.current_batch_size,
+                                selected_graph_batch_size,
+                                state.seq_len_sum,
+                                num_tokens_per_bs_);
+        fillCumulativeDummyRows(py_model_inputs_.attention_inputs.cu_kv_seqlens_device,
+                                state.current_batch_size,
+                                selected_graph_batch_size,
+                                inputs.attention_inputs.context_total_kv_length,
+                                num_tokens_per_bs_);
+        py_model_inputs_.attention_inputs.sequence_lengths_plus_1_device
+            .slice(0, state.current_batch_size, selected_graph_batch_size)
+            .fill_(num_tokens_per_bs_);
+#endif
+    } else if (has_padded_rows && is_prefill_cuda_graph_mode_) {
         py_model_inputs_.attention_inputs.prefix_lengths.slice(0, state.current_batch_size, selected_graph_batch_size)
             .fill_(0);
         py_model_inputs_.attention_inputs.input_lengths.slice(0, state.current_batch_size, selected_graph_batch_size)
             .fill_(0);
+        py_model_inputs_.attention_inputs.cu_seqlens
+            .slice(0, state.current_batch_size + 1, selected_graph_batch_size + 1)
+            .fill_(state.current_seq_len);
+#if !USING_CUDA
         py_model_inputs_.attention_inputs.prefix_lengths_device
             .slice(0, state.current_batch_size, selected_graph_batch_size)
             .fill_(0);
         py_model_inputs_.attention_inputs.input_lengths_device
             .slice(0, state.current_batch_size, selected_graph_batch_size)
             .fill_(0);
-
-        const int last_valid_q  = is_prefill_cuda_graph_mode_ ? state.current_seq_len : state.seq_len_sum;
-        const int last_valid_kv = inputs.attention_inputs.context_total_kv_length;
-        py_model_inputs_.attention_inputs.cu_seqlens
-            .slice(0, state.current_batch_size + 1, selected_graph_batch_size + 1)
-            .fill_(last_valid_q);
         py_model_inputs_.attention_inputs.cu_seqlens_device
             .slice(0, state.current_batch_size + 1, selected_graph_batch_size + 1)
-            .fill_(last_valid_q);
+            .fill_(state.current_seq_len);
         py_model_inputs_.attention_inputs.cu_kv_seqlens_device
             .slice(0, state.current_batch_size + 1, selected_graph_batch_size + 1)
-            .fill_(last_valid_kv);
+            .fill_(inputs.attention_inputs.context_total_kv_length);
+#endif
     }
 
     // launch prepare_cuda_graph when attention inputs are ready.
@@ -640,6 +846,7 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
         py::gil_scoped_acquire gil;
         callPrepareCudaGraph(attn_pyobj, py_model_inputs_);
     }
+    prepared_guard.commit();
 }
 
 void CudaGraphRunner::updateKVCacheKernelBlockId(const PyModelInputs& inputs, CudaGraphState& state) {
@@ -654,14 +861,18 @@ void CudaGraphRunner::updateKVCacheKernelBlockId(const PyModelInputs& inputs, Cu
         if (!src.defined() || src.numel() == 0) {
             return;
         }
+        const auto geometry = blockTableCopyGeometry(src, dst);
+        if (geometry.cols == 0) {
+            return;
+        }
         if (src.dim() < 2) {
-            d2d_copies.add(src.data_ptr(), dst.data_ptr(), src.numel() * src.element_size());
+            d2d_copies.add(src.data_ptr(), dst.data_ptr(), geometry.cols * src.element_size());
             return;
         }
         strided_d2d_copies.add(src.data_ptr(),
                                dst.data_ptr(),
-                               src.size(0),
-                               src.size(1) * src.element_size(),
+                               geometry.rows,
+                               geometry.cols * src.element_size(),
                                src.stride(0) * src.element_size(),
                                dst.stride(0) * dst.element_size());
     };
@@ -711,6 +922,11 @@ PyModelOutputs CudaGraphRunner::forward(const PyModelInputs& inputs, CudaGraphSt
         outputs.hidden_states =
             graph_instances_[state.current_real_graph_seq_len].mem_hold_.decoder_layer_hidden_states_.slice(
                 0, 0, state.current_seq_len);
+        const auto& mtp_target_hidden_states =
+            graph_instances_[state.current_real_graph_seq_len].mem_hold_.mtp_target_hidden_states_;
+        if (mtp_target_hidden_states.defined()) {
+            outputs.mtp_target_hidden_states = mtp_target_hidden_states.slice(0, 0, state.current_seq_len);
+        }
     } else {
         {
             RTP_LLM_PROFILE_SCOPE("cuda_graph.forward(replayDecode)");
@@ -719,6 +935,11 @@ PyModelOutputs CudaGraphRunner::forward(const PyModelInputs& inputs, CudaGraphSt
         outputs.hidden_states =
             graph_instances_[state.current_real_graph_bs].mem_hold_.decoder_layer_hidden_states_.slice(
                 0, 0, state.seq_len_sum);
+        const auto& mtp_target_hidden_states =
+            graph_instances_[state.current_real_graph_bs].mem_hold_.mtp_target_hidden_states_;
+        if (mtp_target_hidden_states.defined()) {
+            outputs.mtp_target_hidden_states = mtp_target_hidden_states.slice(0, 0, state.seq_len_sum);
+        }
     }
     // record forward done event
     forward_event_.record(cuda_graph::graphGetCurrentStream());
@@ -1104,6 +1325,7 @@ void CudaGraphRunner::initCapture() {
 
         // get real output data type (params already prepared in attn impl __init__/create_params)
         py::object attn_pyobj;
+        PyModelOutputs initial_outputs;
         try {
             attn_pyobj = py_attn_pyobj_method_(capture_mem_hold_.py_model_inputs_, true);
         } catch (const py::error_already_set& e) {
@@ -1116,7 +1338,7 @@ void CudaGraphRunner::initCapture() {
             // eager warmup forward. The flag is scoped so real graph capture
             // and replay never contain that synchronization.
             ScopedEnvFlag cuda_graph_warmup("RTP_LLM_CUDA_GRAPH_WARMUP_FORWARD", "1");
-            py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj);
+            initial_outputs = py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj).cast<PyModelOutputs>();
         } catch (const py::error_already_set& e) {
             RTP_LLM_LOG_ERROR("initCapture forward for output datatype failed with Python exception: %s", e.what());
             throw;
@@ -1127,6 +1349,16 @@ void CudaGraphRunner::initCapture() {
         RTP_LLM_LOG_INFO("initCapture forward for output datatype end");
         output = torch::zeros({max_num_token_, hidden_size_}, options_cuda_float_);
         capture_mem_hold_.setHiddenStates(output);
+        if (initial_outputs.mtp_target_hidden_states.defined()) {
+            RTP_LLM_CHECK_WITH_INFO(initial_outputs.mtp_target_hidden_states.dim() == 2,
+                                    "MTP target hidden output must be rank 2, got %ld",
+                                    initial_outputs.mtp_target_hidden_states.dim());
+            RTP_LLM_CHECK_WITH_INFO(initial_outputs.mtp_target_hidden_states.size(0) == max_num_token_,
+                                    "MTP target hidden output rows mismatch graph capacity: %ld != %d",
+                                    initial_outputs.mtp_target_hidden_states.size(0),
+                                    max_num_token_);
+            capture_mem_hold_.setMtpTargetHiddenStates(torch::zeros_like(initial_outputs.mtp_target_hidden_states));
+        }
         initCaptureAttentionInputsPost();
         logCudaGraphPoolMemory("before_capture");
 
@@ -1223,6 +1455,14 @@ void CudaGraphRunner::captureOneGraphInstance(int key, const char* key_type) {
                 throw;
             }
             graph_instances_[key].mem_hold_.decoder_layer_hidden_states_.copy_(outputs.hidden_states);
+            auto& mtp_target_hidden_states = graph_instances_[key].mem_hold_.mtp_target_hidden_states_;
+            RTP_LLM_CHECK_WITH_INFO(mtp_target_hidden_states.defined() == outputs.mtp_target_hidden_states.defined(),
+                                    "MTP target hidden output presence changed during CUDA graph capture");
+            if (mtp_target_hidden_states.defined()) {
+                RTP_LLM_CHECK_WITH_INFO(mtp_target_hidden_states.sizes() == outputs.mtp_target_hidden_states.sizes(),
+                                        "MTP target hidden output shape changed during CUDA graph capture");
+                mtp_target_hidden_states.copy_(outputs.mtp_target_hidden_states);
+            }
             graph.capture_end();
         }
 
@@ -1339,9 +1579,13 @@ void CudaGraphRunner::prepareCaptureInputs(PyModelInputs& inputs, int batch_size
 
 CaptureMemoryHold CudaGraphRunner::createCaptureMemoryHold(PyModelInputs& inputs, int tokens_count) {
     // only when prefill or target model score phase, the num_tokens_per_bs_ > 1
-    return CaptureMemoryHold(capture_mem_hold_.decoder_layer_hidden_states_.slice(0, 0, tokens_count),
-                             inputs,
-                             is_prefill_cuda_graph_mode_ || num_tokens_per_bs_ > 1);
+    CaptureMemoryHold hold(capture_mem_hold_.decoder_layer_hidden_states_.slice(0, 0, tokens_count),
+                           inputs,
+                           is_prefill_cuda_graph_mode_ || num_tokens_per_bs_ > 1);
+    if (capture_mem_hold_.mtp_target_hidden_states_.defined()) {
+        hold.setMtpTargetHiddenStates(capture_mem_hold_.mtp_target_hidden_states_.slice(0, 0, tokens_count));
+    }
+    return hold;
 }
 
 CudaGraphRunner* CudaGraphRunner::createForPrefill(py::object py_instance, GraphParams params) {

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_utils.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_utils.h
@@ -24,6 +24,10 @@ public:
         decoder_layer_hidden_states_ = hidden_states;
     };
 
+    void setMtpTargetHiddenStates(at::Tensor hidden_states) {
+        mtp_target_hidden_states_ = hidden_states;
+    };
+
     CaptureMemoryHold() {}
 
     CaptureMemoryHold(at::Tensor hidden_states, torch_ext::PyModelInputs& inputs, bool is_embedding):
@@ -67,6 +71,7 @@ public:
 public:
     py::object               attn_pyobj_{py::none()};
     at::Tensor               decoder_layer_hidden_states_;
+    at::Tensor               mtp_target_hidden_states_;
     torch_ext::PyModelInputs py_model_inputs_;
 };
 

--- a/rtp_llm/cpp/cuda_graph/prepared_attention_inputs_guard.h
+++ b/rtp_llm/cpp/cuda_graph/prepared_attention_inputs_guard.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <atomic>
+
+namespace rtp_llm {
+
+// Treat attention-input preparation as a transaction. A new attempt first
+// invalidates any previously published state; only a fully successful attempt
+// may publish readiness for the following forward.
+class PreparedAttentionInputsGuard {
+public:
+    explicit PreparedAttentionInputsGuard(std::atomic<bool>& prepared): prepared_(prepared) {
+        prepared_.store(false, std::memory_order_release);
+    }
+
+    PreparedAttentionInputsGuard(const PreparedAttentionInputsGuard&)            = delete;
+    PreparedAttentionInputsGuard& operator=(const PreparedAttentionInputsGuard&) = delete;
+
+    ~PreparedAttentionInputsGuard() {
+        if (!committed_) {
+            prepared_.store(false, std::memory_order_release);
+        }
+    }
+
+    void commit() noexcept {
+        prepared_.store(true, std::memory_order_release);
+        committed_ = true;
+    }
+
+private:
+    std::atomic<bool>& prepared_;
+    bool               committed_{false};
+};
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cuda_graph/tests/BUILD
+++ b/rtp_llm/cpp/cuda_graph/tests/BUILD
@@ -31,6 +31,16 @@ cc_test(
     exec_properties = {'gpu':'A10'},
 )
 
+cc_test(
+    name = "prepared_attention_inputs_guard_test",
+    srcs = ["prepared_attention_inputs_guard_test.cc"],
+    copts = copts(),
+    deps = [
+        "//rtp_llm/cpp/cuda_graph:prepared_attention_inputs_guard",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "test_cuda_graph_runner_libs",
     srcs = [

--- a/rtp_llm/cpp/cuda_graph/tests/BUILD
+++ b/rtp_llm/cpp/cuda_graph/tests/BUILD
@@ -41,6 +41,24 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "cuda_graph_prepare_fill_rocm_test",
+    srcs = ["cuda_graph_prepare_fill_test.cc"],
+    copts = copts(),
+    deps = [
+        "//rtp_llm/models_py/bindings/cuda/kernels:cuda_graph_prepare",
+        "@local_config_rocm//rocm:hip",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@com_google_googletest//:gtest_main",
+    ],
+    tags = ["rocm"],
+    target_compatible_with = select({
+        "@//:using_rocm": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    exec_properties = {"gpu": "MI308X-ROCM7"},
+)
+
 cc_library(
     name = "test_cuda_graph_runner_libs",
     srcs = [

--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_prepare_fill_test.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_prepare_fill_test.cc
@@ -1,0 +1,145 @@
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <vector>
+
+#if !USING_ROCM
+#error "cuda_graph_prepare_fill_rocm_test must be built with --config=rocm"
+#endif
+
+#include "rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.h"
+
+namespace rtp_llm {
+namespace {
+
+TEST(CudaGraphPrepareFillTest, FillsLiteralAndDeviceBasedIotaRegions) {
+    std::vector<int32_t> initial(10, -1);
+    int32_t              source_value = 100;
+    int32_t*             output       = nullptr;
+    int32_t*             source       = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&output, initial.size() * sizeof(int32_t)));
+    ASSERT_EQ(hipSuccess, hipMalloc(&source, sizeof(int32_t)));
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(output, initial.data(), initial.size() * sizeof(int32_t), hipMemcpyHostToDevice));
+    ASSERT_EQ(hipSuccess, hipMemcpy(source, &source_value, sizeof(int32_t), hipMemcpyHostToDevice));
+
+    CudaGraphPrepareFillParams params;
+    auto&                      literal = params.regions[params.region_count++];
+    literal.ptr                        = output + 2;
+    literal.count                      = 4;
+    literal.value                      = 10;
+    literal.step                       = 3;
+
+    auto& from_device        = params.regions[params.region_count++];
+    from_device.ptr          = output + 6;
+    from_device.value_ptr    = source;
+    from_device.count        = 3;
+    from_device.value_offset = 5;
+    from_device.step         = 2;
+
+    invokeCudaGraphPrepareFill(params, nullptr);
+
+    std::vector<int32_t> actual(initial.size());
+    ASSERT_EQ(hipSuccess, hipDeviceSynchronize());
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(actual.data(), output, actual.size() * sizeof(int32_t), hipMemcpyDeviceToHost));
+    EXPECT_EQ(actual, (std::vector<int32_t>{-1, -1, 10, 13, 16, 19, 105, 107, 109, -1}));
+
+    EXPECT_EQ(hipSuccess, hipFree(source));
+    EXPECT_EQ(hipSuccess, hipFree(output));
+}
+
+TEST(CudaGraphPrepareFillTest, ClearsGraphEightTargetVerifyTailForSixLiveRequests) {
+    constexpr int32_t graph_batch = 8;
+    constexpr int32_t live_batch  = 6;
+    constexpr int32_t query_len   = 8;
+    constexpr int32_t mrope_dims  = 3;
+
+    std::vector<int32_t> prefix(graph_batch, 17);
+    std::vector<int32_t> lengths(graph_batch, query_len);
+    std::vector<int32_t> cu_query(graph_batch + 1);
+    std::vector<int32_t> cu_kv(graph_batch + 1);
+    std::vector<int32_t> sequence_lengths(graph_batch, 18);
+    std::vector<int32_t> input_ids(graph_batch * query_len, 91);
+    std::vector<int32_t> position_ids(graph_batch * query_len * mrope_dims, 73);
+    for (int32_t row = 0; row <= graph_batch; ++row) {
+        cu_query[row] = row * query_len;
+        cu_kv[row]    = row * (17 + query_len);
+    }
+
+    auto allocate_and_copy = [](const std::vector<int32_t>& host) {
+        int32_t* device = nullptr;
+        EXPECT_EQ(hipSuccess, hipMalloc(&device, host.size() * sizeof(int32_t)));
+        EXPECT_EQ(hipSuccess,
+                  hipMemcpy(device, host.data(), host.size() * sizeof(int32_t), hipMemcpyHostToDevice));
+        return device;
+    };
+    auto copy_back = [](std::vector<int32_t>& host, int32_t* device) {
+        EXPECT_EQ(hipSuccess,
+                  hipMemcpy(host.data(), device, host.size() * sizeof(int32_t), hipMemcpyDeviceToHost));
+    };
+
+    int32_t* prefix_device           = allocate_and_copy(prefix);
+    int32_t* lengths_device          = allocate_and_copy(lengths);
+    int32_t* cu_query_device         = allocate_and_copy(cu_query);
+    int32_t* cu_kv_device            = allocate_and_copy(cu_kv);
+    int32_t* sequence_lengths_device = allocate_and_copy(sequence_lengths);
+    int32_t* input_ids_device        = allocate_and_copy(input_ids);
+    int32_t* position_ids_device     = allocate_and_copy(position_ids);
+
+    CudaGraphPrepareFillParams params;
+    auto add_region = [&params](int32_t* ptr, int64_t count, int32_t value, int32_t step = 0) {
+        auto& region = params.regions[params.region_count++];
+        region.ptr   = ptr;
+        region.count = count;
+        region.value = value;
+        region.step  = step;
+    };
+    add_region(prefix_device + live_batch, graph_batch - live_batch, 0);
+    add_region(lengths_device + live_batch, graph_batch - live_batch, query_len);
+    add_region(cu_query_device + live_batch + 1,
+               graph_batch - live_batch,
+               (live_batch + 1) * query_len,
+               query_len);
+    add_region(cu_kv_device + live_batch + 1, graph_batch - live_batch, 0, query_len);
+    params.regions[params.region_count - 1].value_ptr    = cu_kv_device + live_batch;
+    params.regions[params.region_count - 1].value_offset = query_len;
+    add_region(sequence_lengths_device + live_batch, graph_batch - live_batch, query_len);
+    add_region(input_ids_device + live_batch * query_len, (graph_batch - live_batch) * query_len, 0);
+    add_region(position_ids_device + live_batch * query_len * mrope_dims,
+               (graph_batch - live_batch) * query_len * mrope_dims,
+               0);
+
+    invokeCudaGraphPrepareFill(params, nullptr);
+    ASSERT_EQ(hipSuccess, hipDeviceSynchronize());
+    copy_back(prefix, prefix_device);
+    copy_back(lengths, lengths_device);
+    copy_back(cu_query, cu_query_device);
+    copy_back(cu_kv, cu_kv_device);
+    copy_back(sequence_lengths, sequence_lengths_device);
+    copy_back(input_ids, input_ids_device);
+    copy_back(position_ids, position_ids_device);
+
+    EXPECT_EQ(prefix, (std::vector<int32_t>{17, 17, 17, 17, 17, 17, 0, 0}));
+    EXPECT_EQ(lengths, (std::vector<int32_t>{8, 8, 8, 8, 8, 8, 8, 8}));
+    EXPECT_EQ(cu_query, (std::vector<int32_t>{0, 8, 16, 24, 32, 40, 48, 56, 64}));
+    EXPECT_EQ(cu_kv, (std::vector<int32_t>{0, 25, 50, 75, 100, 125, 150, 158, 166}));
+    EXPECT_EQ(sequence_lengths, (std::vector<int32_t>{18, 18, 18, 18, 18, 18, 8, 8}));
+    EXPECT_TRUE(std::all_of(input_ids.begin() + live_batch * query_len, input_ids.end(), [](int32_t value) {
+        return value == 0;
+    }));
+    EXPECT_TRUE(std::all_of(position_ids.begin() + live_batch * query_len * mrope_dims,
+                            position_ids.end(),
+                            [](int32_t value) { return value == 0; }));
+
+    EXPECT_EQ(hipSuccess, hipFree(position_ids_device));
+    EXPECT_EQ(hipSuccess, hipFree(input_ids_device));
+    EXPECT_EQ(hipSuccess, hipFree(sequence_lengths_device));
+    EXPECT_EQ(hipSuccess, hipFree(cu_kv_device));
+    EXPECT_EQ(hipSuccess, hipFree(cu_query_device));
+    EXPECT_EQ(hipSuccess, hipFree(lengths_device));
+    EXPECT_EQ(hipSuccess, hipFree(prefix_device));
+}
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_tagged_cache_test.py
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_tagged_cache_test.py
@@ -79,6 +79,25 @@ class StaticInputTailModel:
         return PyModelOutputs(inputs.input_hiddens + tail_signature)
 
 
+class StaticTokenMetadataTailModel:
+    """Expose stale token, MRoPE-position and hidden rows after graph shrink."""
+
+    def prepare_fmha_impl(self, inputs: PyModelInputs, is_cuda_graph: bool = False):
+        return None
+
+    def forward(self, inputs: PyModelInputs, fmha_impl=None) -> PyModelOutputs:
+        tail_signature = torch.stack(
+            (
+                inputs.input_ids[-1]
+                + inputs.input_hiddens[-1].sum().to(torch.int32),
+                inputs.combo_position_ids[-3],
+                inputs.combo_position_ids[-2],
+                inputs.combo_position_ids[-1],
+            )
+        ).to(inputs.input_hiddens.dtype)
+        return PyModelOutputs(inputs.input_hiddens + tail_signature)
+
+
 class AuxiliaryOutputModel:
     """Return a second output whose view must follow the selected graph bucket."""
 
@@ -455,53 +474,116 @@ class TestCudaGraphTaggedCache(unittest.TestCase):
         self.assertFalse(runner.canRun(non_prefill))
 
     def test_target_verify_uses_reserved_block_dummy_rows(self) -> None:
-        query_len = 5
-        prefix_len = 11
+        scenarios = (
+            (4, 5, 11, (4, 3, 2, 1, 4)),
+            # Production shape: DSpark proposes 7+1 tokens and a live batch of
+            # six replays the graph-eight bucket on MI308X.
+            (8, 8, 17, (8, 6, 2, 8)),
+        )
+        for graph_size, query_len, prefix_len, batch_sizes in scenarios:
+            runner = CudaGraphRunner()
+            runner.init_decode(
+                TaggedSequenceLengthModel(),
+                HIDDEN_SIZE,
+                64,
+                TOKENS_PER_BLOCK,
+                TOKENS_PER_BLOCK,
+                [graph_size],
+                GROUP_TAGS,
+                True,
+                query_len,
+            )
+
+            # Exercise both growth and shrink on the same graph instance. The
+            # production failure appeared only after a full bucket lost a request.
+            for batch_size in batch_sizes:
+                with self.subTest(graph_size=graph_size, batch_size=batch_size):
+                    inputs = _build_target_verify_inputs(
+                        GROUP_TAGS,
+                        {"full": 2, "aux": 1},
+                        batch_size=batch_size,
+                        query_len=query_len,
+                        prefix_len=prefix_len,
+                    )
+                    self.assertTrue(runner.canRun(inputs))
+                    self.assertEqual(runner.getCurrentRealGraphSize(), graph_size)
+
+                    output = runner.forward(inputs)
+                    torch.cuda.synchronize()
+                    total_kv_length = batch_size * (query_len + prefix_len)
+                    expected_signature = torch.tensor(
+                        [
+                            graph_size * query_len,
+                            total_kv_length
+                            + (graph_size - batch_size) * query_len,
+                            graph_size * query_len,
+                            prefix_len + 1
+                            if batch_size == graph_size
+                            else query_len,
+                        ],
+                        dtype=output.hidden_states.dtype,
+                        device=output.hidden_states.device,
+                    )
+                    torch.testing.assert_close(
+                        output.hidden_states,
+                        expected_signature.unsqueeze(0).expand_as(
+                            output.hidden_states
+                        ),
+                    )
+
+    def test_target_verify_clears_static_token_metadata_after_shrink(self) -> None:
+        query_len = 8
         runner = CudaGraphRunner()
         runner.init_decode(
-            TaggedSequenceLengthModel(),
+            StaticTokenMetadataTailModel(),
             HIDDEN_SIZE,
             64,
             TOKENS_PER_BLOCK,
             TOKENS_PER_BLOCK,
-            [4],
+            [8],
             GROUP_TAGS,
             True,
             query_len,
+            3,
         )
 
-        # Exercise both growth and shrink on the same graph instance. The
-        # production failure appeared only after a full bucket lost a request.
-        for batch_size in (4, 3, 2, 1, 4):
-            with self.subTest(batch_size=batch_size):
-                inputs = _build_target_verify_inputs(
-                    GROUP_TAGS,
-                    {"full": 2, "aux": 1},
-                    batch_size=batch_size,
-                    query_len=query_len,
-                    prefix_len=prefix_len,
-                )
-                self.assertTrue(runner.canRun(inputs))
-                self.assertEqual(runner.getCurrentRealGraphSize(), 4)
+        # Seed every graph-capacity row with non-zero request data. A later
+        # replay with six live requests must not let rows 48..63 retain it.
+        full_inputs = _build_target_verify_inputs(
+            GROUP_TAGS,
+            {"full": 2, "aux": 1},
+            batch_size=8,
+            query_len=query_len,
+            prefix_len=17,
+        )
+        full_inputs.input_ids.fill_(91)
+        full_inputs.input_hiddens.fill_(7)
+        full_inputs.combo_position_ids = torch.full(
+            (8 * query_len * 3,), 73, dtype=torch.int32, device="cuda"
+        )
+        self.assertTrue(runner.canRun(full_inputs))
+        runner.forward(full_inputs)
+        torch.cuda.synchronize()
 
-                output = runner.forward(inputs)
-                torch.cuda.synchronize()
-                total_query_length = batch_size * query_len
-                total_kv_length = batch_size * (query_len + prefix_len)
-                expected_signature = torch.tensor(
-                    [
-                        4 * query_len,
-                        total_kv_length + (4 - batch_size) * query_len,
-                        4 * query_len,
-                        prefix_len + 1 if batch_size == 4 else query_len,
-                    ],
-                    dtype=output.hidden_states.dtype,
-                    device=output.hidden_states.device,
-                )
-                torch.testing.assert_close(
-                    output.hidden_states,
-                    expected_signature.unsqueeze(0).expand_as(output.hidden_states),
-                )
+        shrunk_inputs = _build_target_verify_inputs(
+            GROUP_TAGS,
+            {"full": 2, "aux": 1},
+            batch_size=6,
+            query_len=query_len,
+            prefix_len=17,
+        )
+        shrunk_inputs.combo_position_ids = torch.arange(
+            1,
+            6 * query_len * 3 + 1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        self.assertTrue(runner.canRun(shrunk_inputs))
+        self.assertEqual(runner.getCurrentRealGraphSize(), 8)
+
+        output = runner.forward(shrunk_inputs)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output.hidden_states, shrunk_inputs.input_hiddens)
 
     def test_block_table_copy_clips_wider_hybrid_staging_rows(self) -> None:
         runner = CudaGraphRunner()

--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_tagged_cache_test.py
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_tagged_cache_test.py
@@ -43,10 +43,72 @@ class TaggedSequenceLengthModel:
                 full_inputs.cu_seqlens_device[-1],
                 full_inputs.cu_kv_seqlens_device[-1],
                 full_inputs.input_lengths_device.sum(),
-                full_inputs.prefix_lengths_device.sum(),
+                full_inputs.sequence_lengths_plus_1_device[-1],
             )
         ).to(inputs.input_hiddens.dtype)
         return PyModelOutputs(inputs.input_hiddens + signature)
+
+
+class TaggedDecodePaddingModel:
+    """Expose metadata that must describe rounded decode rows as safe dummies."""
+
+    def prepare_fmha_impl(self, inputs: PyModelInputs, is_cuda_graph: bool = False):
+        return None
+
+    def forward(self, inputs: PyModelInputs, fmha_impl=None) -> PyModelOutputs:
+        full_inputs = inputs.attention_inputs["full"]
+        signature = torch.stack(
+            (
+                full_inputs.sequence_lengths_plus_1_device.sum(),
+                full_inputs.sequence_lengths_plus_1_device[-1],
+                full_inputs.decode_cu_seqlens_device[-1],
+                full_inputs.decode_cu_seqlens_device[-2],
+            )
+        ).to(inputs.input_hiddens.dtype)
+        return PyModelOutputs(inputs.input_hiddens + signature)
+
+
+class StaticInputTailModel:
+    """Expose stale hidden rows retained by a reused graph input buffer."""
+
+    def prepare_fmha_impl(self, inputs: PyModelInputs, is_cuda_graph: bool = False):
+        return None
+
+    def forward(self, inputs: PyModelInputs, fmha_impl=None) -> PyModelOutputs:
+        tail_signature = inputs.input_hiddens[-1].sum()
+        return PyModelOutputs(inputs.input_hiddens + tail_signature)
+
+
+class AuxiliaryOutputModel:
+    """Return a second output whose view must follow the selected graph bucket."""
+
+    def prepare_fmha_impl(self, inputs: PyModelInputs, is_cuda_graph: bool = False):
+        return None
+
+    def forward(self, inputs: PyModelInputs, fmha_impl=None) -> PyModelOutputs:
+        hidden_states = inputs.input_hiddens + 1
+        target_features = torch.cat(
+            (inputs.input_hiddens + 2, inputs.input_hiddens + 3), dim=1
+        )
+        return PyModelOutputs(hidden_states, target_features)
+
+
+class FailOnceGraphPrepare:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def prepare_cuda_graph(self, inputs) -> None:
+        self.call_count += 1
+        if self.call_count == 1:
+            raise RuntimeError("injected prepare_cuda_graph failure")
+
+
+class RetryableGraphPrepareModel(TaggedBlockTableModel):
+    def __init__(self) -> None:
+        self.graph_prepare = FailOnceGraphPrepare()
+
+    def prepare_fmha_impl(self, inputs: PyModelInputs, is_cuda_graph: bool = False):
+        return self.graph_prepare
 
 
 def _tag_attention_inputs(
@@ -104,6 +166,7 @@ def _build_decode_inputs(
     tags: list[str],
     values: dict[str, int],
     batch_size: int = 2,
+    block_count: int = 1,
 ) -> PyModelInputs:
     attention_inputs = PyAttentionInputs()
     attention_inputs.is_prefill = False
@@ -137,7 +200,7 @@ def _build_decode_inputs(
         values,
         batch_size=batch_size,
         token_count=batch_size,
-        block_count=1,
+        block_count=block_count,
     )
 
 
@@ -277,6 +340,35 @@ class TestCudaGraphTaggedCache(unittest.TestCase):
             )
         )
 
+    def test_failed_async_prepare_is_retried_by_forward(self) -> None:
+        model = RetryableGraphPrepareModel()
+        runner = CudaGraphRunner()
+        runner.init_decode(
+            model,
+            HIDDEN_SIZE,
+            TOKENS_PER_BLOCK,
+            TOKENS_PER_BLOCK,
+            TOKENS_PER_BLOCK,
+            [2],
+            GROUP_TAGS,
+        )
+        inputs = _build_decode_inputs(GROUP_TAGS, {"full": 2, "aux": 1})
+        self.assertTrue(runner.canRun(inputs))
+
+        with self.assertRaisesRegex(
+            RuntimeError, "injected prepare_cuda_graph failure"
+        ):
+            runner.prepareAttentionInputs(inputs)
+        self.assertEqual(model.graph_prepare.call_count, 1)
+
+        output = runner.forward(inputs)
+        torch.cuda.synchronize()
+        self.assertEqual(model.graph_prepare.call_count, 2)
+        torch.testing.assert_close(
+            output.hidden_states,
+            torch.full_like(output.hidden_states, 18),
+        )
+
     def test_prefill_tagged_capture_and_replay_updates(self) -> None:
         runner = CudaGraphRunner()
         runner.init_prefill(
@@ -362,7 +454,7 @@ class TestCudaGraphTaggedCache(unittest.TestCase):
         )
         self.assertFalse(runner.canRun(non_prefill))
 
-    def test_target_verify_clears_rounded_batch_sequence_lengths(self) -> None:
+    def test_target_verify_uses_reserved_block_dummy_rows(self) -> None:
         query_len = 5
         prefix_len = 11
         runner = CudaGraphRunner()
@@ -378,7 +470,9 @@ class TestCudaGraphTaggedCache(unittest.TestCase):
             query_len,
         )
 
-        for batch_size in (1, 2, 4):
+        # Exercise both growth and shrink on the same graph instance. The
+        # production failure appeared only after a full bucket lost a request.
+        for batch_size in (4, 3, 2, 1, 4):
             with self.subTest(batch_size=batch_size):
                 inputs = _build_target_verify_inputs(
                     GROUP_TAGS,
@@ -396,10 +490,10 @@ class TestCudaGraphTaggedCache(unittest.TestCase):
                 total_kv_length = batch_size * (query_len + prefix_len)
                 expected_signature = torch.tensor(
                     [
-                        total_query_length,
-                        total_kv_length,
-                        total_query_length,
-                        batch_size * prefix_len,
+                        4 * query_len,
+                        total_kv_length + (4 - batch_size) * query_len,
+                        4 * query_len,
+                        prefix_len + 1 if batch_size == 4 else query_len,
                     ],
                     dtype=output.hidden_states.dtype,
                     device=output.hidden_states.device,
@@ -407,6 +501,137 @@ class TestCudaGraphTaggedCache(unittest.TestCase):
                 torch.testing.assert_close(
                     output.hidden_states,
                     expected_signature.unsqueeze(0).expand_as(output.hidden_states),
+                )
+
+    def test_block_table_copy_clips_wider_hybrid_staging_rows(self) -> None:
+        runner = CudaGraphRunner()
+        runner.init_decode(
+            TaggedBlockTableModel(),
+            HIDDEN_SIZE,
+            TOKENS_PER_BLOCK,
+            TOKENS_PER_BLOCK,
+            TOKENS_PER_BLOCK,
+            [4],
+            GROUP_TAGS,
+        )
+
+        # Hybrid cache assembly may expose a common staging row wider than a
+        # model-local graph table. Only the representable intersection is part
+        # of this graph; copying the complete staging stride would overwrite the
+        # next captured buffer.
+        inputs = _build_decode_inputs(
+            GROUP_TAGS,
+            {"full": 5, "aux": 3},
+            batch_size=3,
+            block_count=4,
+        )
+        self._assert_replay_signature(runner, inputs, 53)
+
+    def test_decode_clears_rounded_batch_sequence_metadata(self) -> None:
+        runner = CudaGraphRunner()
+        runner.init_decode(
+            TaggedDecodePaddingModel(),
+            HIDDEN_SIZE,
+            64,
+            TOKENS_PER_BLOCK,
+            TOKENS_PER_BLOCK,
+            [4],
+            GROUP_TAGS,
+        )
+
+        full_inputs = _build_decode_inputs(
+            GROUP_TAGS, {"full": 2, "aux": 1}, batch_size=4
+        )
+        self.assertTrue(runner.canRun(full_inputs))
+        runner.forward(full_inputs)
+        torch.cuda.synchronize()
+
+        inputs = _build_decode_inputs(
+            GROUP_TAGS, {"full": 2, "aux": 1}, batch_size=3
+        )
+        self.assertTrue(runner.canRun(inputs))
+        self.assertEqual(runner.getCurrentRealGraphSize(), 4)
+
+        output = runner.forward(inputs)
+        torch.cuda.synchronize()
+        expected_signature = torch.tensor(
+            [7, 1, 4, 3],
+            dtype=output.hidden_states.dtype,
+            device=output.hidden_states.device,
+        )
+        torch.testing.assert_close(
+            output.hidden_states,
+            expected_signature.unsqueeze(0).expand_as(output.hidden_states),
+        )
+
+    def test_decode_clears_hidden_rows_after_batch_shrink(self) -> None:
+        runner = CudaGraphRunner()
+        runner.init_decode(
+            StaticInputTailModel(),
+            HIDDEN_SIZE,
+            64,
+            TOKENS_PER_BLOCK,
+            TOKENS_PER_BLOCK,
+            [4],
+            GROUP_TAGS,
+        )
+
+        full_inputs = _build_decode_inputs(
+            GROUP_TAGS, {"full": 2, "aux": 1}, batch_size=4
+        )
+        full_inputs.input_hiddens[-1].fill_(7)
+        self.assertTrue(runner.canRun(full_inputs))
+        runner.forward(full_inputs)
+        torch.cuda.synchronize()
+
+        inputs = _build_decode_inputs(
+            GROUP_TAGS, {"full": 2, "aux": 1}, batch_size=3
+        )
+        self.assertTrue(runner.canRun(inputs))
+        output = runner.forward(inputs)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            output.hidden_states,
+            torch.zeros_like(output.hidden_states),
+        )
+
+    def test_auxiliary_output_view_follows_each_graph_bucket(self) -> None:
+        runner = CudaGraphRunner()
+        runner.init_decode(
+            AuxiliaryOutputModel(),
+            HIDDEN_SIZE,
+            64,
+            TOKENS_PER_BLOCK,
+            TOKENS_PER_BLOCK,
+            [1, 4],
+            GROUP_TAGS,
+        )
+
+        for batch_size in (4, 1, 3, 1, 4):
+            with self.subTest(batch_size=batch_size):
+                inputs = _build_decode_inputs(
+                    GROUP_TAGS, {"full": 2, "aux": 1}, batch_size=batch_size
+                )
+                inputs.input_hiddens.copy_(
+                    torch.arange(
+                        batch_size * HIDDEN_SIZE,
+                        dtype=inputs.input_hiddens.dtype,
+                        device=inputs.input_hiddens.device,
+                    ).reshape(batch_size, HIDDEN_SIZE)
+                )
+                self.assertTrue(runner.canRun(inputs))
+                output = runner.forward(inputs)
+                torch.cuda.synchronize()
+
+                expected = torch.cat(
+                    (inputs.input_hiddens + 2, inputs.input_hiddens + 3), dim=1
+                )
+                self.assertEqual(
+                    (batch_size, HIDDEN_SIZE * 2),
+                    tuple(output.mtp_target_hidden_states.shape),
+                )
+                torch.testing.assert_close(
+                    output.mtp_target_hidden_states, expected
                 )
 
 

--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
@@ -48,7 +48,8 @@ public:
                      std::vector<int>         decode_capture_batch_sizes,
                      std::vector<std::string> group_tags,
                      bool                     is_target_verify,
-                     int64_t                  num_tokens_per_bs) {
+                     int64_t                  num_tokens_per_bs,
+                     int64_t                  position_id_len_factor) {
         reset_runner();
         GraphParams params;
         params.enable_cuda_graph_debug_mode = false;
@@ -64,6 +65,7 @@ public:
         params.decode_capture_batch_sizes   = std::move(decode_capture_batch_sizes);
         params.kv_cache_group_tags          = std::move(group_tags);
         params.is_target_verify             = is_target_verify;
+        params.position_id_len_factor       = static_cast<int>(position_id_len_factor);
 
         runner_ = CudaGraphRunner::createForDecode(std::move(py_instance), std::move(params));
     }
@@ -138,7 +140,8 @@ PYBIND11_MODULE(libtest_cuda_graph_runner, m) {
              py::arg("decode_capture_batch_sizes"),
              py::arg("group_tags")        = std::vector<std::string>{},
              py::arg("is_target_verify")  = false,
-             py::arg("num_tokens_per_bs") = 1)
+             py::arg("num_tokens_per_bs") = 1,
+             py::arg("position_id_len_factor") = 0)
         .def("canRun", &CudaGraphTestRunner::canRun)
         .def("forward", &CudaGraphTestRunner::forward)
         .def("prepareAttentionInputs", &CudaGraphTestRunner::prepareAttentionInputs)

--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
@@ -76,10 +76,14 @@ public:
         // Production PyWrappedModel creates these device mirrors. Python tests
         // cannot assign them because the bindings intentionally expose them as
         // read-only, so reproduce that input-building step in the test wrapper.
-        inputs.attention_inputs.input_lengths_device  = inputs.attention_inputs.input_lengths.cuda();
-        inputs.attention_inputs.prefix_lengths_device = inputs.attention_inputs.prefix_lengths.cuda();
-        refreshTaggedAttentionInputs(inputs);
+        prepareDeviceMirrors(inputs);
         return runner_->forward(inputs, state_);
+    }
+
+    void prepareAttentionInputs(torch_ext::PyModelInputs& inputs) {
+        c10::InferenceMode inference_guard(true);
+        prepareDeviceMirrors(inputs);
+        runner_->prepareAttentionInputs(inputs, state_);
     }
 
     int getCurrentRealGraphSize() {
@@ -91,6 +95,12 @@ public:
     }
 
 private:
+    void prepareDeviceMirrors(torch_ext::PyModelInputs& inputs) {
+        inputs.attention_inputs.input_lengths_device  = inputs.attention_inputs.input_lengths.cuda();
+        inputs.attention_inputs.prefix_lengths_device = inputs.attention_inputs.prefix_lengths.cuda();
+        refreshTaggedAttentionInputs(inputs);
+    }
+
     void reset_runner() {
         if (runner_ != nullptr) {
             delete runner_;
@@ -131,5 +141,6 @@ PYBIND11_MODULE(libtest_cuda_graph_runner, m) {
              py::arg("num_tokens_per_bs") = 1)
         .def("canRun", &CudaGraphTestRunner::canRun)
         .def("forward", &CudaGraphTestRunner::forward)
+        .def("prepareAttentionInputs", &CudaGraphTestRunner::prepareAttentionInputs)
         .def("getCurrentRealGraphSize", &CudaGraphTestRunner::getCurrentRealGraphSize);
 }

--- a/rtp_llm/cpp/cuda_graph/tests/prepared_attention_inputs_guard_test.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/prepared_attention_inputs_guard_test.cc
@@ -1,0 +1,32 @@
+#include "rtp_llm/cpp/cuda_graph/prepared_attention_inputs_guard.h"
+
+#include <atomic>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+namespace rtp_llm {
+namespace {
+
+TEST(PreparedAttentionInputsGuardTest, FailedAttemptIsInvalidatedBeforeSuccessfulRetry) {
+    std::atomic<bool> prepared{true};
+
+    EXPECT_THROW(
+        {
+            PreparedAttentionInputsGuard guard(prepared);
+            EXPECT_FALSE(prepared.load(std::memory_order_acquire));
+            throw std::runtime_error("injected prepare failure");
+        },
+        std::runtime_error);
+    EXPECT_FALSE(prepared.load(std::memory_order_acquire));
+
+    {
+        PreparedAttentionInputsGuard guard(prepared);
+        EXPECT_FALSE(prepared.load(std::memory_order_acquire));
+        guard.commit();
+    }
+    EXPECT_TRUE(prepared.load(std::memory_order_acquire));
+}
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/disaggregate/cache_store/TcpClient.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/TcpClient.cpp
@@ -73,6 +73,10 @@ std::shared_ptr<arpc::RPCChannelBase> TcpClient::openChannel(const std::string& 
         return nullptr;
     }
 
+    // CacheStore workers are shared across peers. Never block one of those
+    // workers behind a saturated channel: ANet reports enqueue failure through
+    // the RPC callback, and the cache-load state machine applies its bounded
+    // transfer retry policy without starving healthy peers.
     return std::shared_ptr<arpc::RPCChannelBase>(
         dynamic_cast<arpc::RPCChannelBase*>(rpc_channel_manager_->OpenChannel(spec, false, 1000ul)));
 }

--- a/rtp_llm/cpp/distribute/CpuTpBroadcaster.cc
+++ b/rtp_llm/cpp/distribute/CpuTpBroadcaster.cc
@@ -4,7 +4,9 @@
 #include "rtp_llm/cpp/utils/Logger.h"
 
 #include <chrono>
+#include <cstdint>
 #include <cstring>
+#include <limits>
 #include <thread>
 
 #include <errno.h>
@@ -20,6 +22,19 @@ namespace {
 
 constexpr int  kInitTimeoutMs  = 120 * 1000;
 constexpr char kLinkProbeToken = 0x5a;
+
+constexpr uint32_t kFrameMagic   = 0x52545042;  // "RTPB"
+constexpr uint16_t kFrameVersion = 1;
+
+struct BroadcastFrameHeader {
+    uint32_t magic         = kFrameMagic;
+    uint16_t version       = kFrameVersion;
+    uint16_t header_bytes  = sizeof(BroadcastFrameHeader);
+    uint64_t sequence      = 0;
+    uint64_t payload_bytes = 0;
+};
+
+static_assert(sizeof(BroadcastFrameHeader) == 24, "CpuTpBroadcaster frame header must remain stable");
 
 std::string makeUdsPath(const std::string& base, int rank) {
     return base + "_" + std::to_string(rank) + ".sock";
@@ -53,7 +68,7 @@ bool waitFdUntil(int fd, short events, std::chrono::steady_clock::time_point dea
 
         const auto remaining_ms =
             static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count());
-        struct pollfd pfd{};
+        struct pollfd pfd {};
         pfd.fd     = fd;
         pfd.events = events;
         int rc     = ::poll(&pfd, 1, remaining_ms);
@@ -221,6 +236,7 @@ CpuTpBroadcaster::~CpuTpBroadcaster() {
 
 void CpuTpBroadcaster::reset() {
     std::lock_guard<std::mutex> lock(mu_);
+    std::lock_guard<std::mutex> broadcast_lock(broadcast_mu_);
     for (int& fd : peer_fds_) {
         closeFd(fd);
     }
@@ -231,8 +247,9 @@ void CpuTpBroadcaster::reset() {
         my_uds_path_.clear();
     }
     base_path_.clear();
-    tp_rank_ = 0;
-    tp_size_ = 1;
+    tp_rank_       = 0;
+    tp_size_       = 1;
+    next_sequence_ = 0;
     initialized_.store(false, std::memory_order_release);
 }
 
@@ -275,7 +292,7 @@ void CpuTpBroadcaster::initialize(int tp_rank, int tp_size, const std::string& b
             listen_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
             RTP_LLM_CHECK_WITH_INFO(listen_fd_ >= 0, "CpuTpBroadcaster socket: %s", std::strerror(errno));
 
-            struct sockaddr_un addr{};
+            struct sockaddr_un addr {};
             addr.sun_family = AF_UNIX;
             RTP_LLM_CHECK_WITH_INFO(
                 path.size() < sizeof(addr.sun_path), "CpuTpBroadcaster UDS path too long: %s", path.c_str());
@@ -343,7 +360,7 @@ void CpuTpBroadcaster::initialize(int tp_rank, int tp_size, const std::string& b
         }
     } else {
         const std::string  path = makeUdsPath(base_path, 0);
-        struct sockaddr_un addr{};
+        struct sockaddr_un addr {};
         addr.sun_family = AF_UNIX;
         RTP_LLM_CHECK_WITH_INFO(
             path.size() < sizeof(addr.sun_path), "CpuTpBroadcaster UDS path too long: %s", path.c_str());
@@ -400,29 +417,69 @@ void CpuTpBroadcaster::initialize(int tp_rank, int tp_size, const std::string& b
 }
 
 void CpuTpBroadcaster::broadcast(void* buf, std::size_t nbytes, int root) {
+    std::lock_guard<std::mutex> lock(broadcast_mu_);
     RTP_LLM_CHECK_WITH_INFO(initialized_.load(std::memory_order_acquire),
                             "CpuTpBroadcaster::broadcast called before initialize");
-    if (tp_size_ <= 1 || nbytes == 0) {
+    if (tp_size_ <= 1) {
         return;
     }
     RTP_LLM_CHECK_WITH_INFO(root == 0, "CpuTpBroadcaster supports only root=0 (star topology); got %d", root);
+    RTP_LLM_CHECK_WITH_INFO(
+        nbytes <= std::numeric_limits<uint64_t>::max(), "CpuTpBroadcaster payload is too large: %zu bytes", nbytes);
+
+    const BroadcastFrameHeader expected_header{
+        kFrameMagic, kFrameVersion, sizeof(BroadcastFrameHeader), next_sequence_, static_cast<uint64_t>(nbytes)};
 
     if (tp_rank_ == 0) {
         for (int k = 1; k < tp_size_; ++k) {
-            ssize_t n = writeAll(peer_fds_[k], buf, nbytes);
+            ssize_t n = writeAll(peer_fds_[k], &expected_header, sizeof(expected_header));
+            RTP_LLM_CHECK_WITH_INFO(n == static_cast<ssize_t>(sizeof(expected_header)),
+                                    "CpuTpBroadcaster frame-header write to rank %d failed at sequence %llu: %s",
+                                    k,
+                                    static_cast<unsigned long long>(next_sequence_),
+                                    std::strerror(errno));
+            n = writeAll(peer_fds_[k], buf, nbytes);
             RTP_LLM_CHECK_WITH_INFO(n == static_cast<ssize_t>(nbytes),
-                                    "CpuTpBroadcaster write to rank %d (%zu bytes) failed: %s",
+                                    "CpuTpBroadcaster payload write to rank %d (%zu bytes) failed at sequence %llu: %s",
                                     k,
                                     nbytes,
+                                    static_cast<unsigned long long>(next_sequence_),
                                     std::strerror(errno));
         }
     } else {
-        ssize_t n = readAll(peer_fds_[0], buf, nbytes);
+        BroadcastFrameHeader received_header{};
+        ssize_t              n = readAll(peer_fds_[0], &received_header, sizeof(received_header));
+        RTP_LLM_CHECK_WITH_INFO(n == static_cast<ssize_t>(sizeof(received_header)),
+                                "CpuTpBroadcaster frame-header read from rank 0 failed at sequence %llu: %s",
+                                static_cast<unsigned long long>(next_sequence_),
+                                std::strerror(errno));
+        RTP_LLM_CHECK_WITH_INFO(
+            received_header.magic == kFrameMagic && received_header.version == kFrameVersion
+                && received_header.header_bytes == sizeof(BroadcastFrameHeader),
+            "CpuTpBroadcaster invalid frame header at sequence %llu: magic=0x%x version=%u bytes=%u",
+            static_cast<unsigned long long>(next_sequence_),
+            received_header.magic,
+            received_header.version,
+            received_header.header_bytes);
+        RTP_LLM_CHECK_WITH_INFO(received_header.sequence == next_sequence_,
+                                "CpuTpBroadcaster sequence mismatch: expected %llu, got %llu",
+                                static_cast<unsigned long long>(next_sequence_),
+                                static_cast<unsigned long long>(received_header.sequence));
+        RTP_LLM_CHECK_WITH_INFO(
+            received_header.payload_bytes == nbytes,
+            "CpuTpBroadcaster payload size mismatch at sequence %llu: rank 0 sent %llu bytes, rank %d expects %zu",
+            static_cast<unsigned long long>(next_sequence_),
+            static_cast<unsigned long long>(received_header.payload_bytes),
+            tp_rank_,
+            nbytes);
+        n = readAll(peer_fds_[0], buf, nbytes);
         RTP_LLM_CHECK_WITH_INFO(n == static_cast<ssize_t>(nbytes),
-                                "CpuTpBroadcaster read from rank 0 (%zu bytes) failed: %s",
+                                "CpuTpBroadcaster payload read from rank 0 (%zu bytes) failed at sequence %llu: %s",
                                 nbytes,
+                                static_cast<unsigned long long>(next_sequence_),
                                 std::strerror(errno));
     }
+    ++next_sequence_;
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/distribute/CpuTpBroadcaster.h
+++ b/rtp_llm/cpp/distribute/CpuTpBroadcaster.h
@@ -2,15 +2,18 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <string>
 #include <vector>
 
 namespace rtp_llm {
 
-// CPU-only UDS broadcaster for intra-node TP input sync.
+// CPU-only framed UDS broadcaster for intra-node TP input sync.
 // It avoids NCCL cudaDeviceSynchronize for small CPU tensors; cross-node or
-// uninitialized callers fall back to NCCL. broadcast() is main-thread only.
+// uninitialized callers fall back to NCCL. Each frame carries its sequence and
+// payload size so a rank-local input-layout mismatch fails immediately instead
+// of consuming part of the next frame and hanging the TP group.
 class CpuTpBroadcaster {
 public:
     static CpuTpBroadcaster& instance();
@@ -20,9 +23,9 @@ public:
     // throws.
     void initialize(int tp_rank, int tp_size, const std::string& base_path);
 
-    // Blocking broadcast of `nbytes` bytes from `buf` originating at root.
-    // root rank writes to all peer sockets; non-root reads from its peer-0 fd.
-    // Throws on transport error.
+    // Blocking broadcast of one framed payload from `buf` originating at root.
+    // Calls are serialized per process. Throws on transport or frame-contract
+    // mismatch before reading a differently sized payload.
     void broadcast(void* buf, std::size_t nbytes, int root);
 
     // Close all sockets and return the singleton to its initial state so a
@@ -36,10 +39,11 @@ public:
 private:
     CpuTpBroadcaster() = default;
     ~CpuTpBroadcaster();
-    CpuTpBroadcaster(const CpuTpBroadcaster&)            = delete;
+    CpuTpBroadcaster(const CpuTpBroadcaster&) = delete;
     CpuTpBroadcaster& operator=(const CpuTpBroadcaster&) = delete;
 
     std::mutex        mu_;
+    std::mutex        broadcast_mu_;
     std::atomic<bool> initialized_{false};
     int               tp_rank_ = 0;
     int               tp_size_ = 1;
@@ -48,6 +52,7 @@ private:
     // peer_fds_[k] = fd connecting this rank to rank k. peer_fds_[tp_rank_] = -1.
     std::vector<int> peer_fds_;
     std::string      my_uds_path_;  // path to unlink at shutdown (rank 0 only)
+    uint64_t         next_sequence_ = 0;
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/distribute/test/CpuTpBroadcasterTest.cc
+++ b/rtp_llm/cpp/distribute/test/CpuTpBroadcasterTest.cc
@@ -100,7 +100,7 @@ int connectWithRetry(const std::string& path) {
             return -1;
         }
 
-        struct sockaddr_un addr{};
+        struct sockaddr_un addr {};
         addr.sun_family = AF_UNIX;
         std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
         if (::connect(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0) {
@@ -133,7 +133,7 @@ int fakeServerWrongProbe(const std::string& base) {
         return 1;
     }
 
-    struct sockaddr_un addr{};
+    struct sockaddr_un addr {};
     addr.sun_family = AF_UNIX;
     std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
     if (::bind(listen_fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) != 0) {
@@ -259,6 +259,24 @@ int happyPathChild(int rank, int tp_size, const std::string& base) {
     return 0;
 }
 
+int mismatchedPayloadSizeChild(int rank, const std::string& base) {
+    auto& bcast = CpuTpBroadcaster::instance();
+    bcast.reset();
+    bcast.initialize(rank, 2, base);
+
+    if (rank == 0) {
+        uint32_t value = 7;
+        bcast.broadcast(&value, sizeof(value), 0);
+        bcast.reset();
+        return 0;
+    }
+
+    uint64_t  value = 0;
+    const int rc    = expectThrowContains([&] { bcast.broadcast(&value, sizeof(value), 0); }, "payload size mismatch");
+    bcast.reset();
+    return rc;
+}
+
 void runHappyPath(int tp_size) {
     const std::string  base = makeTempBase();
     std::vector<pid_t> pids;
@@ -277,6 +295,16 @@ TEST(CpuTpBroadcasterTest, BroadcastHappyPathTp2) {
 
 TEST(CpuTpBroadcasterTest, BroadcastHappyPathTp4) {
     runHappyPath(4);
+}
+
+TEST(CpuTpBroadcasterTest, RejectsPayloadSizeMismatchBeforeReadingPayload) {
+    const std::string  base = makeTempBase();
+    std::vector<pid_t> pids;
+    pids.push_back(spawnChild([=] { return mismatchedPayloadSizeChild(0, base); }));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    pids.push_back(spawnChild([=] { return mismatchedPayloadSizeChild(1, base); }));
+    expectChildrenOk(pids);
+    cleanupTempBase(base, 2);
 }
 
 TEST(CpuTpBroadcasterTest, Rank0RejectsBadPeerRank) {

--- a/rtp_llm/cpp/engine_base/WeightsConverter.cc
+++ b/rtp_llm/cpp/engine_base/WeightsConverter.cc
@@ -248,8 +248,8 @@ std::unique_ptr<rtp_llm::Weights> WeightsConverter::createGptWeights(std::unique
     gpt_weights.linear_bias_slopes = mayCreateDenseWeights(*global_weight, W::linear_bias_slopes);
     gpt_weights.d2t_map            = mayFindTensor(*global_weight, W::multi_tokens_predict_d2t_map);
     gpt_weights.t2d_map            = mayFindTensor(*global_weight, W::multi_tokens_predict_t2d_map);
-    gpt_weights.dspark_markov_w1   = mayFindTensor(*global_weight, W::v4_dspark_markov_w1);
-    gpt_weights.dspark_markov_w2   = mayFindTensor(*global_weight, W::v4_dspark_markov_w2);
+    gpt_weights.dspark_markov_w1   = mayFindTensor(*global_weight, W::dspark_markov_w1);
+    gpt_weights.dspark_markov_w2   = mayFindTensor(*global_weight, W::dspark_markov_w2);
 
     for (auto& layer_weights : layers_weights) {
         rtp_llm::LayerWeights layer_ws;

--- a/rtp_llm/cpp/engine_base/schedulers/FIFOSchedulerBase.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/FIFOSchedulerBase.cc
@@ -66,21 +66,21 @@ bool FIFOSchedulerBase::checkInputLength(const GenerateStreamPtr& stream) {
     const auto reserve_step = stream->reserveStep();
     if (reserve_step > 0 && !(input_length <= max_seq_len_ && reserve_step <= max_seq_len_ - input_length)) {
         const auto allowed_input_length = reserve_step <= max_seq_len_ ? max_seq_len_ - reserve_step : 0;
-        auto       error_info           = autil::StringUtil::formatString(
-            "input len %zu with speculative reserve_step %zu exceeds max seq len %zu, "
-            "allowed max input len for speculative decoding is %zu",
-            input_length,
-            reserve_step,
-            max_seq_len_,
-            allowed_input_length);
+        auto       error_info =
+            autil::StringUtil::formatString("input len %zu with speculative reserve_step %zu exceeds max seq len %zu, "
+                                            "allowed max input len for speculative decoding is %zu",
+                                            input_length,
+                                            reserve_step,
+                                            max_seq_len_,
+                                            allowed_input_length);
         stream->reportError(ErrorCode::LONG_PROMPT_ERROR, error_info);
         return false;
     }
     if (stream->inputLength() > cache_manager_->maxAvailableTokensNum()) {
         stream->reportError(ErrorCode::EXCEEDS_KV_CACHE_MAX_LEN,
-                            autil::StringUtil::formatString("input len " + std::to_string(stream->inputLength())
-                                                            + " is greater than kv cache max available tokens num "
-                                                            + std::to_string(cache_manager_->maxAvailableTokensNum())));
+                            "input len " + std::to_string(stream->inputLength())
+                                + " is greater than kv cache max available tokens num "
+                                + std::to_string(cache_manager_->maxAvailableTokensNum()));
         return false;
     }
     return true;
@@ -153,17 +153,14 @@ void FIFOSchedulerBase::evaluateWaitingStreams(list<GenerateStreamPtr>& waiting_
     last_admitted_context_token_size_ = 0;
     last_waiting_oldest_age_us_       = 0;
     if (!waiting_streams.empty()) {
-        auto oldest_enqueue_time_us = (*std::min_element(waiting_streams.begin(),
-                                                         waiting_streams.end(),
-                                                         [](const auto& lhs, const auto& rhs) {
-                                                             return lhs->schedulerEnqueueTimeUs()
-                                                                    < rhs->schedulerEnqueueTimeUs();
-                                                         }))
-                                          ->schedulerEnqueueTimeUs();
+        auto oldest_enqueue_time_us =
+            (*std::min_element(waiting_streams.begin(), waiting_streams.end(), [](const auto& lhs, const auto& rhs) {
+                return lhs->schedulerEnqueueTimeUs() < rhs->schedulerEnqueueTimeUs();
+            }))->schedulerEnqueueTimeUs();
         last_waiting_oldest_age_us_ =
             std::max<int64_t>(0, autil::TimeUtility::currentTimeInMicroSeconds() - oldest_enqueue_time_us);
     }
-    const size_t inited_kv_streams = max_inited_kv_cache_streams_ > 0 ? countInitedKVCacheStreams() : 0;
+    const size_t inited_kv_streams         = max_inited_kv_cache_streams_ > 0 ? countInitedKVCacheStreams() : 0;
     size_t       admitted_new_init_streams = 0;
 
     for (auto it = waiting_streams.begin(); it != waiting_streams.end();) {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
@@ -147,35 +147,53 @@ void GenerateStateMachine::handleRunning() {
         && stream_cache_resource_->isContextStream()) {
         return;
     }
-    // Use the publish-time seqLength so incrKVBlock doesn't race the async
-    // worker's update() — a stale read skips the block-boundary allocation.
-    // Prefer Normal state; fall back to MTP state if the stream is MTP.
+    // A pending MTP round may already own a complete device page-table
+    // snapshot for the next execution.  If the existing allocation also has
+    // enough reserved slots, do not touch the mutable host table: the worker
+    // will commit the identical swaps before a later capacity boundary.
     int             seq_len_override = -1;
     GenerateStream* stream           = stream_cache_resource_->stream();
     if (stream != nullptr) {
-        const int normal_override = stream->getNormalAsyncDeviceState().next_real_seq_len;
-        if (normal_override > 0) {
-            seq_len_override = normal_override;
-        } else {
-            const auto& mtp_state    = stream->getMtpAsyncDeviceState();
-            const int   mtp_override = mtp_state.next_real_seq_len;
-            if (mtp_override > 0) {
-                seq_len_override = mtp_override;
+        const bool  pending   = stream->hasPendingAsyncBookkeeping();
+        const auto mtp_state = stream->getMtpAsyncDeviceState();
+        if (pending && GenerateStream::hasMtpCacheSnapshot(mtp_state) && mtp_state.next_seq_len_upper_bound > 0
+            && stream_cache_resource_->singleBatchNeedBlocks(mtp_state.next_seq_len_upper_bound,
+                                                             static_cast<int>(reserve_step_))
+                   == 0) {
+            return;
+        }
+
+        // Only use publish-time overrides while the host commit is still in
+        // flight.  Once it finishes, complete_token_ids is authoritative and
+        // avoids carrying a conservative upper bound into later rounds.
+        if (pending) {
+            const int normal_override = stream->getNormalAsyncDeviceState().next_real_seq_len;
+            if (normal_override > 0) {
+                seq_len_override = normal_override;
+            } else if (mtp_state.next_seq_len_upper_bound > 0) {
+                seq_len_override = mtp_state.next_seq_len_upper_bound;
             }
         }
         if (asyncDebugEnabled() && stream->hasPendingAsyncBookkeeping()) {
             RTP_LLM_LOG_WARNING("[async-debug] handleRunning while async bookkeeping pending: stream=%ld pd_sep=%d "
-                                "status=%s seq_len=%d normal_last_real=%d normal_next_real=%d "
+                                "status=%s published_seq_upper=%d normal_last_real=%d normal_next_real=%d "
                                 "mtp_next_real=%d override=%d",
                                 stream->streamId(),
                                 stream->queryPdSep(),
                                 StreamStateToString(status.load(std::memory_order_acquire)).c_str(),
-                                stream->seqLength(),
+                                mtp_state.next_seq_len_upper_bound,
                                 stream->getNormalAsyncDeviceState().last_real_seq_len,
                                 stream->getNormalAsyncDeviceState().next_real_seq_len,
-                                stream->getMtpAsyncDeviceState().next_real_seq_len,
+                                mtp_state.next_seq_len_upper_bound,
                                 seq_len_override);
         }
+    }
+    // incrKVBlock may append or compact host block slots even when no new
+    // physical allocation is ultimately needed.  Invalidate the old device
+    // snapshot before entering that mutation path; the gatherer will use the
+    // now-authoritative host table for this round.
+    if (stream != nullptr) {
+        stream->clearMtpCacheSnapshot();
     }
     auto result = stream_cache_resource_->incrKVBlock(seq_len_override);
     if (!result.ok()) {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <memory>
@@ -105,8 +106,7 @@ GenerateStream::GenerateStream(const shared_ptr<GenerateInput>& input,
 
     cum_log_probs_ = torch::zeros({(int64_t)init_batch_size}, torch::kFloat32);
 
-    is_context_stream_  = std::make_shared<bool>();
-    *is_context_stream_ = true;
+    is_context_stream_ = std::make_shared<std::atomic<bool>>(true);
     generate_status_    = std::make_shared<GenerateStateMachine>(stream_cache_resource_);
     sub_generate_status_.reserve(maxBatchSize());
     sub_generate_status_.clear();
@@ -419,7 +419,11 @@ bool GenerateStream::returnCumLogProbs() const {
 }
 
 bool GenerateStream::genTimeline() const {
-    return seqLength() <= inputLength() + profileStep() - 1 ? gen_timeline_ : false;
+    return genTimelineAtSeqLength(seqLength());
+}
+
+bool GenerateStream::genTimelineAtSeqLength(int seq_length) const {
+    return seq_length <= inputLength() + profileStep() - 1 ? gen_timeline_ : false;
 }
 
 void GenerateStream::setGenTimeline(bool gen_timeline) {
@@ -556,7 +560,7 @@ void GenerateStream::incLastOutputPos() {
 }
 
 bool GenerateStream::isContextStream() const {
-    return *is_context_stream_;
+    return is_context_stream_->load(std::memory_order_acquire);
 }
 
 const torch::Tensor& GenerateStream::cumLogProbs() const {
@@ -755,6 +759,37 @@ bool GenerateStream::isActive() const {
     return !hasErrorWithoutLock() && getStatus() != StreamState::FINISHED;
 }
 
+bool GenerateStream::finishOrCancel(int64_t wait_timeout_ms, const std::string& cancel_reason) {
+    RTP_LLM_CHECK_WITH_INFO(wait_timeout_ms >= 0, "finishOrCancel wait_timeout_ms must be non-negative");
+
+    std::unique_lock<std::mutex> lock(*mutex_);
+    const auto                   lifecycle_finished = [this] { return getStatus() == StreamState::FINISHED; };
+    if (lifecycle_finished()) {
+        return true;
+    }
+
+    const bool successful_completion_pending =
+        hasEventWithoutLock(StreamEvents::GenerateDone) && !hasErrorWithoutLock();
+    if (!successful_completion_pending) {
+        reportEventWithoutLock(StreamEvents::Error, ErrorCode::CANCELLED, cancel_reason);
+    }
+
+    bool finished = false;
+    if (wait_timeout_ms == 0) {
+        consumer_cv_->wait(lock, lifecycle_finished);
+        finished = true;
+    } else {
+        finished = consumer_cv_->wait_for(lock, std::chrono::milliseconds(wait_timeout_ms), lifecycle_finished);
+    }
+
+    if (!finished && !hasErrorWithoutLock()) {
+        reportEventWithoutLock(StreamEvents::Error,
+                               ErrorCode::CANCELLED,
+                               cancel_reason + ": timed out waiting for scheduler lifecycle commit");
+    }
+    return finished;
+}
+
 void GenerateStream::setReserveStep(size_t reserve_step) {
     // Keep GenerateStream as the only entry point for setting reserve_step.
     reserve_step_ = reserve_step;
@@ -763,6 +798,15 @@ void GenerateStream::setReserveStep(size_t reserve_step) {
 }
 
 StreamState GenerateStream::moveToNext() {
+    // Most MTP rounds can execute from the immutable device page-table
+    // snapshot while the previous host commit is in flight.  A page-capacity
+    // boundary is different: the allocator must append blocks to the mutable
+    // host table, so join the worker before acquiring mutex_.  Waiting after
+    // taking mutex_ would deadlock with specUpdate().
+    if (needsAsyncBookkeepingJoinForKvReservation()) {
+        waitPendingAsyncBookkeeping();
+    }
+
     StreamState state;
     bool        should_report_metric = false;
     {
@@ -795,6 +839,31 @@ StreamState GenerateStream::moveToNext() {
         reportMetricOnce();
     }
     return state;
+}
+
+bool GenerateStream::needsAsyncBookkeepingJoinForKvReservation() const {
+    if (getStatus() != StreamState::RUNNING || !hasPendingAsyncBookkeeping()) {
+        return false;
+    }
+
+    const auto state = getMtpAsyncDeviceState();
+    // pending_async_bookkeeping_ is shared by normal decode and MTP.  Normal
+    // decode never publishes MtpAsyncDeviceState, so it must not be forced to
+    // wait on an MTP-only cache snapshot.  MTP publishes the state before it
+    // claims the async worker, making a non-zero epoch a stable mode marker.
+    if (state.epoch == 0) {
+        return false;
+    }
+    if (!hasMtpCacheSnapshot(state) || state.next_seq_len_upper_bound <= 0 || stream_cache_resource_ == nullptr) {
+        return true;
+    }
+
+    // Reading group vector sizes is safe while specUpdate only swaps existing
+    // elements.  No allocator mutation can run concurrently: scheduler calls
+    // moveToNext serially on this engine thread.
+    return stream_cache_resource_->singleBatchNeedBlocks(state.next_seq_len_upper_bound,
+                                                         static_cast<int>(reserve_step_))
+           > 0;
 }
 
 bool GenerateStream::hasError() const {
@@ -962,7 +1031,7 @@ void GenerateStream::specUpdate(const StreamSpecUpdateInfo& update_info) {
     RTP_LLM_PROFILE_FUNCTION();
     std::lock_guard<std::mutex> lock(*mutex_);
     RTP_LLM_LOG_DEBUG("stream [%s] spec update", streamLogTag().c_str());
-    *is_context_stream_ = false;
+    is_context_stream_->store(false, std::memory_order_release);
     if (reportUpdateErrorWithoutLock(update_info.error_info)) {
         return;
     }
@@ -1094,7 +1163,7 @@ void GenerateStream::update(const StreamUpdateInfo& update_info) {
     RTP_LLM_PROFILE_FUNCTION();
     std::lock_guard<std::mutex> lock(*mutex_);
     RTP_LLM_LOG_DEBUG("stream [%s] update", streamLogTag().c_str());
-    *is_context_stream_ = false;
+    is_context_stream_->store(false, std::memory_order_release);
     if (reportUpdateErrorWithoutLock(update_info.error_info)) {
         return;
     }
@@ -1413,7 +1482,7 @@ void GenerateStream::setPerfTest(bool perf_test) {
 }
 
 void GenerateStream::setIsContextStream(bool is_context_stream) {
-    *is_context_stream_ = is_context_stream;
+    is_context_stream_->store(is_context_stream, std::memory_order_release);
 }
 
 StreamCacheResource& GenerateStream::streamCacheResource() {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -213,6 +213,7 @@ public:
     bool   returnPromptLogits() const;
     bool   returnCumLogProbs() const;
     bool   genTimeline() const;
+    bool   genTimelineAtSeqLength(int seq_length) const;
     int    profileStep() const;
     void   setGenTimeline(bool gen_timeline);
     bool   updatePrefix(const std::shared_ptr<SystemPrompt>& system_prompt);
@@ -331,6 +332,12 @@ public:
     virtual StreamState getStatus() const;
     bool                isFinished() const;  // Returns true if stream is finished
     bool                isActive() const;    // Returns true if stream is active (no error and not finished)
+
+    // A response consumer may observe GenerateDone before the scheduler has
+    // committed RUNNING -> FINISHED. Preserve that successful completion and
+    // wait for scheduler-owned resource release; otherwise publish cancellation
+    // and wait for the same terminal transition.
+    bool finishOrCancel(int64_t wait_timeout_ms, const std::string& cancel_reason);
     bool                isSubGenerateDoneWithoutLock(int batch_id) const;
 
     size_t iterCount() const;
@@ -562,21 +569,6 @@ public:
         return sp_output_buffer_;
     }
 
-    // Opaque CUDA event used by async MTP to wait for linear-attention KV swaps
-    // without including cuda_runtime.h in this header.
-    void setPendingSwapDoneEvent(std::shared_ptr<void> event) {
-        std::lock_guard<std::mutex> lk(*pending_swap_done_event_mutex_);
-        pending_swap_done_event_ = std::move(event);
-    }
-    std::shared_ptr<void> getPendingSwapDoneEvent() const {
-        std::lock_guard<std::mutex> lk(*pending_swap_done_event_mutex_);
-        return pending_swap_done_event_;
-    }
-    void clearPendingSwapDoneEvent() {
-        std::lock_guard<std::mutex> lk(*pending_swap_done_event_mutex_);
-        pending_swap_done_event_.reset();
-    }
-
     // Count worker claims on this stream's KV resource.
     // releaseResource waits for zero so worker-side update/specUpdate cannot
     // write into blocks already returned to the pool.
@@ -595,31 +587,50 @@ public:
         torch::Tensor accept_len_gpu;
         torch::Tensor accept_tokens_gpu;
         torch::Tensor next_seq_len_gpu;
+        // Position tuple of the next round's newest committed token.  DSpARK
+        // carries this beside next_seq_len so MRoPE target-verify graphs can
+        // be prepared without consulting worker-owned host bookkeeping.
+        torch::Tensor next_position_ids_gpu;
         torch::Tensor propose_tokens_gpu;
+        // Immutable physical and logical-to-kernel page tables for the next
+        // speculative round. The async worker may still be committing the
+        // equivalent host-side swaps; model input gathering consumes this
+        // pair instead of racing the mutable BlockIds object. Keeping the pair
+        // atomic at the state level is required by hybrid models: attention
+        // consumes the physical table while recurrent kernels consume the
+        // kernel-granularity table.
+        torch::Tensor next_kv_cache_block_id_gpu;
+        torch::Tensor next_kv_cache_kernel_block_id_gpu;
         // Main-thread mirrors used when DROP_BROAD_SYNC lets the next step run
         // before worker-side specUpdate has written sp_output_buffer fields.
         torch::Tensor last_hidden_states_gpu;
         torch::Tensor draft_all_probs_gpu;
-        // True host seqLength observed when this state is published. MTP async
-        // uses it as the base for the next KV allocation upper bound.
+        // Upper bound for the sequence length represented by the previous
+        // round. It equals host seqLength when no worker is pending; otherwise
+        // it chains from the prior published bound so multiple overlapped
+        // bookkeeping rounds can never make cache allocation underestimate
+        // the device sequence.
         // -1 = unset (first iter / cleared).
-        int last_real_seq_len = -1;
-        // Host seq_len override for the next iter's incrKVBlock. In async MTP
-        // this may be an upper bound based on last_real_seq_len, not a value to
-        // chain as the next round's true length.
+        int previous_seq_len_upper_bound = -1;
+        // Conservative host-visible bound for the next iteration. It advances
+        // monotonically while workers overlap and resets to exact host state
+        // once bookkeeping catches up.
         // -1 = unset (first iter / cleared).
-        int next_real_seq_len = -1;
+        int next_seq_len_upper_bound = -1;
     };
 
     uint64_t setMtpAsyncDeviceState(MtpAsyncDeviceState state) {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         state.epoch      = ++mtp_async_epoch_counter_;
         mtp_async_state_ = std::move(state);
         return mtp_async_state_.epoch;
     }
-    const MtpAsyncDeviceState& getMtpAsyncDeviceState() const {
+    MtpAsyncDeviceState getMtpAsyncDeviceState() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         return mtp_async_state_;
     }
     bool clearMtpAsyncDeviceState(uint64_t epoch) {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         // Legacy/testing escape hatch. Active MTP decode paths should keep
         // device tensors alive and overwrite them on the next publish.
         if (mtp_async_state_.epoch != epoch) {
@@ -641,27 +652,63 @@ public:
         state.propose_tokens_gpu = std::move(propose_tokens_gpu);
         setMtpAsyncDeviceState(std::move(state));
     }
-    const torch::Tensor& getAcceptLenGpu() const {
+    torch::Tensor getAcceptLenGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         return mtp_async_state_.accept_len_gpu;
     }
-    const torch::Tensor& getAcceptTokensGpu() const {
+    torch::Tensor getAcceptTokensGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         return mtp_async_state_.accept_tokens_gpu;
     }
-    const torch::Tensor& getNextSeqLenGpu() const {
+    torch::Tensor getNextSeqLenGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         return mtp_async_state_.next_seq_len_gpu;
     }
-    const torch::Tensor& getProposeTokensGpu() const {
+    torch::Tensor getNextPositionIdsGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
+        return mtp_async_state_.next_position_ids_gpu;
+    }
+    torch::Tensor getProposeTokensGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         return mtp_async_state_.propose_tokens_gpu;
     }
-    const torch::Tensor& getLastHiddenStatesGpu() const {
+    torch::Tensor getNextKVCacheBlockIdGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
+        return mtp_async_state_.next_kv_cache_block_id_gpu;
+    }
+    torch::Tensor getNextKVCacheKernelBlockIdGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
+        return mtp_async_state_.next_kv_cache_kernel_block_id_gpu;
+    }
+    static bool hasMtpCacheSnapshot(const MtpAsyncDeviceState& state) {
+        const auto valid = [](const torch::Tensor& table) {
+            return table.defined() && table.is_cuda() && table.scalar_type() == torch::kInt32 && table.dim() == 3
+                   && table.size(1) == 1;
+        };
+        const auto& physical = state.next_kv_cache_block_id_gpu;
+        const auto& kernel   = state.next_kv_cache_kernel_block_id_gpu;
+        return valid(physical) && valid(kernel) && physical.size(0) == kernel.size(0);
+    }
+    bool hasMtpCacheSnapshot() const {
+        return hasMtpCacheSnapshot(getMtpAsyncDeviceState());
+    }
+    void clearMtpCacheSnapshot() {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
+        mtp_async_state_.next_kv_cache_block_id_gpu        = torch::Tensor();
+        mtp_async_state_.next_kv_cache_kernel_block_id_gpu = torch::Tensor();
+    }
+    torch::Tensor getLastHiddenStatesGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         return mtp_async_state_.last_hidden_states_gpu;
     }
-    const torch::Tensor& getDraftAllProbsGpu() const {
+    torch::Tensor getDraftAllProbsGpu() const {
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         return mtp_async_state_.draft_all_probs_gpu;
     }
     void clearSpecDecodeDeviceState() {
         // Unconditional legacy/testing escape hatch. Active MTP decode paths
         // should publish/overwrite MtpAsyncDeviceState instead of clearing it.
+        std::lock_guard<std::mutex> lock(*mtp_async_state_mutex_);
         mtp_async_state_ = MtpAsyncDeviceState{};
     }
 
@@ -772,6 +819,11 @@ public:
     bool     queryPdSep() const;
 
 protected:
+    // moveToNext() runs under mutex_, while the async MTP worker needs the
+    // same mutex to commit accepted tokens/cache swaps.  Decide whether a
+    // capacity-boundary join is needed before taking mutex_.
+    bool needsAsyncBookkeepingJoinForKvReservation() const;
+
     // Consumer-visible state is read and written under mutex_. Public readers
     // acquire the lock; already-locked engine paths use these helpers.
     void         checkTimeoutWithoutLock();
@@ -819,7 +871,10 @@ protected:
     bool                                  generation_done_             = false;
     int64_t                               generation_done_time_us_     = 0;
     std::shared_ptr<StreamCacheResource>  stream_cache_resource_;
-    std::shared_ptr<bool>                 is_context_stream_;
+    // Prefill-to-decode transition is committed by the output/bookkeeping
+    // worker and observed by the scheduler thread. Keep this flag atomic; the
+    // shared_ptr preserves the existing CopyOnWrite sharing semantics.
+    std::shared_ptr<std::atomic<bool>>    is_context_stream_;
     size_t                                iter_count_    = 0;
     size_t                                sp_iter_count_ = 0;
     std::vector<int32_t>                  speculative_accepted_tokens_per_pos_;
@@ -881,12 +936,6 @@ protected:
     bool                               contain_propose_token_ = false;
     int                                mtp_token_index_       = 0;
     SpeculativeExecutorStreamOutputPtr sp_output_buffer_      = nullptr;
-    // cudaEvent_t (type-erased) recorded after specUpdate runs
-    // swapLinearBlocks. MtpExecutor waits on it before issuing the next
-    // target verify. nullptr on streams without pending swaps.
-    std::shared_ptr<void>       pending_swap_done_event_;
-    std::shared_ptr<std::mutex> pending_swap_done_event_mutex_ = std::make_shared<std::mutex>();
-
     // Separate lock/cv avoids deadlocking releaseResource with worker updates
     // that need mutex_. Shared ownership preserves the coordinator across
     // GenerateStream copies captured by async workers.
@@ -901,6 +950,7 @@ protected:
     // Stream-async device-resident state for the next decode step's prepare.
     // These structs stay default-constructed (epoch=0, undefined tensors) until
     // their corresponding async/sync publisher installs a usable state.
+    std::shared_ptr<std::mutex>        mtp_async_state_mutex_ = std::make_shared<std::mutex>();
     MtpAsyncDeviceState                mtp_async_state_;
     uint64_t                           mtp_async_epoch_counter_ = 0;
     NormalAsyncDeviceState             normal_async_state_;

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -247,8 +247,8 @@ static bool applyP2PSideChannelToStream(const std::shared_ptr<FusedAsyncReadCont
                 .propose_tokens_gpu     = std::move(propose_tokens_gpu),
                 .last_hidden_states_gpu = sp_output_buffer->hidden_states,
                 .draft_all_probs_gpu    = sp_output_buffer->all_probs,
-                .last_real_seq_len      = stream->seqLength(),
-                .next_real_seq_len      = stream->seqLength(),
+                .previous_seq_len_upper_bound = stream->seqLength(),
+                .next_seq_len_upper_bound     = stream->seqLength(),
             });
         }
         RTP_LLM_LOG_DEBUG("applyP2PSideChannel: propose_tokens count=%zu", payload->propose_tokens.size());

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -495,6 +495,10 @@ bool StreamCacheResource::asyncLoadCache() {
     if (load_cache_once_.exchange(true)) {
         return true;
     }
+    return submitAsyncLoadCache();
+}
+
+bool StreamCacheResource::submitAsyncLoadCache() {
     auto meta = std::make_shared<MetaImpl>(
         reuseCache() && enableMemoryCache(), reuseCache() && enableRemoteCache(), stream_->traceId());
     meta->generate_stream_ = stream_;
@@ -511,11 +515,10 @@ bool StreamCacheResource::loadCacheDone() {
     if (!load_cache_context_->done()) {
         return false;  // coordinator 后台线程尚未处理完
     }
-    // 加载完成（无论成功失败），更新 reuse lengths
-    waitLoadCacheDone(load_cache_context_);
-    if (!load_cache_context_->success()) {
+    const auto completed_context = load_cache_context_;
+    if (!completed_context->success()) {
         // 区分匹配失败和传输失败
-        auto      read_context = std::dynamic_pointer_cast<FusedAsyncReadContext>(load_cache_context_);
+        auto      read_context = std::dynamic_pointer_cast<FusedAsyncReadContext>(completed_context);
         bool      should_retry = false;
         const int max_retry    = resource_context_.load_cache_retry_times;
         if (read_context && read_context->fusedMatchContext()) {
@@ -544,6 +547,10 @@ bool StreamCacheResource::loadCacheDone() {
             }
         }
 
+        // A retryable transfer failure must not mark the stream failed before
+        // the retry budget is exhausted. Non-retryable failures preserve the
+        // existing synchronous error-reporting behavior.
+        waitLoadCacheDone(completed_context, !should_retry);
         load_cache_context_.reset();
 
         if (should_retry) {
@@ -560,13 +567,23 @@ bool StreamCacheResource::loadCacheDone() {
                 return true;
             }
             load_cache_retry_count_++;
-            asyncLoadCache();
+            if (!submitAsyncLoadCache()) {
+                RTP_LLM_LOG_WARNING("load cache retry submission failed at retry %d/%d, stream: [%ld]",
+                                    load_cache_retry_count_,
+                                    max_retry,
+                                    stream_->streamId());
+                stream_->reportEventWithoutLock(
+                    StreamEvents::Error, ErrorCode::LOAD_CACHE_TIMEOUT, "load cache retry submission failed");
+                releaseResource();
+                return true;
+            }
             return false;  // 失败重试
         } else {
             // 匹配失败：不重试，继续执行
             return true;
         }
     }
+    waitLoadCacheDone(completed_context);
     load_cache_context_.reset();
     return true;
 }
@@ -676,7 +693,7 @@ void StreamCacheResource::loadCacheSync() {
     // TODO: scheduler will call incrkvblock after load cache, or may lack block on p2p connector
 }
 
-void StreamCacheResource::waitLoadCacheDone(const std::shared_ptr<AsyncContext>& load_context) {
+void StreamCacheResource::waitLoadCacheDone(const std::shared_ptr<AsyncContext>& load_context, bool report_error) {
     RTP_LLM_PROFILE_FUNCTION();
     if (!load_context) {
         return;
@@ -687,7 +704,7 @@ void StreamCacheResource::waitLoadCacheDone(const std::shared_ptr<AsyncContext>&
         RTP_LLM_LOG_WARNING("load cache done but not success, stream: [%s], error: %s",
                             stream_->streamLogTag().c_str(),
                             error.ToString().c_str());
-        if (error.hasError()) {
+        if (report_error && error.hasError()) {
             // loadCacheDone() is called from moveToNext(), which already holds the stream mutex.
             stream_->reportErrorWithoutLock(error.code(), error.ToString());
         }

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
@@ -125,7 +125,8 @@ public:
 
 private:
     void loadCacheSync();
-    void waitLoadCacheDone(const std::shared_ptr<AsyncContext>& load_context);
+    bool submitAsyncLoadCache();
+    void waitLoadCacheDone(const std::shared_ptr<AsyncContext>& load_context, bool report_error = true);
     void updateReuseLengthsFromContext(const std::shared_ptr<FusedAsyncReadContext>& read_context);
     std::shared_ptr<AsyncContext> storeCacheAsync(const std::shared_ptr<BatchKVCacheResource>& batch_resource,
                                                   bool                                         enable_memory_cache,

--- a/rtp_llm/cpp/engine_base/stream/StreamGroups.h
+++ b/rtp_llm/cpp/engine_base/stream/StreamGroups.h
@@ -23,12 +23,28 @@ public:
 
     StreamGroups(const std::list<GenerateStreamPtr>& streams) {
         for (auto& stream : streams) {
-            auto cur_batch_size  = stream->currentBatchSize();
-            auto next_batch_size = stream->nextBatchSize();
+            // A cache snapshot is published only for an established decode
+            // stream. Avoid reading is_context_stream_ while the prior worker
+            // redundantly commits the same decode state.
+            const auto mtp_state        = stream->getMtpAsyncDeviceState();
+            const bool use_mtp_snapshot = GenerateStream::hasMtpCacheSnapshot(mtp_state);
+            const bool is_context       = use_mtp_snapshot ? false : stream->isContextStream();
+            // A speculative stream is admitted only with one fixed sequence.
+            // currentBatchSize()/nextBatchSize() derive their answer from the
+            // mutable output-token history, which belongs to the bookkeeping
+            // worker while a device snapshot is active. Do not read that
+            // history merely to rediscover the invariant batch size.
+            if (use_mtp_snapshot) {
+                RTP_LLM_CHECK_WITH_INFO(stream->maxBatchSize() == 1 && !stream->hasNumBeams(),
+                                        "MTP cache snapshots require one non-beam sequence per stream, stream=%ld",
+                                        stream->streamId());
+            }
+            const auto cur_batch_size  = use_mtp_snapshot ? 1 : stream->currentBatchSize();
+            const auto next_batch_size = use_mtp_snapshot ? 1 : stream->nextBatchSize();
             if (stream->isFakeStream()) {
                 is_fake_stream_ = true;
             }
-            if (stream->isContextStream()) {
+            if (is_context) {
                 context_streams_.push_back(stream);
                 total_context_batch_size_ += cur_batch_size;
                 max_context_seq_len_ = std::max(max_context_seq_len_, (size_t)stream->contextLength());
@@ -41,18 +57,25 @@ public:
             } else {
                 decode_streams_.push_back(stream);
                 total_decode_batch_size_ += cur_batch_size;
-                if (!has_multimodal_input_ && stream->multimodalFeaturesLength() > 0) {
+                // Decode does not consume multimodal feature tensors. Avoid
+                // multimodalFeaturesLength(), which also derives a multiplier
+                // from worker-owned output-token history.
+                if (!use_mtp_snapshot && !has_multimodal_input_ && stream->multimodalFeaturesLength() > 0) {
                     has_multimodal_input_ = true;
                 }
             }
             auto block_update_copy_num = stream->streamCacheResource().getKVBlockUpdateMapping().size();
-            if (stream->isContextStream()) {
+            if (is_context) {
                 context_block_update_copy_num_ += block_update_copy_num;
             } else {
                 decode_block_update_copy_num_ += block_update_copy_num;
             }
-            auto execute_token_size = static_cast<size_t>(stream->currentExecuteTokenSize());
-            if (stream->isContextStream()) {
+            // A decode round always executes one input row per live sequence.
+            // While an async MTP commit is pending, complete_token_ids is
+            // worker-owned; do not read it merely to rediscover cur_batch_size.
+            auto execute_token_size = use_mtp_snapshot ? static_cast<size_t>(cur_batch_size) :
+                                                         static_cast<size_t>(stream->currentExecuteTokenSize());
+            if (is_context) {
                 auto reuse_length = stream->reuseLength();
                 context_execute_token_size_ += execute_token_size;
                 context_execute_token_size_with_cache_ += execute_token_size;
@@ -61,18 +84,27 @@ public:
                 }
             }
             model_execute_token_size_ += execute_token_size;
-            total_sampler_batch_size_in_ += stream->needTilingForSampling() ? next_batch_size : cur_batch_size;
+            total_sampler_batch_size_in_ +=
+                !use_mtp_snapshot && stream->needTilingForSampling() ? next_batch_size : cur_batch_size;
             total_sampler_batch_size_out_ += next_batch_size;
             max_blocks_num_ = std::max(max_blocks_num_, stream->curBlocksNum());
-            if (stream->hasCacheKeys()) {
+            // cache_keys are context/CacheStore metadata and are not consumed
+            // by a decode-only model input.  Avoid traversing them while the
+            // speculative worker updates the corresponding token history.
+            if (!use_mtp_snapshot && stream->hasCacheKeys()) {
                 for (int32_t batch_id = 0; batch_id < cur_batch_size; ++batch_id) {
                     max_cache_keys_num_ = std::max(max_cache_keys_num_, stream->cacheKeys(batch_id).size());
                 }
             }
-            max_seq_len_ = std::max(max_seq_len_, (size_t)stream->seqLength());
+            const int    snapshot_seq_len = mtp_state.next_seq_len_upper_bound;
+            const size_t seq_len          = use_mtp_snapshot && snapshot_seq_len > 0 ?
+                                                static_cast<size_t>(snapshot_seq_len) :
+                                                static_cast<size_t>(stream->seqLength());
+            max_seq_len_                  = std::max(max_seq_len_, seq_len);
             total_score_batch_size_ += stream->scoreLen();
             adapter_names.push_back(stream->adapterName());
-            gen_timeline_ |= stream->genTimeline();
+            gen_timeline_ |= use_mtp_snapshot ? stream->genTimelineAtSeqLength(static_cast<int>(seq_len)) :
+                                                stream->genTimeline();
         }
     }
 

--- a/rtp_llm/cpp/engine_base/stream/test/GenerateStreamTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/GenerateStreamTest.cc
@@ -293,6 +293,53 @@ TEST_F(GenerateStreamTest, pendingCompletionIsConsumerVisibleBeforeSchedulerComm
     EXPECT_TRUE(stream->stream_cache_resource_->isResourceReleased());
 }
 
+TEST_F(GenerateStreamTest, finishOrCancelPreservesPendingSuccessfulCompletion) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createComplexContextStream({1, 2, 3}));
+    stream->setNeedReleaseResource(true);
+    stream->generate_status_->status.store(StreamState::RUNNING);
+    stream->reportEvent(StreamEvents::GenerateDone);
+
+    std::promise<void> stop_started;
+    auto               stop_ready = stop_started.get_future();
+    auto               stop_result = std::async(std::launch::async, [stream, &stop_started] {
+        stop_started.set_value();
+        return stream->finishOrCancel(1000, "cancel stream");
+    });
+    stop_ready.get();
+    EXPECT_EQ(stop_result.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
+    EXPECT_FALSE(stream->hasError());
+
+    EXPECT_EQ(stream->moveToNext(), StreamState::FINISHED);
+    EXPECT_TRUE(stop_result.get());
+    EXPECT_FALSE(stream->hasError());
+    EXPECT_TRUE(stream->stream_cache_resource_->isResourceReleased());
+}
+
+TEST_F(GenerateStreamTest, finishOrCancelCancelsIncompleteStreamAndWaitsForCommit) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createComplexContextStream({1, 2, 3}));
+    stream->setNeedReleaseResource(true);
+    stream->generate_status_->status.store(StreamState::RUNNING);
+
+    std::promise<void> stop_started;
+    auto               stop_ready = stop_started.get_future();
+    auto               stop_result = std::async(std::launch::async, [stream, &stop_started] {
+        stop_started.set_value();
+        return stream->finishOrCancel(1000, "client closed");
+    });
+    stop_ready.get();
+    for (int i = 0; i < 100 && !stream->hasError(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(stream->hasError());
+    EXPECT_EQ(stream->statusInfo().code(), ErrorCode::CANCELLED);
+
+    EXPECT_EQ(stream->moveToNext(), StreamState::FINISHED);
+    EXPECT_TRUE(stop_result.get());
+    EXPECT_TRUE(stream->stream_cache_resource_->isResourceReleased());
+}
+
 TEST_F(GenerateStreamTest, nextOutputDrainsFinalOutputBeforeCompletion) {
     auto builder = GenerateStreamBuilder();
     auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
@@ -669,12 +716,58 @@ TEST_F(GenerateStreamTest, testMtpAsyncDeviceStateTracksRealAndUpperBoundSeqLen)
     auto stream  = builder.createContextStream({1, 2, 3, 4, 5, 6});
 
     GenerateStream::MtpAsyncDeviceState state;
-    state.last_real_seq_len = stream->seqLength();
-    state.next_real_seq_len = state.last_real_seq_len + 2;
+    state.previous_seq_len_upper_bound = stream->seqLength();
+    state.next_seq_len_upper_bound     = state.previous_seq_len_upper_bound + 2;
     stream->setMtpAsyncDeviceState(std::move(state));
 
-    ASSERT_EQ(stream->getMtpAsyncDeviceState().last_real_seq_len, stream->seqLength());
-    ASSERT_EQ(stream->getMtpAsyncDeviceState().next_real_seq_len, stream->seqLength() + 2);
+    ASSERT_EQ(stream->getMtpAsyncDeviceState().previous_seq_len_upper_bound, stream->seqLength());
+    ASSERT_EQ(stream->getMtpAsyncDeviceState().next_seq_len_upper_bound, stream->seqLength() + 2);
+}
+
+TEST_F(GenerateStreamTest, testMtpAsyncDeviceStatePublishesCoherentConcurrentSnapshots) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = builder.createContextStream({1, 2, 3, 4, 5, 6});
+
+    constexpr int       publishes_per_writer = 1000;
+    std::atomic<bool>   start{false};
+    std::atomic<bool>   writers_done{false};
+    std::atomic<bool>   incoherent_snapshot{false};
+    std::vector<std::thread> writers;
+    for (int writer_id = 0; writer_id < 2; ++writer_id) {
+        writers.emplace_back([&, writer_id] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            for (int i = 1; i <= publishes_per_writer; ++i) {
+                const int marker = writer_id * publishes_per_writer + i;
+                GenerateStream::MtpAsyncDeviceState state;
+                state.previous_seq_len_upper_bound = marker;
+                state.next_seq_len_upper_bound     = marker;
+                stream->setMtpAsyncDeviceState(std::move(state));
+            }
+        });
+    }
+    std::thread reader([&] {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        while (!writers_done.load(std::memory_order_acquire)) {
+            const auto state = stream->getMtpAsyncDeviceState();
+            if (state.epoch != 0 && state.previous_seq_len_upper_bound != state.next_seq_len_upper_bound) {
+                incoherent_snapshot.store(true, std::memory_order_release);
+            }
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    for (auto& writer : writers) {
+        writer.join();
+    }
+    writers_done.store(true, std::memory_order_release);
+    reader.join();
+
+    EXPECT_FALSE(incoherent_snapshot.load(std::memory_order_acquire));
+    EXPECT_EQ(stream->getMtpAsyncDeviceState().epoch, 2u * publishes_per_writer);
 }
 
 // setSpecDecodeDeviceState / clearSpecDecodeDeviceState

--- a/rtp_llm/cpp/engine_base/stream/test/StreamCacheResourceTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/StreamCacheResourceTest.cc
@@ -822,6 +822,48 @@ TEST_F(StreamCacheResourceTest, testAsyncLoadCache_ThenLoadCacheDone_UpdatesReus
     EXPECT_EQ(stream_->memoryReuseLength(), memory_reuse_len);
 }
 
+TEST_F(StreamCacheResourceTest, testAsyncLoadCache_ThenLoadCacheDone_AttributesRemoteReuse) {
+    prepareResource(/*reuse_cache=*/true);
+    auto& resource = stream_->streamCacheResource();
+
+    stream_->generate_input_->generate_config->reuse_cache         = true;
+    resource.resource_context_.enable_remote_cache                 = true;
+    stream_->generate_input_->generate_config->enable_remote_cache = true;
+
+    auto mock_coord =
+        std::make_shared<testing::NiceMock<MockKVCacheConnectorCoordinator>>(cache_manager_->config_,
+                                                                             cache_manager_->kv_cache_config_,
+                                                                             cache_manager_->runtime_config_,
+                                                                             cache_manager_->allocator_);
+    ON_CALL(*mock_coord, hasActiveConnectors()).WillByDefault(testing::Return(true));
+    cache_manager_->coordinator_ = mock_coord;
+
+    auto match_child = std::make_shared<testing::NiceMock<MockAsyncContext>>();
+    ON_CALL(*match_child, done()).WillByDefault(testing::Return(true));
+    ON_CALL(*match_child, success()).WillByDefault(testing::Return(true));
+    auto fused_match = std::make_shared<FusedAsyncContext>(std::vector<std::shared_ptr<AsyncContext>>{match_child});
+
+    auto kv_resource = std::make_shared<KVCacheResource>();
+    kv_resource->setRemoteReuseBlockNum(1);
+
+    std::shared_ptr<Meta> meta;
+    auto                  load_ctx = std::make_shared<FusedAsyncReadContext>(fused_match, kv_resource, meta);
+    load_ctx->setFusedReadContext(nullptr);
+
+    EXPECT_CALL(*mock_coord, asyncRead(testing::_))
+        .WillOnce(testing::Return(std::static_pointer_cast<AsyncContext>(load_ctx)));
+
+    ASSERT_TRUE(resource.initKVBlock().ok());
+    ASSERT_TRUE(resource.asyncLoadCache());
+    ASSERT_TRUE(resource.loadCacheDone());
+
+    const int remote_reuse_len = resource.seqSizePerBlock();
+    EXPECT_EQ(stream_->initialReuseLength(), remote_reuse_len);
+    EXPECT_EQ(stream_->reuseLength(), remote_reuse_len);
+    EXPECT_EQ(stream_->localReuseLength(), 0);
+    EXPECT_EQ(stream_->remoteReuseLength(), remote_reuse_len);
+}
+
 TEST_F(StreamCacheResourceTest, testP2PSideChannelRestoresZeroFirstTokenAndMtpState) {
     prepareResourceWithInputTokens({1, 2, 3}, /*reuse_cache=*/true);
     stream_->vocab_size_ = 16;

--- a/rtp_llm/cpp/engine_base/stream/test/StreamCacheResourceTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/StreamCacheResourceTest.cc
@@ -13,6 +13,7 @@
 #include "rtp_llm/cpp/cache/connector/Meta.h"
 #include "rtp_llm/cpp/cache/connector/p2p/P2PConnectorAsyncContext.h"
 #include "rtp_llm/cpp/cache/connector/test/mock/MockAsyncContext.h"
+#include "rtp_llm/cpp/cache/connector/test/mock/MockKVCacheConnector.h"
 #include "rtp_llm/cpp/cache/connector/test/mock/MockKVCacheConnectorCoordinator.h"
 #include "rtp_llm/cpp/cache/KVCacheResource.h"
 #include "rtp_llm/cpp/engine_base/stream/GenerateStream.h"
@@ -775,6 +776,65 @@ TEST_F(StreamCacheResourceTest, testLoadCacheDone_Done_ReturnsTrue_ClearsContext
 
     // Subsequent call returns true (no context)
     ASSERT_TRUE(resource.loadCacheDone());
+}
+
+TEST_F(StreamCacheResourceTest, testLoadCacheDone_TransferFailureRetriesThenSucceeds) {
+    prepareResource(/*reuse_cache=*/true);
+    auto& resource = stream_->streamCacheResource();
+
+    stream_->generate_input_->generate_config->reuse_cache         = true;
+    resource.resource_context_.enable_memory_cache                 = true;
+    resource.resource_context_.load_cache_retry_times              = 1;
+    stream_->generate_input_->generate_config->enable_memory_cache = true;
+
+    auto mock_coord =
+        std::make_shared<testing::NiceMock<MockKVCacheConnectorCoordinator>>(cache_manager_->config_,
+                                                                             cache_manager_->kv_cache_config_,
+                                                                             cache_manager_->runtime_config_,
+                                                                             cache_manager_->allocator_);
+    ON_CALL(*mock_coord, hasActiveConnectors()).WillByDefault(testing::Return(true));
+    cache_manager_->coordinator_ = mock_coord;
+
+    auto match_child = std::make_shared<testing::NiceMock<MockAsyncMatchContext>>();
+    ON_CALL(*match_child, done()).WillByDefault(testing::Return(true));
+    ON_CALL(*match_child, success()).WillByDefault(testing::Return(true));
+    ON_CALL(*match_child, matchedBlockCount()).WillByDefault(testing::Return(1));
+    auto fused_match = std::make_shared<FusedAsyncContext>(
+        std::vector<std::shared_ptr<AsyncContext>>{std::static_pointer_cast<AsyncContext>(match_child)});
+
+    auto failed_read = std::make_shared<testing::NiceMock<MockAsyncContext>>();
+    ON_CALL(*failed_read, done()).WillByDefault(testing::Return(true));
+    ON_CALL(*failed_read, success()).WillByDefault(testing::Return(false));
+    ON_CALL(*failed_read, errorInfo())
+        .WillByDefault(testing::Return(ErrorInfo(ErrorCode::LOAD_CACHE_TIMEOUT, "first transfer failed")));
+    auto failed_fused_read = std::make_shared<FusedAsyncContext>(
+        std::vector<std::shared_ptr<AsyncContext>>{std::static_pointer_cast<AsyncContext>(failed_read)});
+    auto failed_resource = std::make_shared<KVCacheResource>();
+    failed_resource->setMemoryReuseBlockNum(1);
+    auto failed_context = std::make_shared<FusedAsyncReadContext>(fused_match, failed_resource, nullptr);
+    failed_context->setFusedReadContext(failed_fused_read);
+
+    auto successful_resource = std::make_shared<KVCacheResource>();
+    successful_resource->setMemoryReuseBlockNum(1);
+    auto successful_context = std::make_shared<FusedAsyncReadContext>(fused_match, successful_resource, nullptr);
+    successful_context->setFusedReadContext(nullptr);
+
+    EXPECT_CALL(*mock_coord, asyncRead(testing::_))
+        .WillOnce(testing::Return(std::static_pointer_cast<AsyncContext>(failed_context)))
+        .WillOnce(testing::Return(std::static_pointer_cast<AsyncContext>(successful_context)));
+
+    ASSERT_TRUE(resource.initKVBlock().ok());
+    ASSERT_TRUE(resource.asyncLoadCache());
+
+    EXPECT_FALSE(resource.loadCacheDone());
+    EXPECT_FALSE(stream_->hasError());
+    EXPECT_EQ(resource.load_cache_retry_count_, 1);
+    EXPECT_EQ(resource.load_cache_context_, successful_context);
+
+    EXPECT_TRUE(resource.loadCacheDone());
+    EXPECT_FALSE(stream_->hasError());
+    EXPECT_EQ(resource.load_cache_context_, nullptr);
+    EXPECT_EQ(stream_->memoryReuseLength(), resource.seqSizePerBlock());
 }
 
 TEST_F(StreamCacheResourceTest, testAsyncLoadCache_ThenLoadCacheDone_UpdatesReuseLength) {

--- a/rtp_llm/cpp/model_rpc/DecodeRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/DecodeRpcServer.cc
@@ -576,7 +576,7 @@ void DecodeRpcServer::localGenerate(DecodeGenerateContext& decode_context) {
             // The per-step refresher (MtpExecutor's device-state publish) is gated
             // on RTP_LLM_STREAM_ASYNC / RTP_LLM_MTP_ASYNC_DEVICE_STATE. Publishing
             // this static snapshot without those pipelines active would leave a
-            // stale next_real_seq_len that overrides incrKVBlock forever (same
+            // stale next_seq_len_upper_bound that overrides incrKVBlock forever (same
             // failure mode as the normal-decode grpc device state).
             auto env_on = [](const char* name) {
                 const char* value = std::getenv(name);
@@ -591,8 +591,8 @@ void DecodeRpcServer::localGenerate(DecodeGenerateContext& decode_context) {
                     .propose_tokens_gpu     = std::move(propose_tokens_gpu),
                     .last_hidden_states_gpu = sp_output_buffer->hidden_states,
                     .draft_all_probs_gpu    = sp_output_buffer->all_probs,
-                    .last_real_seq_len      = generate_stream->seqLength(),
-                    .next_real_seq_len      = generate_stream->seqLength(),
+                    .previous_seq_len_upper_bound = generate_stream->seqLength(),
+                    .next_seq_len_upper_bound     = generate_stream->seqLength(),
                 });
             }
         }

--- a/rtp_llm/cpp/model_rpc/DecodeRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/DecodeRpcServer.cc
@@ -1,7 +1,9 @@
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <mutex>
 #include <memory>
+#include <thread>
 #include <unistd.h>
 #include <limits.h>
 #include <condition_variable>
@@ -250,6 +252,16 @@ size_t DecodeRpcServer::minLoadedCacheBlockCount(const std::vector<size_t>& rank
     return *std::min_element(rank_loaded_cache_block_counts.begin(), rank_loaded_cache_block_counts.end());
 }
 
+ErrorInfo DecodeRpcServer::validateRemoteLoadTopology(size_t worker_size, size_t peer_size) {
+    if (worker_size == 0 || peer_size == 0) {
+        return ErrorInfo(ErrorCode::LOAD_KV_CACHE_FAILED, "worker or peer address list is empty");
+    }
+    if (worker_size % peer_size != 0 && peer_size % worker_size != 0) {
+        return ErrorInfo(ErrorCode::LOAD_KV_CACHE_FAILED, "peer address count is not compatible with worker count");
+    }
+    return ErrorInfo::OkStatus();
+}
+
 std::vector<size_t> DecodeRpcServer::completionQueueExpectedResponseCounts(size_t worker_size) {
     const size_t        completion_queue_count = (worker_size + 1) / 2;
     std::vector<size_t> expected_response_counts(completion_queue_count, 0);
@@ -371,29 +383,113 @@ void DecodeRpcServer::allocateResource(DecodeGenerateContext& decode_context) {
     decode_context.request_info = input->request_info;
     auto generate_stream        = engine_->makeStream(input);
     decode_context.setRequestTimeoutMs(generate_stream->getTimeoutMs());
-
-    // Set CanRun event so that handleWaiting() will execute initKVBlock()
-    generate_stream->reportEvent(StreamEvents::CanRun);
     decode_context.setStream(generate_stream);
 
-    // WAITING -> LOADING_CACHE -> WAITING, 直到load cache完成并移动到 WAITING 状态
-    // NOTE: 此处的 busy-wait 是安全的，因为 stream 尚未 enqueue 到 scheduler，
-    // 不会与其他线程并发调用 moveToNext()。gRPC 线程独占驱动状态机直到 WAITING。
-    while (!generate_stream->hasError() && generate_stream->moveToNext() == StreamState::LOADING_CACHE) {
-        this_thread::sleep_for(chrono::milliseconds(1));
-    }
-    if (generate_stream->hasError()) {
-        auto   stream_error = generate_stream->statusInfo();
-        string error_msg    = stream_error.ToString();
-        if (error_msg.empty()) {
-            error_msg = "malloc kv cache block failed at decode node";
+    auto cache_manager = engine_->getCacheManager();
+    RTP_LLM_CHECK_WITH_INFO(cache_manager != nullptr, "decode cache manager is null");
+
+    const auto& pd_config            = maga_init_params_.pd_sep_config;
+    const auto  allocation_begin_us  = currentTimeUs();
+    const auto  cancellation_poll_ms = std::max<int64_t>(pd_config.decode_retry_interval_ms, 50);
+
+    auto finish_allocation_error = [&](grpc::StatusCode grpc_code, ErrorCode error_code, const std::string& message) {
+        const std::string error_msg = "request: [" + decode_context.request_key + "] " + message;
+        generate_stream->reportError(error_code, error_msg);
+        // The stream has not entered the scheduler yet, so the RPC thread owns this final transition.
+        // Committing FINISHED here releases any partially allocated resource and prevents stopStream()
+        // from waiting for a scheduler that has never seen the stream.
+        generate_stream->moveToNext();
+        decode_context.error_info   = ErrorInfo(error_code, error_msg);
+        decode_context.error_status = grpc::Status(grpc_code, error_msg);
+        RTP_LLM_LOG_ERROR("%s", error_msg.c_str());
+    };
+
+    int64_t allocation_attempts = 0;
+    while (true) {
+        const auto request_cost_ms = (currentTimeUs() - decode_context.request_begin_time_us) / 1000;
+        if (decode_context.request_timeout_ms > 0 && request_cost_ms >= decode_context.request_timeout_ms) {
+            finish_allocation_error(grpc::StatusCode::DEADLINE_EXCEEDED,
+                                    ErrorCode::GENERATE_TIMEOUT,
+                                    "decode allocation exceeded request timeout");
+            return;
         }
-        error_msg = "request: [" + decode_context.request_key + "] " + error_msg;
-        RTP_LLM_LOG_ERROR(error_msg);
-        decode_context.error_info = ErrorInfo(stream_error.code(), error_msg);
-        decode_context.error_status =
-            serializeErrorMsg(decode_context.request_key, decode_context.request_info, decode_context.error_info);
-        return;
+        if (decode_context.isRequestCancelled()) {
+            finish_allocation_error(
+                grpc::StatusCode::CANCELLED, ErrorCode::CANCELLED, "decode allocation cancelled by client");
+            return;
+        }
+
+        const auto observed_generation = cache_manager->allocationGeneration();
+        const auto allocation_status   = generate_stream->streamCacheResource().initKVBlock();
+        ++allocation_attempts;
+        decode_context.retry_times        = allocation_attempts;
+        decode_context.retry_cost_time_ms = (currentTimeUs() - allocation_begin_us) / 1000;
+
+        if (allocation_status.ok()) {
+            // Preserve the decode-side connector lookup that the old state-machine-driven
+            // allocation performed before the explicit P/D handoff.  Besides avoiding a redundant
+            // transfer for an already cached prefix, this is what attributes that prefix to the
+            // decode remote-cache counters.  The explicit P/D handoff below still fills the suffix.
+            auto& cache_resource = generate_stream->streamCacheResource();
+            if (cache_resource.asyncLoadCache()) {
+                generate_stream->recordLoadingCacheStartTime();
+                while (!cache_resource.loadCacheDone()) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+                generate_stream->recordLoadingCacheDoneTime();
+            }
+
+            if (generate_stream->hasError()) {
+                const auto  stream_error = generate_stream->statusInfo();
+                std::string error_msg    = stream_error.ToString();
+                if (error_msg.empty()) {
+                    error_msg = "decode initial cache load failed";
+                }
+                error_msg = "request: [" + decode_context.request_key + "] " + error_msg;
+                decode_context.error_info   = ErrorInfo(stream_error.code(), error_msg);
+                decode_context.error_status =
+                    serializeErrorMsg(decode_context.request_key,
+                                      decode_context.request_info,
+                                      decode_context.error_info);
+                RTP_LLM_LOG_ERROR("%s", error_msg.c_str());
+                return;
+            }
+
+            // Allocation and the optional connector lookup are complete. Mark the initial load
+            // phase as initiated so FIFO admission performs only the post-handoff incremental
+            // reservation and never repeats initKVBlock()/asyncLoadCache().
+            generate_stream->reportEvent(StreamEvents::LoadInitiated);
+            break;
+        }
+
+        if (!absl::IsUnavailable(allocation_status)) {
+            const auto grpc_code = absl::IsResourceExhausted(allocation_status) ? grpc::StatusCode::RESOURCE_EXHAUSTED :
+                                                                                  grpc::StatusCode::INTERNAL;
+            finish_allocation_error(grpc_code, ErrorCode::MALLOC_FAILED, allocation_status.ToString());
+            return;
+        }
+
+        int64_t wait_ms = cancellation_poll_ms;
+        if (decode_context.request_timeout_ms > 0) {
+            wait_ms = std::min(wait_ms, decode_context.request_timeout_ms - request_cost_ms);
+        }
+        wait_ms = std::max<int64_t>(wait_ms, 1);
+
+        // Temporary KV pressure is admission backpressure, not a failed RPC stage.  The legacy
+        // DECODE_RETRY_{TIMES,TIMEOUT_MS} limits bound re-execution after stage errors; applying
+        // them here rejects healthy queued requests (the production default is only 100 ms).
+        // Capacity wait therefore follows the request's own deadline/cancellation.  Timed wakeups
+        // only service those stop conditions; a new allocator attempt is made exclusively after
+        // the resource generation changes, avoiding the old 1 ms malloc storm.
+        while (!cache_manager->waitForAllocationChange(observed_generation, wait_ms)) {
+            const auto now_request_cost_ms    = (currentTimeUs() - decode_context.request_begin_time_us) / 1000;
+            decode_context.retry_cost_time_ms = (currentTimeUs() - allocation_begin_us) / 1000;
+            if (decode_context.isRequestCancelled()
+                || (decode_context.request_timeout_ms > 0
+                    && now_request_cost_ms >= decode_context.request_timeout_ms)) {
+                break;
+            }
+        }
     }
 
     GRPC_RET_IF_ERROR(decode_context,
@@ -584,13 +680,13 @@ void DecodeRpcServer::localGenerate(DecodeGenerateContext& decode_context) {
             };
             if (env_on("RTP_LLM_STREAM_ASYNC") || env_on("RTP_LLM_MTP_ASYNC_DEVICE_STATE")) {
                 generate_stream->setMtpAsyncDeviceState(GenerateStream::MtpAsyncDeviceState{
-                    .epoch                  = 0,
-                    .accept_len_gpu         = std::move(accept_len),
-                    .accept_tokens_gpu      = std::move(accept_tokens),
-                    .next_seq_len_gpu       = std::move(next_seq_len),
-                    .propose_tokens_gpu     = std::move(propose_tokens_gpu),
-                    .last_hidden_states_gpu = sp_output_buffer->hidden_states,
-                    .draft_all_probs_gpu    = sp_output_buffer->all_probs,
+                    .epoch                        = 0,
+                    .accept_len_gpu               = std::move(accept_len),
+                    .accept_tokens_gpu            = std::move(accept_tokens),
+                    .next_seq_len_gpu             = std::move(next_seq_len),
+                    .propose_tokens_gpu           = std::move(propose_tokens_gpu),
+                    .last_hidden_states_gpu       = sp_output_buffer->hidden_states,
+                    .draft_all_probs_gpu          = sp_output_buffer->all_probs,
                     .previous_seq_len_upper_bound = generate_stream->seqLength(),
                     .next_seq_len_upper_bound     = generate_stream->seqLength(),
                 });
@@ -728,13 +824,14 @@ DecodeRpcServer::LoadCacheResult DecodeRpcServer::loadCacheForAllRank(DecodeGene
     auto&       cache_keys         = generate_stream->cacheKeys(0);
     const auto& block_ids_by_group = generate_stream->kvCachePtr()->groupBlocks(0);
 
-    if (resource_.workers.size() % decode_context.peer_addrs.size() != 0
-        && decode_context.peer_addrs.size() % resource_.workers.size() != 0) {
-        RTP_LLM_LOG_WARNING("request:[%s] peer ips size %d not equal to worker size %d",
+    const auto topology_error = validateRemoteLoadTopology(resource_.workers.size(), decode_context.peer_addrs.size());
+    if (!topology_error.ok()) {
+        RTP_LLM_LOG_WARNING("request:[%s] invalid remote load topology: peer count=%zu worker count=%zu error=%s",
                             decode_context.request_key.c_str(),
                             decode_context.peer_addrs.size(),
-                            resource_.workers.size());
-        return {ErrorInfo(ErrorCode::LOAD_KV_CACHE_FAILED, "peer ips size not equal to worker size"), 0};
+                            resource_.workers.size(),
+                            topology_error.ToString().c_str());
+        return {topology_error, 0};
     }
 
     auto load_cache_timeout_ms = maga_init_params_.pd_sep_config.load_cache_timeout_ms;
@@ -1455,13 +1552,6 @@ GroupBlockIds DecodeRpcServer::decodeGroupBlockIds(const BroadcastLoadRequestPB&
     return block_ids_by_group;
 }
 
-grpc::Status DecodeRpcServer::allocateResourceFunc(DecodeGenerateContext& decode_context) {
-    CHECK_REQUEST_STOP(decode_context)
-    allocateResource(decode_context);
-    CHECK_ERROR_STATUS(decode_context)
-    return grpc::Status::OK;
-}
-
 // Report a terminal early failure to FlexLB via finishedTaskInfo so the scheduler can clean up its
 // inflight entry immediately instead of waiting for the 300s TTL eviction. finishTask() removes the
 // running entry first, so the fallback dequeue in ~GenerateContext() becomes a no-op afterwards and
@@ -1534,10 +1624,6 @@ grpc::Status DecodeRpcServer::RemoteGenerate(grpc::ServerContext* server_context
         }
     });
 
-    auto max_retry_times      = maga_init_params_.pd_sep_config.decode_retry_times;
-    auto max_retry_timeout_ms = maga_init_params_.pd_sep_config.decode_retry_timeout_ms;
-    int  retry_interval_ms    = maga_init_params_.pd_sep_config.decode_retry_interval_ms;
-
     try {
         EXECUTE_STAGE_FUNC(prepareGenerateContext, decode_context);
         if (decode_context.trace_span_guard) {
@@ -1547,20 +1633,15 @@ grpc::Status DecodeRpcServer::RemoteGenerate(grpc::ServerContext* server_context
                                                           std::to_string(decode_context.request_id));
             decode_context.trace_span_guard->setAttribute(telemetry::kAttrRtpLlmRequestId, decode_context.request_id);
         }
-        // Allocation retries are one logical stage, including retry backoff. The
-        // retry helper performs stop/error checks without advancing this stage.
+        CHECK_REQUEST_STOP(decode_context);
         decode_context.stat_info.nextStage();
-        EXECUTE_WITH_RETRY(
-            allocateResourceFunc, decode_context, max_retry_times, max_retry_timeout_ms, retry_interval_ms);
+        allocateResource(decode_context);
         decode_context.stat_info.finishStage();
         if (decode_context.hasError()) {
-            RTP_LLM_LOG_WARNING("request [%s] allocate resource failed after retry %ld times, cost time ms [%ld], "
-                                "max retry time [%ld], max retry timeout ms [%ld]",
+            RTP_LLM_LOG_WARNING("request [%s] allocate resource failed after %ld attempts, cost time ms [%ld]",
                                 decode_context.request_key.c_str(),
                                 decode_context.retry_times,
-                                decode_context.retry_cost_time_ms,
-                                max_retry_times + 1,
-                                max_retry_timeout_ms);
+                                decode_context.retry_cost_time_ms);
             // Retries are exhausted: this is the final failure point, report it to FlexLB so the
             // scheduler releases its inflight entry without waiting for TTL eviction.
             auto& stream     = decode_context.getStream();

--- a/rtp_llm/cpp/model_rpc/DecodeRpcServer.h
+++ b/rtp_llm/cpp/model_rpc/DecodeRpcServer.h
@@ -77,12 +77,11 @@ private:
         size_t                  cache_model_id;
     };
 
-    void         initThreadPool();
-    void         prepareGenerateContext(DecodeGenerateContext& decode_context);
-    void         allocateResource(DecodeGenerateContext& decode_context);
-    grpc::Status allocateResourceFunc(DecodeGenerateContext& decode_context);
-    void         loadCacheFromPrefill(DecodeGenerateContext& decode_context);
-    void         localGenerate(DecodeGenerateContext& decode_context);
+    void initThreadPool();
+    void prepareGenerateContext(DecodeGenerateContext& decode_context);
+    void allocateResource(DecodeGenerateContext& decode_context);
+    void loadCacheFromPrefill(DecodeGenerateContext& decode_context);
+    void localGenerate(DecodeGenerateContext& decode_context);
     // Report a terminal early failure to FlexLB via meta_->finishTask(); guaranteed at most once per
     // request. MUST NOT be called inside functions driven by EXECUTE_WITH_RETRY (would report while
     // retries could still succeed); only call at final failure points.
@@ -126,6 +125,7 @@ private:
                                                const std::vector<size_t>& required_cache_key_counts,
                                                const std::vector<size_t>& transferred_cache_key_counts);
     static size_t minLoadedCacheBlockCount(const std::vector<size_t>& rank_loaded_cache_block_counts);
+    static ErrorInfo validateRemoteLoadTopology(size_t worker_size, size_t peer_size);
     static std::vector<size_t> completionQueueExpectedResponseCounts(size_t worker_size);
     static int                 markLoadedCacheReuse(const std::shared_ptr<GenerateStream>& stream,
                                                     const LoadCacheResult&                 load_result,

--- a/rtp_llm/cpp/model_rpc/GenerateContext.cc
+++ b/rtp_llm/cpp/model_rpc/GenerateContext.cc
@@ -163,10 +163,14 @@ void GenerateContext::stopStream() {
                 stream_->reportError(ErrorCode::CANCELLED, "context cleanup before stream finished");
             }
         }
-        while (stream_->getStatus() == StreamState::RUNNING) {
-            RTP_LLM_LOG_DEBUG("waiting stream [%d] running done to cancel", stream_->generateInput()->request_id);
-            usleep(1000);
+        if (!stream_->finishOrCancel(kStopStreamWaitTimeoutMs, "cancel stream")) {
+            RTP_LLM_LOG_WARNING("stopStream timeout (%ld ms) waiting for Engine Loop for request [%d]",
+                                kStopStreamWaitTimeoutMs,
+                                stream_->generateInput()->request_id);
         }
+        // RuntimeMeta snapshots the stream's terminal status during dequeue.
+        // Capture only after reportError/finishOrCancel have committed it so
+        // FlexLB observes the real cancellation or context error code.
         meta->dequeue(request_id, stream_);
         stream_.reset();
     }

--- a/rtp_llm/cpp/model_rpc/GenerateContext.h
+++ b/rtp_llm/cpp/model_rpc/GenerateContext.h
@@ -85,6 +85,8 @@ protected:
     bool                                  retryable_ = true;
     std::chrono::system_clock::time_point request_begin_time_;
 
+    static constexpr int64_t kStopStreamWaitTimeoutMs = 2000;
+
 protected:
     void stopStream();
 };

--- a/rtp_llm/cpp/model_rpc/PrefillGenerateContext.cc
+++ b/rtp_llm/cpp/model_rpc/PrefillGenerateContext.cc
@@ -78,33 +78,14 @@ void PrefillGenerateContext::setStream(const std::shared_ptr<GenerateStream>& st
 
 void PrefillGenerateContext::stopStream() {
     if (stream_) {
-        if (stream_->getStatus() != StreamState::FINISHED) {
-            // The scheduler's moveToNext() runs BEFORE process() in each step(),
-            // so GenerateDone set during process() won't be detected until the
-            // NEXT iteration. Wait for the scheduler to move the stream to FINISHED
-            // naturally, which sets FINISHED and triggers releaseResource() →
-            // tryReleaseKVBlock() → insertIntoCache() to persist KV cache.
-            // Only reportError for genuine errors (no GenerateDone, or hasError).
-            if (!(stream_->hasEvent(StreamEvents::GenerateDone) && !stream_->hasError())) {
-                stream_->reportError(ErrorCode::CANCELLED, "cancel stream");
-            }
+        if (!stream_->finishOrCancel(prefill_stop_stream_wait_timeout_ms_, "cancel prefill stream")) {
+            RTP_LLM_LOG_WARNING("stopStream timeout (%ld ms) waiting for Engine Loop for request [%d]",
+                                prefill_stop_stream_wait_timeout_ms_,
+                                stream_->generateInput()->request_id);
         }
-        int wait_iters = 0;
-        while (stream_->getStatus() == StreamState::RUNNING) {
-            RTP_LLM_LOG_DEBUG("waiting prefill stream [%d] running done to cancel",
-                              stream_->generateInput()->request_id);
-            usleep(1000);
-            if (++wait_iters > prefill_stop_stream_wait_timeout_ms_) {
-                RTP_LLM_LOG_WARNING("stopStream timeout (%ld ms) waiting for Engine Loop, "
-                                    "forcing cancel for request [%d]",
-                                    prefill_stop_stream_wait_timeout_ms_,
-                                    stream_->generateInput()->request_id);
-                stream_->reportError(ErrorCode::CANCELLED, "stopStream timeout waiting for Engine Loop");
-                break;
-            }
-        }
+        // Dequeue captures terminal status for runtime scheduling metadata.
+        // Do it after cancellation/finish settlement to preserve its error.
         dequeueStreamFromRuntimeMeta();
-        // stream status will only be set to finished by scheduler.
         markRequestEnd();
         stream_.reset();
     }

--- a/rtp_llm/cpp/model_rpc/test/DecodeRpcServerTest.cc
+++ b/rtp_llm/cpp/model_rpc/test/DecodeRpcServerTest.cc
@@ -189,6 +189,16 @@ TEST(DecodeRpcServerTest, MultiRankHandoffUsesMinimumPrefix) {
     EXPECT_EQ(DecodeRpcServer::minLoadedCacheBlockCount({}), 0u);
 }
 
+TEST(DecodeRpcServerTest, EmptyRemoteLoadTopologyFailsBeforePartitionArithmetic) {
+    EXPECT_EQ(DecodeRpcServer::validateRemoteLoadTopology(/*worker_size=*/0, /*peer_size=*/1).code(),
+              ErrorCode::LOAD_KV_CACHE_FAILED);
+    EXPECT_EQ(DecodeRpcServer::validateRemoteLoadTopology(/*worker_size=*/1, /*peer_size=*/0).code(),
+              ErrorCode::LOAD_KV_CACHE_FAILED);
+    EXPECT_TRUE(DecodeRpcServer::validateRemoteLoadTopology(/*worker_size=*/4, /*peer_size=*/2).ok());
+    EXPECT_EQ(DecodeRpcServer::validateRemoteLoadTopology(/*worker_size=*/3, /*peer_size=*/2).code(),
+              ErrorCode::LOAD_KV_CACHE_FAILED);
+}
+
 TEST(DecodeRpcServerTest, OddTpWorkersWaitForEveryCompletionQueueResponse) {
     EXPECT_EQ(DecodeRpcServer::completionQueueExpectedResponseCounts(3), (std::vector<size_t>{2, 1}));
     EXPECT_EQ(DecodeRpcServer::completionQueueExpectedResponseCounts(5), (std::vector<size_t>{2, 2, 1}));

--- a/rtp_llm/cpp/models/BUILD
+++ b/rtp_llm/cpp/models/BUILD
@@ -186,6 +186,7 @@ cc_library(
         "//rtp_llm/cpp/cuda_graph:cuda_graph_impl",
         "//rtp_llm/cpp/cuda_graph:cuda_graph_base",
         "//rtp_llm/cpp/cuda_graph:cuda_graph_hdrs_lib",
+        "//rtp_llm/cpp/cuda_graph:prepared_attention_inputs_guard",
         "//rtp_llm/models_py/bindings/common:fuse_copy_op",
         "//rtp_llm/cpp/multimodal_processor:multimodal_types",
     ] + select({

--- a/rtp_llm/cpp/models/ModelTypes.cc
+++ b/rtp_llm/cpp/models/ModelTypes.cc
@@ -11,24 +11,44 @@
 
 namespace rtp_llm {
 
+namespace {
+
+struct KvBlockTableShapeHint {
+    int64_t rank      = 0;
+    int64_t group_num = 1;
+    int64_t width     = 0;
+};
+
+KvBlockTableShapeHint inspectKvBlockTable(const torch::Tensor& table, const char* name) {
+    if (!table.defined()) {
+        return {};
+    }
+    const auto rank = table.dim();
+    RTP_LLM_CHECK_WITH_INFO(rank == 2 || rank == 3,
+                            "%s must be [batch, blocks] or [group, batch, blocks], got rank %lld",
+                            name,
+                            static_cast<long long>(rank));
+    return {rank, rank == 3 ? table.size(0) : 1, table.size(rank - 1)};
+}
+
+}  // namespace
+
 GptModelInputShapeHints getModelInputShapeHints(const GptModelInputs& inputs) {
     GptModelInputShapeHints shape_hints{};
-    shape_hints[GptModelInputIndex::comboTokens] = inputs.combo_tokens.defined() ? inputs.combo_tokens.numel() : 0;
+    const auto kernel_block_table = inspectKvBlockTable(inputs.kv_cache_kernel_block_id, "kv_cache_kernel_block_id");
+    const auto block_table        = inspectKvBlockTable(inputs.kv_cache_block_id, "kv_cache_block_id");
+    shape_hints[GptModelInputIndex::comboTokens]  = inputs.combo_tokens.defined() ? inputs.combo_tokens.numel() : 0;
     shape_hints[GptModelInputIndex::inputLengths] = inputs.input_lengths.defined() ? inputs.input_lengths.numel() : 0;
     shape_hints[GptModelInputIndex::sequenceLengths] =
         inputs.sequence_lengths.defined() ? inputs.sequence_lengths.numel() : 0;
     shape_hints[GptModelInputIndex::prefixLengths] =
         inputs.prefix_lengths.defined() ? inputs.prefix_lengths.numel() : 0;
-    shape_hints[GptModelInputIndex::maxKernelBlocksPerBatch] =
-        inputs.kv_cache_kernel_block_id.defined() ? inputs.kv_cache_kernel_block_id.size(2) : 0;
-    shape_hints[GptModelInputIndex::maxBlocksPerBatch] =
-        inputs.kv_cache_block_id.defined() ? inputs.kv_cache_block_id.size(2) : 0;
+    shape_hints[GptModelInputIndex::maxKernelBlocksPerBatch] = kernel_block_table.width;
+    shape_hints[GptModelInputIndex::maxBlocksPerBatch]       = block_table.width;
     shape_hints[GptModelInputIndex::cacheKeysWidth] =
         inputs.cache_keys.defined() && inputs.cache_keys.dim() >= 2 ? inputs.cache_keys.size(1) : 0;
     shape_hints[GptModelInputIndex::kvCacheGroupNum] =
-        inputs.kv_cache_kernel_block_id.defined() ?
-            inputs.kv_cache_kernel_block_id.size(0) :
-            (inputs.kv_cache_block_id.defined() ? inputs.kv_cache_block_id.size(0) : 1);
+        kernel_block_table.rank ? kernel_block_table.group_num : block_table.group_num;
     // Kept as a reserved zero-valued slot for shape-hint wire compatibility.
     // Per-layer group mapping is carried by GroupedCacheLayerLayout now, not by
     // a broadcast tensor.
@@ -74,29 +94,56 @@ GptModelInputShapeHints getModelInputShapeHints(const GptModelInputs& inputs) {
     shape_hints[GptModelInputIndex::mtpHiddenStatesRows] =
         inputs.last_hidden_states.defined() ? inputs.last_hidden_states.size(0) : 0;
 
-    // encode root-side tensor device for fields that may live on GPU on the
-    // PDFUSION fast path, so non-root ranks can allocate matching GPU buffers
-    // and tpSync's pack/unpack stays in lockstep.
-    uint32_t device_bits = 0;
-    if (inputs.combo_tokens.defined() && inputs.combo_tokens.is_cuda()) {
-        device_bits |= GptModelInputDeviceBit::kDeviceBitComboTokens;
-    }
-    if (inputs.input_lengths.defined() && inputs.input_lengths.is_cuda()) {
-        device_bits |= GptModelInputDeviceBit::kDeviceBitInputLengths;
-    }
-    if (inputs.sequence_lengths.defined() && inputs.sequence_lengths.is_cuda()) {
-        device_bits |= GptModelInputDeviceBit::kDeviceBitSequenceLengths;
-    }
-    if (inputs.prefix_lengths.defined() && inputs.prefix_lengths.is_cuda()) {
-        device_bits |= GptModelInputDeviceBit::kDeviceBitPrefixLengths;
-    }
-    if (inputs.lm_output_indexes.defined() && inputs.lm_output_indexes.is_cuda()) {
-        device_bits |= GptModelInputDeviceBit::kDeviceBitLmOutputIndexes;
-    }
-    if (inputs.kv_cache_kernel_block_id.defined() && inputs.kv_cache_kernel_block_id.is_cuda()) {
-        device_bits |= GptModelInputDeviceBit::kDeviceBitKernelBlockId;
-    }
-    shape_hints[GptModelInputIndex::tensorDeviceMap] = static_cast<int64_t>(device_bits);
+    uint32_t control_flags = 0;
+    auto     encode_flag   = [&](bool enabled, GptModelInputControlFlag flag) {
+        if (enabled) {
+            control_flags |= flag;
+        }
+    };
+    encode_flag(inputs.need_all_logits, GptModelInputControlFlag::kControlNeedAllLogits);
+    encode_flag(inputs.need_all_hidden_states, GptModelInputControlFlag::kControlNeedAllHiddenStates);
+    encode_flag(inputs.need_moe_gating, GptModelInputControlFlag::kControlNeedMoeGating);
+    encode_flag(inputs.warmup, GptModelInputControlFlag::kControlWarmup);
+    encode_flag(inputs.skip_run, GptModelInputControlFlag::kControlSkipRun);
+    encode_flag(inputs.is_fake_stream, GptModelInputControlFlag::kControlFakeStream);
+    encode_flag(inputs.is_target_verify, GptModelInputControlFlag::kControlTargetVerify);
+    encode_flag(inputs.pd_separation, GptModelInputControlFlag::kControlPdSeparation);
+    encode_flag(inputs.decode_entrance, GptModelInputControlFlag::kControlDecodeEntrance);
+    encode_flag(inputs.use_opaque_kv_cache_store, GptModelInputControlFlag::kControlOpaqueKvCacheStore);
+    shape_hints[GptModelInputIndex::modelControlFlags]     = static_cast<int64_t>(control_flags);
+    shape_hints[GptModelInputIndex::kvBlockStrideBytes]    = static_cast<int64_t>(inputs.kv_block_stride_bytes);
+    shape_hints[GptModelInputIndex::kvScaleStrideBytes]    = static_cast<int64_t>(inputs.kv_scale_stride_bytes);
+    shape_hints[GptModelInputIndex::seqSizePerBlock]       = static_cast<int64_t>(inputs.seq_size_per_block);
+    shape_hints[GptModelInputIndex::kernelSeqSizePerBlock] = static_cast<int64_t>(inputs.kernel_seq_size_per_block);
+
+    // Encode the root-side placement of every tensor that may enter the packed
+    // broadcast.  Some tensors (notably DSpARK MRoPE position ids) are created
+    // directly on CUDA rather than moved by ensureModelInputsOnCuda, so an
+    // allow-list of only the common device-input fields is not sufficient.
+    uint32_t device_bits   = 0;
+    auto     encode_device = [&](const torch::Tensor& tensor, GptModelInputDeviceBit bit) {
+        if (tensor.defined() && tensor.is_cuda()) {
+            device_bits |= bit;
+        }
+    };
+    encode_device(inputs.combo_tokens, GptModelInputDeviceBit::kDeviceBitComboTokens);
+    encode_device(inputs.input_lengths, GptModelInputDeviceBit::kDeviceBitInputLengths);
+    encode_device(inputs.sequence_lengths, GptModelInputDeviceBit::kDeviceBitSequenceLengths);
+    encode_device(inputs.prefix_lengths, GptModelInputDeviceBit::kDeviceBitPrefixLengths);
+    encode_device(inputs.kv_cache_kernel_block_id, GptModelInputDeviceBit::kDeviceBitKernelBlockId);
+    encode_device(inputs.kv_cache_block_id, GptModelInputDeviceBit::kDeviceBitBlockId);
+    encode_device(inputs.kv_cache_group_types, GptModelInputDeviceBit::kDeviceBitCacheGroupTypes);
+    encode_device(inputs.cache_keys, GptModelInputDeviceBit::kDeviceBitCacheKeys);
+    encode_device(inputs.kv_cache_update_mapping, GptModelInputDeviceBit::kDeviceBitCacheUpdateMapping);
+    encode_device(inputs.request_id, GptModelInputDeviceBit::kDeviceBitRequestId);
+    encode_device(inputs.request_pd_separation, GptModelInputDeviceBit::kDeviceBitRequestPdSeparation);
+    encode_device(inputs.lm_output_indexes, GptModelInputDeviceBit::kDeviceBitLmOutputIndexes);
+    encode_device(inputs.combo_position_ids, GptModelInputDeviceBit::kDeviceBitComboPositionIds);
+    encode_device(inputs.text_tokens_mask, GptModelInputDeviceBit::kDeviceBitTextTokensMask);
+    encode_device(inputs.mm_features_locs, GptModelInputDeviceBit::kDeviceBitMmFeaturesLocs);
+    shape_hints[GptModelInputIndex::tensorDeviceMap]          = static_cast<int64_t>(device_bits);
+    shape_hints[GptModelInputIndex::kvCacheKernelBlockIdRank] = kernel_block_table.rank;
+    shape_hints[GptModelInputIndex::kvCacheBlockIdRank]       = block_table.rank;
     return shape_hints;
 }
 
@@ -128,6 +175,17 @@ std::array<int64_t, 2> decodeMtpHiddenStatesShape(int64_t total_numel, int64_t r
     return {rows, cols};
 }
 
+std::vector<int64_t> decodeKvBlockTableShape(int64_t rank, int64_t group_num, int64_t batch_size, int64_t max_blocks) {
+    RTP_LLM_CHECK_WITH_INFO(
+        rank == 2 || rank == 3, "KV block-table rank must be 2 or 3, got %lld", static_cast<long long>(rank));
+    RTP_LLM_CHECK_WITH_INFO(group_num >= 0 && batch_size >= 0 && max_blocks >= 0,
+                            "KV block-table dimensions must be non-negative");
+    if (rank == 2) {
+        return {batch_size, max_blocks};
+    }
+    return {group_num, batch_size, max_blocks};
+}
+
 void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallelism_config) {
     if (parallelism_config.tp_size <= 1) {
         return;
@@ -153,20 +211,35 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
     // extra-input (model-specific, treated as opaque flat 1-D tensors) per-tensor element count
     torch::Tensor mm_extra_input_shape_t;
     int64_t*      mm_extra_input_shape_ptr = nullptr;
-    inputs.need_all_logits                 = shape_hints_ptr[GptModelInputIndex::needAllLogits];
-    inputs.need_all_hidden_states          = shape_hints_ptr[GptModelInputIndex::needAllHiddenStates];
-    inputs.skip_run                        = shape_hints_ptr[GptModelInputIndex::skipRun];
-    inputs.is_fake_stream                  = shape_hints_ptr[GptModelInputIndex::isFakeStream];
-    if (inputs.skip_run) {
-        return;
-    }
-
     auto checkedHint = [&](GptModelInputIndex index, const char* name) -> int64_t {
         const auto value = shape_hints_ptr[index];
         RTP_LLM_CHECK_WITH_INFO(
             value >= 0, "tpSyncModelInputs received negative %s shape hint: %lld", name, static_cast<long long>(value));
         return value;
     };
+    const auto control_flags         = static_cast<uint32_t>(shape_hints_ptr[GptModelInputIndex::modelControlFlags]);
+    auto       has_flag              = [&](GptModelInputControlFlag flag) { return (control_flags & flag) != 0; };
+    inputs.need_all_logits           = has_flag(GptModelInputControlFlag::kControlNeedAllLogits);
+    inputs.need_all_hidden_states    = has_flag(GptModelInputControlFlag::kControlNeedAllHiddenStates);
+    inputs.need_moe_gating           = has_flag(GptModelInputControlFlag::kControlNeedMoeGating);
+    inputs.warmup                    = has_flag(GptModelInputControlFlag::kControlWarmup);
+    inputs.skip_run                  = has_flag(GptModelInputControlFlag::kControlSkipRun);
+    inputs.is_fake_stream            = has_flag(GptModelInputControlFlag::kControlFakeStream);
+    inputs.is_target_verify          = has_flag(GptModelInputControlFlag::kControlTargetVerify);
+    inputs.pd_separation             = has_flag(GptModelInputControlFlag::kControlPdSeparation);
+    inputs.decode_entrance           = has_flag(GptModelInputControlFlag::kControlDecodeEntrance);
+    inputs.use_opaque_kv_cache_store = has_flag(GptModelInputControlFlag::kControlOpaqueKvCacheStore);
+    inputs.kv_block_stride_bytes =
+        static_cast<size_t>(checkedHint(GptModelInputIndex::kvBlockStrideBytes, "kvBlockStrideBytes"));
+    inputs.kv_scale_stride_bytes =
+        static_cast<size_t>(checkedHint(GptModelInputIndex::kvScaleStrideBytes, "kvScaleStrideBytes"));
+    inputs.seq_size_per_block =
+        static_cast<size_t>(checkedHint(GptModelInputIndex::seqSizePerBlock, "seqSizePerBlock"));
+    inputs.kernel_seq_size_per_block =
+        static_cast<size_t>(checkedHint(GptModelInputIndex::kernelSeqSizePerBlock, "kernelSeqSizePerBlock"));
+    if (inputs.skip_run) {
+        return;
+    }
 
     const auto mm_features_num = checkedHint(GptModelInputIndex::mmFeaturesNum, "mmFeaturesNum");
     if (mm_features_num) {
@@ -195,10 +268,13 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
         cudaSyncAndCheck();
     }
 
-    const auto max_kernel_blocks = checkedHint(GptModelInputIndex::maxKernelBlocksPerBatch, "maxKernelBlocksPerBatch");
-    const auto max_blocks        = checkedHint(GptModelInputIndex::maxBlocksPerBatch, "maxBlocksPerBatch");
-    const auto cache_keys_width  = checkedHint(GptModelInputIndex::cacheKeysWidth, "cacheKeysWidth");
-    const auto kv_cache_group_num      = checkedHint(GptModelInputIndex::kvCacheGroupNum, "kvCacheGroupNum");
+    const auto max_kernel_blocks  = checkedHint(GptModelInputIndex::maxKernelBlocksPerBatch, "maxKernelBlocksPerBatch");
+    const auto max_blocks         = checkedHint(GptModelInputIndex::maxBlocksPerBatch, "maxBlocksPerBatch");
+    const auto cache_keys_width   = checkedHint(GptModelInputIndex::cacheKeysWidth, "cacheKeysWidth");
+    const auto kv_cache_group_num = checkedHint(GptModelInputIndex::kvCacheGroupNum, "kvCacheGroupNum");
+    const auto kernel_block_table_rank =
+        checkedHint(GptModelInputIndex::kvCacheKernelBlockIdRank, "kvCacheKernelBlockIdRank");
+    const auto block_table_rank        = checkedHint(GptModelInputIndex::kvCacheBlockIdRank, "kvCacheBlockIdRank");
     const auto group_types_len         = checkedHint(GptModelInputIndex::kvCacheGroupTypesLen, "kvCacheGroupTypesLen");
     const auto combo_position_ids_size = checkedHint(GptModelInputIndex::comboPositionIds, "comboPositionIds");
     const auto text_tokens_mask_size   = checkedHint(GptModelInputIndex::textTokensMask, "textTokensMask");
@@ -249,16 +325,16 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
         };
 
         inputs.combo_tokens     = allocBuf(rtp_llm::DataType::TYPE_INT32,
-                                           {checkedHint(GptModelInputIndex::comboTokens, "comboTokens")},
+                                       {checkedHint(GptModelInputIndex::comboTokens, "comboTokens")},
                                        pickAlloc(GptModelInputDeviceBit::kDeviceBitComboTokens));
         inputs.input_lengths    = allocBuf(rtp_llm::DataType::TYPE_INT32,
-                                           {checkedHint(GptModelInputIndex::inputLengths, "inputLengths")},
+                                        {checkedHint(GptModelInputIndex::inputLengths, "inputLengths")},
                                         pickAlloc(GptModelInputDeviceBit::kDeviceBitInputLengths));
         inputs.sequence_lengths = allocBuf(rtp_llm::DataType::TYPE_INT32,
                                            {checkedHint(GptModelInputIndex::sequenceLengths, "sequenceLengths")},
                                            pickAlloc(GptModelInputDeviceBit::kDeviceBitSequenceLengths));
         inputs.prefix_lengths   = allocBuf(rtp_llm::DataType::TYPE_INT32,
-                                           {context_batch_size},
+                                         {context_batch_size},
                                          pickAlloc(GptModelInputDeviceBit::kDeviceBitPrefixLengths));
         if (max_kernel_blocks != 0) {
             // kv_cache_kernel_block_id residency follows the producer (rank 0): device only when
@@ -267,33 +343,47 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
             // off-by-tensor and non-root unpacks garbage).
             inputs.kv_cache_kernel_block_id =
                 allocBuf(rtp_llm::DataType::TYPE_INT32,
-                         {kv_cache_group_num,
-                          checkedHint(GptModelInputIndex::inputLengths, "inputLengths"),
-                          max_kernel_blocks},
+                         decodeKvBlockTableShape(kernel_block_table_rank,
+                                                 kv_cache_group_num,
+                                                 checkedHint(GptModelInputIndex::inputLengths, "inputLengths"),
+                                                 max_kernel_blocks),
                          pickAlloc(GptModelInputDeviceBit::kDeviceBitKernelBlockId));
             inputs.kv_cache_update_mapping =
                 allocBuf(rtp_llm::DataType::TYPE_INT32,
-                         {checkedHint(GptModelInputIndex::kvCacheUpdateCopyNum, "kvCacheUpdateCopyNum"), 3});
+                         {checkedHint(GptModelInputIndex::kvCacheUpdateCopyNum, "kvCacheUpdateCopyNum"), 3},
+                         pickAlloc(GptModelInputDeviceBit::kDeviceBitCacheUpdateMapping));
         }
         if (max_blocks != 0) {
-            inputs.kv_cache_block_id = allocBuf(
-                rtp_llm::DataType::TYPE_INT32,
-                {kv_cache_group_num, checkedHint(GptModelInputIndex::inputLengths, "inputLengths"), max_blocks});
+            inputs.kv_cache_block_id =
+                allocBuf(rtp_llm::DataType::TYPE_INT32,
+                         decodeKvBlockTableShape(block_table_rank,
+                                                 kv_cache_group_num,
+                                                 checkedHint(GptModelInputIndex::inputLengths, "inputLengths"),
+                                                 max_blocks),
+                         pickAlloc(GptModelInputDeviceBit::kDeviceBitBlockId));
             if (inputs.pd_separation) {
                 inputs.cache_keys = allocBuf(rtp_llm::DataType::TYPE_INT64,
-                                             {context_batch_size, cache_keys_width ? cache_keys_width : max_blocks});
+                                             {context_batch_size, cache_keys_width ? cache_keys_width : max_blocks},
+                                             pickAlloc(GptModelInputDeviceBit::kDeviceBitCacheKeys));
             }
         }
         if (group_types_len) {
-            inputs.kv_cache_group_types = allocBuf(rtp_llm::DataType::TYPE_INT32, {group_types_len});
+            inputs.kv_cache_group_types = allocBuf(rtp_llm::DataType::TYPE_INT32,
+                                                   {group_types_len},
+                                                   pickAlloc(GptModelInputDeviceBit::kDeviceBitCacheGroupTypes));
         }
-        inputs.request_id            = allocBuf(rtp_llm::DataType::TYPE_INT64, {request_length});
-        inputs.request_pd_separation = allocBuf(rtp_llm::DataType::TYPE_BOOL, {request_length});
+        inputs.request_id = allocBuf(
+            rtp_llm::DataType::TYPE_INT64, {request_length}, pickAlloc(GptModelInputDeviceBit::kDeviceBitRequestId));
+        inputs.request_pd_separation = allocBuf(rtp_llm::DataType::TYPE_BOOL,
+                                                {request_length},
+                                                pickAlloc(GptModelInputDeviceBit::kDeviceBitRequestPdSeparation));
         inputs.lm_output_indexes     = allocBuf(rtp_llm::DataType::TYPE_INT32,
-                                                {checkedHint(GptModelInputIndex::lmOutputIndexes, "lmOutputIndexes")},
+                                            {checkedHint(GptModelInputIndex::lmOutputIndexes, "lmOutputIndexes")},
                                             pickAlloc(GptModelInputDeviceBit::kDeviceBitLmOutputIndexes));
         if (combo_position_ids_size) {
-            inputs.combo_position_ids = allocBuf(rtp_llm::DataType::TYPE_INT32, {combo_position_ids_size});
+            inputs.combo_position_ids = allocBuf(rtp_llm::DataType::TYPE_INT32,
+                                                 {combo_position_ids_size},
+                                                 pickAlloc(GptModelInputDeviceBit::kDeviceBitComboPositionIds));
         } else {
             // An in-place CP remap from the previous forward leaves a rank-local
             // vector here; the root publishing none means this pass has no position
@@ -314,10 +404,14 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
             inputs.last_hidden_states = torch::Tensor();
         }
         if (text_tokens_mask_size) {
-            inputs.text_tokens_mask = allocBuf(rtp_llm::DataType::TYPE_INT32, {text_tokens_mask_size});
+            inputs.text_tokens_mask = allocBuf(rtp_llm::DataType::TYPE_INT32,
+                                               {text_tokens_mask_size},
+                                               pickAlloc(GptModelInputDeviceBit::kDeviceBitTextTokensMask));
         }
         if (mm_features_locs_size) {
-            inputs.mm_features_locs = allocBuf(rtp_llm::DataType::TYPE_INT32, {mm_features_locs_size});
+            inputs.mm_features_locs = allocBuf(rtp_llm::DataType::TYPE_INT32,
+                                               {mm_features_locs_size},
+                                               pickAlloc(GptModelInputDeviceBit::kDeviceBitMmFeaturesLocs));
         }
         if (mm_features_num) {
             std::vector<torch::Tensor> mm_features;

--- a/rtp_llm/cpp/models/ModelTypes.h
+++ b/rtp_llm/cpp/models/ModelTypes.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <utility>
 #include <memory>
+#include <vector>
 
 namespace kmonitor {
 class MetricsReporter;
@@ -99,9 +100,23 @@ enum GptModelInputIndex : size_t {
     // last_hidden_states can have a different row count from combo_tokens for
     // DSpARK prefill seeding, so transmit its leading dimension explicitly.
     mtpHiddenStatesRows,
-    // Per-tensor device hint bitmap from root so non-root ranks allocate
-    // matching GPU buffers and keep tpSync broadcast lanes consistent.
+    // Root-owned scalar execution contract. Tensor shapes alone are not
+    // enough to choose the same model path on every TP rank (for example,
+    // target-verify selects a different CUDA graph/linear-attention mode).
+    modelControlFlags,
+    kvBlockStrideBytes,
+    kvScaleStrideBytes,
+    seqSizePerBlock,
+    kernelSeqSizePerBlock,
+    // Exact per-tensor placement bitmap from root.  Every tensor collected by
+    // tpSyncModelInputs has a bit so non-root ranks choose the same CPU/UDS or
+    // CUDA/NCCL lane as rank 0.
     tensorDeviceMap,
+    // Preserve the root-side KV block-table layout across TP sync. Legacy
+    // models use [batch, blocks], while grouped-cache models use
+    // [group, batch, blocks].
+    kvCacheKernelBlockIdRank,
+    kvCacheBlockIdRank,
     gptModelInputLength,
 };
 
@@ -110,20 +125,44 @@ enum GptModelInputIndex : size_t {
 // 12288 = 3.2G elements).
 using GptModelInputShapeHints = std::array<int64_t, GptModelInputIndex::gptModelInputLength>;
 
-// Bit positions for `tensorDeviceMap`. Only fields that participate in the
-// MTP/Eagle decode-prepare GPU path need a bit; other fields stay CPU.
+// Bit positions for `tensorDeviceMap`.  Keep this exhaustive with respect to
+// tpSyncModelInputs' broadcast set: a missing bit can make rank 0 and non-root
+// ranks classify one payload into different transports and deadlock TP.
 enum GptModelInputDeviceBit : uint32_t {
-    kDeviceBitComboTokens     = 1u << 0,
-    kDeviceBitInputLengths    = 1u << 1,
-    kDeviceBitSequenceLengths = 1u << 2,
-    kDeviceBitPrefixLengths   = 1u << 3,
-    kDeviceBitLmOutputIndexes = 1u << 4,
-    kDeviceBitKernelBlockId   = 1u << 5,
+    kDeviceBitComboTokens         = 1u << 0,
+    kDeviceBitInputLengths        = 1u << 1,
+    kDeviceBitSequenceLengths     = 1u << 2,
+    kDeviceBitPrefixLengths       = 1u << 3,
+    kDeviceBitKernelBlockId       = 1u << 4,
+    kDeviceBitBlockId             = 1u << 5,
+    kDeviceBitCacheGroupTypes     = 1u << 6,
+    kDeviceBitCacheKeys           = 1u << 7,
+    kDeviceBitCacheUpdateMapping  = 1u << 8,
+    kDeviceBitRequestId           = 1u << 9,
+    kDeviceBitRequestPdSeparation = 1u << 10,
+    kDeviceBitLmOutputIndexes     = 1u << 11,
+    kDeviceBitComboPositionIds    = 1u << 12,
+    kDeviceBitTextTokensMask      = 1u << 13,
+    kDeviceBitMmFeaturesLocs      = 1u << 14,
+};
+
+enum GptModelInputControlFlag : uint32_t {
+    kControlNeedAllLogits       = 1u << 0,
+    kControlNeedAllHiddenStates = 1u << 1,
+    kControlNeedMoeGating       = 1u << 2,
+    kControlWarmup              = 1u << 3,
+    kControlSkipRun             = 1u << 4,
+    kControlFakeStream          = 1u << 5,
+    kControlTargetVerify        = 1u << 6,
+    kControlPdSeparation        = 1u << 7,
+    kControlDecodeEntrance      = 1u << 8,
+    kControlOpaqueKvCacheStore  = 1u << 9,
 };
 
 GptModelInputShapeHints getModelInputShapeHints(const GptModelInputs& inputs);
 torch::Tensor           makeModelInputShapeHintsTensor(const GptModelInputs& inputs);
 std::array<int64_t, 2>  decodeMtpHiddenStatesShape(int64_t total_numel, int64_t rows);
+std::vector<int64_t> decodeKvBlockTableShape(int64_t rank, int64_t group_num, int64_t batch_size, int64_t max_blocks);
 
 void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallelism_config);
 

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/models/PyWrappedModel.h"
+#include "rtp_llm/cpp/cuda_graph/prepared_attention_inputs_guard.h"
 #include "rtp_llm/cpp/cache/KVCacheManager.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
 #include "rtp_llm/cpp/utils/DebugUtils.h"
@@ -688,6 +689,7 @@ void PyWrappedModel::prepareAttentionInputs(const GptModelInputs& inputs) {
 
 void PyWrappedModel::prepareAttentionInputs(const GptModelInputs& inputs, bool skip_forward_event_sync) {
     RTP_LLM_PROFILE_SCOPE("py_model.prepareAttentionInputs");
+    PreparedAttentionInputsGuard prepared_guard(prepared_attention_inputs_);
     d2d_copies_.clear();
     if (pinned_check_remaining_ > 0) {
         --pinned_check_remaining_;
@@ -715,7 +717,6 @@ void PyWrappedModel::prepareAttentionInputs(const GptModelInputs& inputs, bool s
         attention_inputs_by_tag_ = setupKVCacheForAttentionInputs(attention_inputs, inputs);
     }
     attention_inputs_ = std::move(attention_inputs);
-    prepared_attention_inputs_.store(true, std::memory_order_release);
 
     // CRITICAL ORDERING: flush queued H2D copies BEFORE graph_runner_->prepareAttentionInputs.
     // The graph runner internally launches strided D2D copies that READ from these freshly
@@ -729,7 +730,6 @@ void PyWrappedModel::prepareAttentionInputs(const GptModelInputs& inputs, bool s
         RTP_LLM_PROFILE_SCOPE("py_model.prepareAttentionInputs(fused_h2d)");
         fusedCopy(d2d_copies_);
     }
-
     graph_state_         = CudaGraphState();
     auto empty           = torch::Tensor();
     // buildPyAttentionInputs() has already copied combo_position_ids to the
@@ -748,6 +748,7 @@ void PyWrappedModel::prepareAttentionInputs(const GptModelInputs& inputs, bool s
         RTP_LLM_PROFILE_SCOPE("py_model.prepareAttentionInputs(cuda_graph_prepare)");
         graph_runner_->prepareAttentionInputs(py_model_inputs, graph_state_, skip_forward_event_sync);
     }
+    prepared_guard.commit();
 }
 
 void PyWrappedModel::updateKVCacheKernelBlockId(const GptModelInputs& inputs) {
@@ -889,12 +890,18 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
         cache_store_write_cycle.finish();
 
         RTP_LLM_LOG_DEBUG("Python object instance forward method called successfully.");
+        auto attach_mtp_target_hidden_states = [&py_model_outputs](GptModelOutputs outputs) {
+            if (py_model_outputs.mtp_target_hidden_states.defined()) {
+                outputs.mtp_target_hidden_states = py_model_outputs.mtp_target_hidden_states;
+            }
+            return outputs;
+        };
         if (dspark_model_role_ != DSparkModelRole::NONE) {
             if (dspark_model_role_ == DSparkModelRole::PROPOSE) {
                 // Python returns normalized [B*gamma, hidden_dim]. Reuse the
                 // regular C++ lm_head and TP logits gather for every proposal
                 // row; the speculative executor owns only Markov sampling.
-                return callForwardPostLayers(hidden_states, inputs, true);
+                return attach_mtp_target_hidden_states(callForwardPostLayers(hidden_states, inputs, true));
             }
             // Commit only updates the draft KV cache and has no logits
             // consumer. Preserve its row-aligned hidden output for the common
@@ -902,17 +909,18 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
             GptModelOutputs outputs;
             outputs.hidden_states     = hidden_states;
             outputs.all_hidden_states = hidden_states;
-            return outputs;
+            return attach_mtp_target_hidden_states(std::move(outputs));
         }
         if (device_props_.enable_prefill_cp && has_context_request) {
             if (!inputs.need_all_logits && !inputs.need_all_hidden_states) {
                 context_parallel_processor_->handleOutputsLastHidden(hidden_states, inputs, cp_params);
-                return forwardPostLayersLastHidden(hidden_states, inputs);
+                return attach_mtp_target_hidden_states(forwardPostLayersLastHidden(hidden_states, inputs));
             }
             size_t num_valid_tokens = context_parallel_processor_->handleOutputs(hidden_states, inputs, cp_params);
-            return callForwardPostLayers(hidden_states, inputs, true, num_valid_tokens);
+            return attach_mtp_target_hidden_states(
+                callForwardPostLayers(hidden_states, inputs, true, num_valid_tokens));
         }
-        return callForwardPostLayers(hidden_states, inputs, true);
+        return attach_mtp_target_hidden_states(callForwardPostLayers(hidden_states, inputs, true));
 
     } catch (const py::error_already_set& e) {
         RTP_LLM_LOG_ERROR("Python error during forward call on Python instance: %s", e.what());

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -312,7 +312,7 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
         // | Model Type                | is_prefill_cuda_graph    | sp_config.type | model_id | num_tokens_per_bs       |
         // +---------------------------+--------------------------+----------------+----------+-------------------------+
         // | Embedding Model (prefill) | true                     | SP_TYPE_NONE   | -        | max_seq_len             |
-        // | DSpARK proposal (decode)  | false                    | DSpARK         | 1        | gen_num_per_cycle       |
+        // | DSpARK proposal (decode)  | false                    | DSpARK         | 1        | gen_num_per_cycle + optional anchor |
         // | DSpARK commit (decode)    | false                    | DSpARK         | 1        | gen_num_per_cycle + 1   |
         // | Draft commit (prefill)    | true                     | != SP_TYPE_NONE| 1        | gen_num_per_cycle + 1   |
         // | Normal Model (decode)     | false                    | SP_TYPE_NONE   | -        | 1 (default)             |
@@ -322,7 +322,8 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
         // clang-format on
 
         if (dspark_model_role_ == DSparkModelRole::PROPOSE) {
-            graph_params.num_tokens_per_bs = params.sp_config.gen_num_per_cycle;
+            graph_params.num_tokens_per_bs = params.sp_config.gen_num_per_cycle
+                                             + static_cast<int>(!params.sp_config.sp_dspark_sample_from_anchor);
         } else if (dspark_model_role_ == DSparkModelRole::COMMIT) {
             graph_params.num_tokens_per_bs = params.sp_config.gen_num_per_cycle + 1;
         } else if (is_prefill_cuda_graph_mode && params.sp_config.type == SP_TYPE_NONE) {

--- a/rtp_llm/cpp/models/models_weight/W.h
+++ b/rtp_llm/cpp/models/models_weight/W.h
@@ -25,8 +25,8 @@ static const std::string multi_tokens_predict_final_ln_gamma = "multi_tokens_pre
 static const std::string multi_tokens_predict_final_ln_beta  = "multi_tokens_predict_final_layernorm.beta";
 static const std::string multi_tokens_predict_d2t_map        = "multi_tokens_predict_d2t_map";
 static const std::string multi_tokens_predict_t2d_map        = "multi_tokens_predict_t2d_map";
-static const std::string v4_dspark_markov_w1                 = "v4.dspark.markov_w1.weight";
-static const std::string v4_dspark_markov_w2                 = "v4.dspark.markov_w2.weight";
+static const std::string dspark_markov_w1                    = "dspark_markov_w1.weight";
+static const std::string dspark_markov_w2                    = "dspark_markov_w2.weight";
 
 // eagle3
 static const std::string eagle3_fc_proj          = "eagle3_fc.weight";

--- a/rtp_llm/cpp/models/test/ModelDataTest.cc
+++ b/rtp_llm/cpp/models/test/ModelDataTest.cc
@@ -109,14 +109,14 @@ TEST_F(ModelDataTest, testDSparkLongPrefillShapeHintsStayInt64) {
     EXPECT_EQ(wire_hints.scalar_type(), torch::kInt64);
     EXPECT_EQ(wire_hints.data_ptr<int64_t>()[GptModelInputIndex::mtpHiddenStates], 3221225472LL);
     EXPECT_EQ(decodeMtpHiddenStatesShape(shape_hints[GptModelInputIndex::mtpHiddenStates],
-                                        shape_hints[GptModelInputIndex::mtpHiddenStatesRows]),
+                                         shape_hints[GptModelInputIndex::mtpHiddenStatesRows]),
               (std::array<int64_t, 2>{262144, 12288}));
 
     inputs.last_hidden_states = backing.expand({1048576, 12288});
     shape_hints               = getModelInputShapeHints(inputs);
     EXPECT_EQ(shape_hints[GptModelInputIndex::mtpHiddenStates], 12884901888LL);
     EXPECT_EQ(decodeMtpHiddenStatesShape(shape_hints[GptModelInputIndex::mtpHiddenStates],
-                                        shape_hints[GptModelInputIndex::mtpHiddenStatesRows]),
+                                         shape_hints[GptModelInputIndex::mtpHiddenStatesRows]),
               (std::array<int64_t, 2>{1048576, 12288}));
 }
 
@@ -125,6 +125,119 @@ TEST_F(ModelDataTest, testMtpHiddenShapeRejectsInvalidMetadataBeforeAllocation) 
     EXPECT_THROW((void)decodeMtpHiddenStatesShape(1, 0), RTPException);
     EXPECT_THROW((void)decodeMtpHiddenStatesShape(5, 2), RTPException);
     EXPECT_THROW((void)decodeMtpHiddenStatesShape(0, 1), RTPException);
+}
+
+TEST_F(ModelDataTest, testShapeHintsCarryExactPackedBroadcastPlacement) {
+    GptModelInputs inputs;
+    inputs.combo_tokens             = torch::zeros({8}, torch::kInt32).cuda();
+    inputs.input_lengths            = torch::zeros({1}, torch::kInt32).cuda();
+    inputs.sequence_lengths         = torch::zeros({1}, torch::kInt32).cuda();
+    inputs.prefix_lengths           = torch::zeros({1}, torch::kInt32).cuda();
+    inputs.kv_cache_kernel_block_id = torch::zeros({4, 1, 93}, torch::kInt32).cuda();
+    inputs.kv_cache_block_id        = torch::zeros({4, 1, 93}, torch::kInt32);
+    inputs.kv_cache_group_types     = torch::zeros({4}, torch::kInt32);
+    inputs.kv_cache_update_mapping  = torch::zeros({2, 3}, torch::kInt32).cuda();
+    inputs.request_id               = torch::zeros({1}, torch::kInt64);
+    inputs.request_pd_separation    = torch::zeros({1}, torch::kBool);
+    inputs.lm_output_indexes        = torch::zeros({7}, torch::kInt32).cuda();
+    // This is the exact mixed-device DSpARK TP2 case that previously made
+    // rank 0 send 1504 CPU bytes while rank 1 waited for 1600.
+    inputs.combo_position_ids = torch::zeros({24}, torch::kInt32).cuda();
+
+    const auto hints     = getModelInputShapeHints(inputs);
+    const auto map       = static_cast<uint32_t>(hints[GptModelInputIndex::tensorDeviceMap]);
+    auto       is_device = [&](GptModelInputDeviceBit bit) { return (map & bit) != 0; };
+
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitComboTokens));
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitInputLengths));
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitSequenceLengths));
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitPrefixLengths));
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitKernelBlockId));
+    EXPECT_FALSE(is_device(GptModelInputDeviceBit::kDeviceBitBlockId));
+    EXPECT_FALSE(is_device(GptModelInputDeviceBit::kDeviceBitCacheGroupTypes));
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitCacheUpdateMapping));
+    EXPECT_FALSE(is_device(GptModelInputDeviceBit::kDeviceBitRequestId));
+    EXPECT_FALSE(is_device(GptModelInputDeviceBit::kDeviceBitRequestPdSeparation));
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitLmOutputIndexes));
+    EXPECT_TRUE(is_device(GptModelInputDeviceBit::kDeviceBitComboPositionIds));
+}
+
+TEST_F(ModelDataTest, testTpSyncBlockTableShapesPreserve2DAnd3D) {
+    GptModelInputs inputs;
+    inputs.input_lengths            = torch::zeros({2}, torch::kInt32);
+    inputs.kv_cache_kernel_block_id = torch::zeros({2, 11}, torch::kInt32);
+    inputs.kv_cache_block_id        = torch::zeros({2, 7}, torch::kInt32);
+
+    auto hints = getModelInputShapeHints(inputs);
+    EXPECT_EQ(hints[GptModelInputIndex::kvCacheKernelBlockIdRank], 2);
+    EXPECT_EQ(hints[GptModelInputIndex::kvCacheBlockIdRank], 2);
+    EXPECT_EQ(hints[GptModelInputIndex::kvCacheGroupNum], 1);
+    EXPECT_EQ(hints[GptModelInputIndex::maxKernelBlocksPerBatch], 11);
+    EXPECT_EQ(hints[GptModelInputIndex::maxBlocksPerBatch], 7);
+    EXPECT_EQ(decodeKvBlockTableShape(hints[GptModelInputIndex::kvCacheKernelBlockIdRank],
+                                      hints[GptModelInputIndex::kvCacheGroupNum],
+                                      hints[GptModelInputIndex::inputLengths],
+                                      hints[GptModelInputIndex::maxKernelBlocksPerBatch]),
+              (std::vector<int64_t>{2, 11}));
+    EXPECT_EQ(decodeKvBlockTableShape(hints[GptModelInputIndex::kvCacheBlockIdRank],
+                                      hints[GptModelInputIndex::kvCacheGroupNum],
+                                      hints[GptModelInputIndex::inputLengths],
+                                      hints[GptModelInputIndex::maxBlocksPerBatch]),
+              (std::vector<int64_t>{2, 7}));
+
+    inputs.kv_cache_kernel_block_id = torch::zeros({4, 2, 11}, torch::kInt32);
+    inputs.kv_cache_block_id        = torch::zeros({4, 2, 7}, torch::kInt32);
+    hints                           = getModelInputShapeHints(inputs);
+    EXPECT_EQ(hints[GptModelInputIndex::kvCacheKernelBlockIdRank], 3);
+    EXPECT_EQ(hints[GptModelInputIndex::kvCacheBlockIdRank], 3);
+    EXPECT_EQ(hints[GptModelInputIndex::kvCacheGroupNum], 4);
+    EXPECT_EQ(decodeKvBlockTableShape(hints[GptModelInputIndex::kvCacheKernelBlockIdRank],
+                                      hints[GptModelInputIndex::kvCacheGroupNum],
+                                      hints[GptModelInputIndex::inputLengths],
+                                      hints[GptModelInputIndex::maxKernelBlocksPerBatch]),
+              (std::vector<int64_t>{4, 2, 11}));
+    EXPECT_EQ(decodeKvBlockTableShape(hints[GptModelInputIndex::kvCacheBlockIdRank],
+                                      hints[GptModelInputIndex::kvCacheGroupNum],
+                                      hints[GptModelInputIndex::inputLengths],
+                                      hints[GptModelInputIndex::maxBlocksPerBatch]),
+              (std::vector<int64_t>{4, 2, 7}));
+}
+
+TEST_F(ModelDataTest, testShapeHintsCarryTpControlPlaneAndCacheGeometry) {
+    GptModelInputs inputs;
+    inputs.need_all_logits           = true;
+    inputs.need_all_hidden_states    = true;
+    inputs.need_moe_gating           = true;
+    inputs.warmup                    = true;
+    inputs.skip_run                  = true;
+    inputs.is_fake_stream            = true;
+    inputs.is_target_verify          = true;
+    inputs.pd_separation             = true;
+    inputs.decode_entrance           = true;
+    inputs.use_opaque_kv_cache_store = true;
+    inputs.kv_block_stride_bytes     = 4096;
+    inputs.kv_scale_stride_bytes     = 256;
+    inputs.seq_size_per_block        = 64;
+    inputs.kernel_seq_size_per_block = 16;
+
+    const auto hints = getModelInputShapeHints(inputs);
+    const auto flags = static_cast<uint32_t>(hints[GptModelInputIndex::modelControlFlags]);
+    auto       has   = [&](GptModelInputControlFlag flag) { return (flags & flag) != 0; };
+
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlNeedAllLogits));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlNeedAllHiddenStates));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlNeedMoeGating));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlWarmup));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlSkipRun));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlFakeStream));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlTargetVerify));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlPdSeparation));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlDecodeEntrance));
+    EXPECT_TRUE(has(GptModelInputControlFlag::kControlOpaqueKvCacheStore));
+    EXPECT_EQ(hints[GptModelInputIndex::kvBlockStrideBytes], 4096);
+    EXPECT_EQ(hints[GptModelInputIndex::kvScaleStrideBytes], 256);
+    EXPECT_EQ(hints[GptModelInputIndex::seqSizePerBlock], 64);
+    EXPECT_EQ(hints[GptModelInputIndex::kernelSeqSizePerBlock], 16);
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -52,9 +52,10 @@ void releaseHostMemoryCache() {
 #endif
 }
 
-bool shouldUseCudaMallocKVCacheBacking(const PDSepConfig& pd_sep_config, const CacheStoreConfig& cache_store_config) {
+bool shouldUseDeviceMallocKVCacheBacking(const PDSepConfig& pd_sep_config,
+                                         const CacheStoreConfig& cache_store_config) {
     // Only PD cache-store RDMA registers KV cache as user MR.  Keep the
-    // raw cudaMalloc backing out of direct KVCacheManager users and non-RDMA
+    // raw device allocation backing out of direct KVCacheManager users and non-RDMA
     // paths so PyTorch allocator behavior is unchanged elsewhere.
     const bool pd_role = pd_sep_config.role_type == RoleType::PREFILL || pd_sep_config.role_type == RoleType::DECODE;
     const bool has_cache_store_server = pd_sep_config.cache_store_listen_port > 0
@@ -461,7 +462,8 @@ std::shared_ptr<GenerateStream> NormalEngine::createMinFakeStream(int32_t max_ne
 }
 
 void NormalEngine::initCacheManager(std::optional<WarmUpResult> warm_up_result) {
-    const bool use_cuda_malloc_block_pool = shouldUseCudaMallocKVCacheBacking(pd_sep_config, cache_store_config);
+    const bool use_device_malloc_block_pool =
+        shouldUseDeviceMallocKVCacheBacking(pd_sep_config, cache_store_config);
     if (propose_params_ && propose_params_->draftModel()) {
         auto config = CacheConfigCreator::createSpConfig(model_config_,
                                                          propose_params_->getEngineInitParams().model_config_,
@@ -482,7 +484,7 @@ void NormalEngine::initCacheManager(std::optional<WarmUpResult> warm_up_result) 
                                                                       sp_config,
                                                                       pd_sep_config,
                                                                       cache_store_config,
-                                                                      use_cuda_malloc_block_pool);
+                                                                      use_device_malloc_block_pool);
         resource_context_.role_type     = pd_sep_config.role_type;
         if (!resource_context_.cache_manager->init()) {
             RTP_LLM_FAIL("init kv cache manager failed");
@@ -507,7 +509,7 @@ void NormalEngine::initCacheManager(std::optional<WarmUpResult> warm_up_result) 
                                                                       SpeculativeExecutionConfig{},
                                                                       pd_sep_config,
                                                                       cache_store_config,
-                                                                      use_cuda_malloc_block_pool);
+                                                                      use_device_malloc_block_pool);
         resource_context_.role_type     = pd_sep_config.role_type;
         if (!resource_context_.cache_manager->init()) {
             RTP_LLM_FAIL("init kv cache manager failed");

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -395,8 +395,8 @@ WarmUpResult NormalEngine::decodeWarmUp(const EngineInitParams& params) {
     // value when the user passed --seq_size_per_block < 256.
     const int cache_gen_num_per_cycle =
         sp_config.type != SP_TYPE_NONE ? static_cast<int>(sp_config.gen_num_per_cycle) : 0;
-    auto cache_config = CacheConfigCreator::createBasicConfig(
-        model_config_, parallelism_config, false, cache_gen_num_per_cycle);
+    auto cache_config =
+        CacheConfigCreator::createBasicConfig(model_config_, parallelism_config, false, cache_gen_num_per_cycle);
     cache_config.block_num = 5;
     // createBasicConfig's SingleConfigCreator / HybridConfigCreator paths can
     // leave kernel_seq_size_per_block at 0 (only the real createConfig path
@@ -483,7 +483,7 @@ void NormalEngine::initCacheManager(std::optional<WarmUpResult> warm_up_result) 
                                                                       pd_sep_config,
                                                                       cache_store_config,
                                                                       use_cuda_malloc_block_pool);
-        resource_context_.role_type = pd_sep_config.role_type;
+        resource_context_.role_type     = pd_sep_config.role_type;
         if (!resource_context_.cache_manager->init()) {
             RTP_LLM_FAIL("init kv cache manager failed");
         }
@@ -508,7 +508,7 @@ void NormalEngine::initCacheManager(std::optional<WarmUpResult> warm_up_result) 
                                                                       pd_sep_config,
                                                                       cache_store_config,
                                                                       use_cuda_malloc_block_pool);
-        resource_context_.role_type = pd_sep_config.role_type;
+        resource_context_.role_type     = pd_sep_config.role_type;
         if (!resource_context_.cache_manager->init()) {
             RTP_LLM_FAIL("init kv cache manager failed");
         }
@@ -577,6 +577,11 @@ absl::Status NormalEngine::trySaveStepError() const {
 std::shared_ptr<GenerateStream> NormalEngine::makeStream(const std::shared_ptr<GenerateInput>& input) {
     std::shared_ptr<GenerateStream> stream = std::make_shared<NormalGenerateStream>(
         input, model_config_, runtime_config, resource_context_, metrics_reporter_);
+    // DecodeRpcServer calls makeStream() before enqueue() so it can allocate the
+    // destination KV table before P/D cache handoff.  Install engine-owned stream
+    // invariants here as well; otherwise that first allocation is planned without
+    // the speculative-round headroom.
+    stream->setReserveStep(reserve_step_);
     return stream;
 }
 

--- a/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
+++ b/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
@@ -298,8 +298,11 @@ void publishModelInputCoreTensorsToCuda(GptModelInputs& model_input, TensorHolde
     model_input.input_lengths    = publishInt32ToCuda(model_input.input_lengths, host_holder);
     model_input.sequence_lengths = publishInt32ToCuda(model_input.sequence_lengths, host_holder);
     model_input.prefix_lengths   = publishInt32ToCuda(model_input.prefix_lengths, host_holder);
-    // Migrate the 3-D KV kernel block id tensor with one H2D, replacing the
-    // former per-group tensorHoldHostAndToCuda copies in PyWrappedModel.
+    // Publish the physical/kernel page-table pair together. Hybrid models
+    // consume both views, and the speculative async path snapshots the pair
+    // atomically for the next round. This also replaces the former per-group
+    // tensorHoldHostAndToCuda copies in PyWrappedModel.
+    model_input.kv_cache_block_id        = publishInt32ToCuda(model_input.kv_cache_block_id, host_holder);
     model_input.kv_cache_kernel_block_id = publishInt32ToCuda(model_input.kv_cache_kernel_block_id, host_holder);
 }
 
@@ -391,6 +394,10 @@ absl::Status NormalModelInputGatherer::processDecodeStreams(GptModelInputs&     
                                    && stream_groups.totalDecodeBatchSize() > 0 && !ctx.need_cal_position_id;
     if (use_normal_device_state) {
         for (const auto& stream : stream_groups.decodeStreams()) {
+            if (stream->hasMtpCacheSnapshot()) {
+                use_normal_device_state = false;
+                break;
+            }
             const auto& state = stream->getNormalAsyncDeviceState();
             if (stream->currentBatchSize() != 1 || !state.last_sample_token_gpu.defined()
                 || !state.last_sample_token_gpu.is_cuda() || !state.next_seq_len_gpu.defined()
@@ -410,14 +417,35 @@ absl::Status NormalModelInputGatherer::processDecodeStreams(GptModelInputs&     
     for (const auto& stream : stream_groups.decodeStreams()) {
         model_input.need_all_logits        = model_input.need_all_logits || stream->calculateLoss();
         model_input.need_all_hidden_states = model_input.need_all_hidden_states || stream->needReturnHiddenStates();
-        auto  current_batch_size           = stream->currentBatchSize();
-        auto& kv_cache                     = *stream->kvCachePtr();
-        RTP_LLM_LOG_DEBUG("decode kv_cache: %s", kv_cache.debugString().c_str());
-        RTP_LLM_LOG_DEBUG("decode stream: %s", stream->debugString().c_str());
+        const bool use_mtp_cache_snapshot = stream->hasMtpCacheSnapshot();
+        const auto current_batch_size     = use_mtp_cache_snapshot ? 1 : stream->currentBatchSize();
+        if (use_mtp_cache_snapshot) {
+            RTP_LLM_CHECK_WITH_INFO(stream->maxBatchSize() == 1 && !stream->hasNumBeams(),
+                                    "MTP cache snapshots require one non-beam sequence per stream, stream=%ld",
+                                    stream->streamId());
+        }
+        auto& kv_cache = *stream->kvCachePtr();
+        if (!use_mtp_cache_snapshot) {
+            RTP_LLM_LOG_DEBUG("decode kv_cache: %s", kv_cache.debugString().c_str());
+            RTP_LLM_LOG_DEBUG("decode stream: %s", stream->debugString().c_str());
+        }
 
         for (auto i = 0; i < current_batch_size; ++i) {
             model_input.trace_ids.push_back(stream->traceId());
-            if (use_normal_device_state) {
+            if (use_mtp_cache_snapshot) {
+                // MtpBatchStreamProcessor replaces every model-semantic field
+                // below from the immutable per-round device state. Populate
+                // only shape-safe sentinels here; reading token history,
+                // seqLength or MRoPE state would race the prior worker.
+                ctx.merged_tokens[ctx.batch_idx]    = 0;
+                ctx.input_lengths[ctx.batch_idx]    = 1;
+                ctx.sequence_lengths[ctx.batch_idx] = 0;
+                if (ctx.need_cal_position_id) {
+                    std::fill_n(ctx.combo_position_ids + ctx.batch_idx * config_.position_id_len_factor,
+                                config_.position_id_len_factor,
+                                0);
+                }
+            } else if (use_normal_device_state) {
                 const auto&             state = stream->getNormalAsyncDeviceState();
                 static std::atomic<int> debug_log_budget{200};
                 if (asyncDebugEnabled() && stream->hasPendingAsyncBookkeeping()
@@ -451,8 +479,16 @@ absl::Status NormalModelInputGatherer::processDecodeStreams(GptModelInputs&     
                                                    + ctx.batch_idx * config_.position_id_len_factor);
                 }
             }
-            copyKvCacheBlocksToModelInput(
-                model_input, kv_cache, i, ctx.batch_idx, ctx.max_blocks_num, config_.kernel_blocks_per_kv_block);
+            // MTP may intentionally overlap this gather with the previous
+            // worker's host-side linear-cache swaps.  In that case the row is
+            // filled from the immutable device snapshot by
+            // MtpBatchStreamProcessor after this generic gather completes.
+            // Leave both host tables zeroed here instead of racing the mutable
+            // BlockIds vectors.
+            if (!use_mtp_cache_snapshot) {
+                copyKvCacheBlocksToModelInput(
+                    model_input, kv_cache, i, ctx.batch_idx, ctx.max_blocks_num, config_.kernel_blocks_per_kv_block);
+            }
             ctx.batch_idx += 1;
         }
         addCacheUpdateCopy(ctx, stream->streamCacheResource().getKVBlockUpdateMapping(), config_.kv_cache_group_tags);

--- a/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdlib>
+#include <map>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -32,6 +33,85 @@ torch::Tensor cloneHiddenSlice(const torch::Tensor& hidden_states, int64_t start
 }
 
 }  // namespace
+
+torch::Tensor MtpBatchStreamProcessor::advanceLinearCacheBlockTable(const torch::Tensor& current_table,
+                                                                    const torch::Tensor& previous_seq_lengths,
+                                                                    const torch::Tensor& accept_lengths,
+                                                                    const std::vector<CacheGroupType>& group_types,
+                                                                    int64_t seq_size_per_block) {
+    RTP_LLM_PROFILE_SCOPE("executor.mtp.advance_linear_cache_block_table");
+    RTP_LLM_CHECK_WITH_INFO(current_table.defined() && current_table.is_cuda()
+                                && current_table.scalar_type() == torch::kInt32 && current_table.dim() == 3,
+                            "MTP cache snapshot source must be CUDA int32 [group,batch,blocks]");
+    RTP_LLM_CHECK_WITH_INFO(previous_seq_lengths.defined() && previous_seq_lengths.is_cuda()
+                                && previous_seq_lengths.scalar_type() == torch::kInt32
+                                && previous_seq_lengths.dim() == 1,
+                            "MTP cache snapshot previous_seq_lengths must be CUDA int32 [batch]");
+    RTP_LLM_CHECK_WITH_INFO(accept_lengths.defined() && accept_lengths.is_cuda()
+                                && accept_lengths.scalar_type() == torch::kInt32 && accept_lengths.dim() == 1,
+                            "MTP cache snapshot accept_lengths must be CUDA int32 [batch]");
+    RTP_LLM_CHECK_WITH_INFO(seq_size_per_block > 0, "MTP cache snapshot block size must be positive");
+
+    const int64_t group_count = current_table.size(0);
+    const int64_t batch_size  = current_table.size(1);
+    const int64_t block_count = current_table.size(2);
+    RTP_LLM_CHECK_WITH_INFO(static_cast<int64_t>(group_types.size()) == group_count,
+                            "MTP cache snapshot group count mismatch: table=%ld config=%zu",
+                            group_count,
+                            group_types.size());
+    RTP_LLM_CHECK_WITH_INFO(previous_seq_lengths.numel() == batch_size && accept_lengths.numel() == batch_size,
+                            "MTP cache snapshot batch mismatch: table=%ld previous=%ld accept=%ld",
+                            batch_size,
+                            previous_seq_lengths.numel(),
+                            accept_lengths.numel());
+    if (batch_size == 0 || block_count == 0) {
+        return current_table.clone();
+    }
+
+    // Build one permutation per request, then apply it to every LINEAR group.
+    // This is the vectorized form of LinearBlocksUtil.h's two sequential
+    // swaps.  The scheduler's reserve_step contract guarantees active source
+    // and destination indices are within block_count.
+    const auto long_options = current_table.options().dtype(torch::kInt64);
+    auto       permutation =
+        torch::arange(block_count, long_options).reshape({1, block_count}).expand({batch_size, block_count}).clone();
+    auto accept         = accept_lengths.to(torch::kInt64);
+    auto current_cached = previous_seq_lengths.to(torch::kInt64) - 1;
+    auto next_cached    = current_cached + accept;
+    auto active         = accept > 1;
+    auto zeros          = torch::zeros_like(current_cached);
+
+    auto apply_swap = [&](torch::Tensor source, torch::Tensor destination, const torch::Tensor& enabled) {
+        auto safe_source        = torch::where(enabled, source, zeros);
+        auto safe_destination   = torch::where(enabled, destination, zeros);
+        auto source_values      = permutation.gather(1, safe_source.unsqueeze(1)).squeeze(1);
+        auto destination_values = permutation.gather(1, safe_destination.unsqueeze(1)).squeeze(1);
+        permutation.scatter_(
+            1, safe_source.unsqueeze(1), torch::where(enabled, destination_values, source_values).unsqueeze(1));
+        permutation.scatter_(
+            1, safe_destination.unsqueeze(1), torch::where(enabled, source_values, destination_values).unsqueeze(1));
+    };
+
+    auto cached_swap_needed = torch::remainder(current_cached + 1, seq_size_per_block)
+                              > torch::remainder(next_cached + seq_size_per_block - 1, seq_size_per_block);
+    auto cached_source = torch::floor_divide(current_cached, seq_size_per_block)
+                         + (seq_size_per_block - torch::remainder(current_cached, seq_size_per_block) - 1);
+    auto cached_destination = torch::floor_divide(next_cached, seq_size_per_block) - 1;
+    apply_swap(cached_source, cached_destination, active & cached_swap_needed);
+
+    auto final_source      = torch::floor_divide(current_cached, seq_size_per_block) + accept - 1;
+    auto final_destination = torch::floor_divide(next_cached - 1, seq_size_per_block);
+    apply_swap(final_source, final_destination, active);
+
+    auto next_table = current_table.clone();
+    for (int64_t group_id = 0; group_id < group_count; ++group_id) {
+        if (group_types[static_cast<size_t>(group_id)] != CacheGroupType::LINEAR) {
+            continue;
+        }
+        next_table.select(0, group_id).copy_(current_table.select(0, group_id).gather(1, permutation));
+    }
+    return next_table;
+}
 
 void MtpBatchStreamProcessor::expandTargetVerifyPositionIds(const StreamGroups& stream_groups,
                                                             GptModelInputs&     model_input) const {
@@ -168,9 +248,9 @@ torch::Tensor columnAsFlat(const torch::Tensor& tensor, int64_t col) {
 // falls back to host token ids, where the handoff wrote the first generated
 // token. The SPOutputBuffer is deliberately not consulted: prepareStreams
 // zero-initializes it for dspark streams, so its content is noise here.
-torch::Tensor dsparkNewestToken(const GenerateStreamPtr& stream) {
-    const auto& accept_tokens = stream->getAcceptTokensGpu();
-    const auto& accept_len    = stream->getAcceptLenGpu();
+torch::Tensor dsparkNewestToken(const GenerateStreamPtr& stream, const GenerateStream::MtpAsyncDeviceState& state) {
+    const auto& accept_tokens = state.accept_tokens_gpu;
+    const auto& accept_len    = state.accept_len_gpu;
     if (accept_tokens.defined() && accept_tokens.is_cuda() && accept_len.defined() && accept_len.is_cuda()) {
         auto idx_t = (accept_len - 1).to(torch::kLong);
         return accept_tokens.squeeze(0).index_select(/*dim=*/0, idx_t);
@@ -203,8 +283,9 @@ dsparkRoundHeadState(const StreamGroups& stream_groups, const GptModelInputs& mo
     torch::Tensor host_seq_lens;
     int64_t       idx = 0;
     for (const auto& stream : stream_groups.allStreams()) {
-        anchors.push_back(toCudaInt32(dsparkNewestToken(stream), host_holder).reshape({1}));
-        const auto& next_seq_len = stream->getNextSeqLenGpu();
+        const auto state = stream->getMtpAsyncDeviceState();
+        anchors.push_back(toCudaInt32(dsparkNewestToken(stream, state), host_holder).reshape({1}));
+        const auto& next_seq_len = state.next_seq_len_gpu;
         if (next_seq_len.defined() && next_seq_len.is_cuda()) {
             committed_end_parts.push_back((next_seq_len.reshape({1}) - 1).to(torch::kInt32));
         } else {
@@ -221,8 +302,9 @@ dsparkRoundHeadState(const StreamGroups& stream_groups, const GptModelInputs& mo
 }
 
 torch::Tensor pickOneStepTargetLastToken(const GenerateStreamPtr& stream) {
-    const auto& accept_tokens = stream->getAcceptTokensGpu();
-    const auto& accept_len    = stream->getAcceptLenGpu();
+    const auto state          = stream->getMtpAsyncDeviceState();
+    const auto& accept_tokens = state.accept_tokens_gpu;
+    const auto& accept_len    = state.accept_len_gpu;
     if (useMtpDeviceState() && accept_tokens.defined() && accept_tokens.is_cuda() && accept_len.defined()
         && accept_len.is_cuda()) {
         auto idx_t = (accept_len - 1).to(torch::kLong);
@@ -299,17 +381,17 @@ void copyScoreSamplerTokenIds(torch::Tensor&       token_ids,
     dst.copy_(src);
 }
 
-const char* missingMtpStateReason(const GenerateStreamPtr& stream) {
-    if (!stream->getAcceptTokensGpu().defined()) {
+const char* missingMtpStateReason(const GenerateStream::MtpAsyncDeviceState& state) {
+    if (!state.accept_tokens_gpu.defined()) {
         return "accept_tokens_gpu_missing";
     }
-    if (!stream->getAcceptLenGpu().defined()) {
+    if (!state.accept_len_gpu.defined()) {
         return "accept_len_gpu_missing";
     }
-    if (!stream->getProposeTokensGpu().defined()) {
+    if (!state.propose_tokens_gpu.defined()) {
         return "propose_tokens_gpu_missing";
     }
-    if (!stream->getNextSeqLenGpu().defined()) {
+    if (!state.next_seq_len_gpu.defined()) {
         return "next_seq_len_gpu_missing";
     }
     return nullptr;
@@ -320,7 +402,7 @@ void logMtpStateFallback(const GenerateStreamPtr& stream, const char* reason) {
     if (!shouldLogFallback(count)) {
         return;
     }
-    const auto& mtp_state        = stream->getMtpAsyncDeviceState();
+    const auto  mtp_state        = stream->getMtpAsyncDeviceState();
     auto        sp_output_buffer = stream->getSPOutputBuffer();
     RTP_LLM_LOG_INFO("[mtp-async-fallback] reason=%s stream=%ld epoch=%lu fallback_count=%lu success_count=%lu "
                      "tensors_holder_size=%zu seq_len=%d",
@@ -341,14 +423,15 @@ bool collectMtpStateProposeSlices(const std::list<GenerateStreamPtr>& streams,
         next_seq_lengths->clear();
     }
     for (const auto& stream : streams) {
-        torch::Tensor gpu_t = stream->getProposeTokensGpu();
+        const auto    state = stream->getMtpAsyncDeviceState();
+        torch::Tensor gpu_t = state.propose_tokens_gpu;
         if (!gpu_t.defined() || !gpu_t.is_cuda()) {
             logMtpStateFallback(stream, "propose_tokens_gpu_missing");
             return false;
         }
         propose_slices.push_back(lastColumnAsFlat(gpu_t));
         if (next_seq_lengths) {
-            torch::Tensor next_seq_len = stream->getNextSeqLenGpu();
+            torch::Tensor next_seq_len = state.next_seq_len_gpu;
             if (next_seq_len.defined() && next_seq_len.is_cuda()) {
                 next_seq_lengths->push_back(std::move(next_seq_len));
             }
@@ -384,6 +467,49 @@ bool legacyGpuProposePathEnabled(size_t batch_size) {
 }
 
 }  // namespace
+
+torch::Tensor MtpBatchStreamProcessor::collectDSparkPositionBases(const StreamGroups& stream_groups,
+                                                                  TensorHolder&       host_holder) const {
+    const int64_t position_factor    = static_cast<int64_t>(model_input_gatherer_config_.position_id_len_factor);
+    const int64_t batch_size         = static_cast<int64_t>(stream_groups.size());
+    const bool    needs_position_ids = model_input_gatherer_config_.has_positional_encoding
+                                    || model_input_gatherer_config_.mm_position_ids_style != PositionIdsStyle::DEFAULT;
+    if (!needs_position_ids || position_factor <= 0 || batch_size == 0) {
+        return {};
+    }
+
+    std::vector<torch::Tensor> base_positions;
+    base_positions.reserve(batch_size);
+    for (const auto& stream : stream_groups.allStreams()) {
+        const auto& device_positions = stream->getNextPositionIdsGpu();
+        if (device_positions.defined() && device_positions.is_cuda() && device_positions.scalar_type() == torch::kInt32
+            && device_positions.numel() == position_factor) {
+            base_positions.push_back(device_positions.reshape({1, position_factor}));
+            continue;
+        }
+
+        auto host_positions =
+            torch::zeros({position_factor}, torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true));
+        stream->generateNextPositionId(host_positions.data_ptr<int32_t>());
+        base_positions.push_back(toCudaInt32(host_positions, host_holder).reshape({1, position_factor}));
+    }
+
+    return torch::cat(base_positions, 0).reshape({batch_size, position_factor}).contiguous();
+}
+
+torch::Tensor MtpBatchStreamProcessor::expandDSparkPositionIds(const torch::Tensor& position_bases,
+                                                               int64_t              width) const {
+    if (!position_bases.defined() || position_bases.numel() == 0) {
+        return {};
+    }
+    RTP_LLM_CHECK_WITH_INFO(width > 0, "DSpARK position width must be positive, got %ld", width);
+    RTP_LLM_CHECK_WITH_INFO(
+        position_bases.dim() == 2, "DSpARK position bases must be [batch, factor], got dim=%ld", position_bases.dim());
+    auto bases = position_bases.to(torch::kInt32).unsqueeze(1);
+    auto steps = torch::arange(width, cudaInt32Options()).reshape({1, width, 1});
+    return (bases + steps).reshape({-1}).contiguous();
+}
+
 absl::Status MtpBatchStreamProcessor::dispatchPrefill(const StreamGroups& stream_groups,
                                                       const MergedOutput& prefill_output,
                                                       const MergedOutput& propose_output) const {
@@ -437,6 +563,8 @@ absl::StatusOr<GptModelInputs> MtpBatchStreamProcessor::gatherDecodeModelInput(c
 
     RTP_LLM_CHECK(model_input.ok());
 
+    overlayMtpCacheSnapshots(stream_groups, model_input.value(), host_holder);
+
     if (propose_step_ == 1 || is_dspark_) {
         return model_input;
     }
@@ -444,6 +572,75 @@ absl::StatusOr<GptModelInputs> MtpBatchStreamProcessor::gatherDecodeModelInput(c
     gatherHiddenStates(stream_groups, model_input.value());
 
     return model_input;
+}
+
+void MtpBatchStreamProcessor::overlayMtpCacheSnapshots(const StreamGroups& stream_groups,
+                                                       GptModelInputs&     model_input,
+                                                       TensorHolder&       host_holder) const {
+    struct SnapshotBucket {
+        std::vector<torch::Tensor> physical_tables;
+        std::vector<torch::Tensor> kernel_tables;
+        std::vector<int64_t>       rows;
+    };
+
+    std::map<std::pair<int64_t, int64_t>, SnapshotBucket> buckets;
+    int64_t                                                row = 0;
+    for (const auto& stream : stream_groups.decodeStreams()) {
+        const auto state        = stream->getMtpAsyncDeviceState();
+        const bool use_snapshot = GenerateStream::hasMtpCacheSnapshot(state);
+        if (use_snapshot) {
+            RTP_LLM_CHECK_WITH_INFO(stream->maxBatchSize() == 1 && !stream->hasNumBeams(),
+                                    "MTP cache snapshots require one non-beam sequence per stream, stream=%ld",
+                                    stream->streamId());
+            const auto& physical = state.next_kv_cache_block_id_gpu;
+            const auto& kernel   = state.next_kv_cache_kernel_block_id_gpu;
+            auto&       bucket   = buckets[{physical.size(2), kernel.size(2)}];
+            bucket.physical_tables.push_back(physical);
+            bucket.kernel_tables.push_back(kernel);
+            bucket.rows.push_back(row);
+        }
+        row += use_snapshot ? 1 : stream->currentBatchSize();
+    }
+
+    if (buckets.empty()) {
+        return;
+    }
+    // Generic gathering produces pinned host tables. Move the complete mixed
+    // batch once, preserving freshly admitted host rows, then replace only the
+    // steady rows with their device snapshots. TensorHolder keeps the pinned
+    // sources alive until the non-blocking copies complete.
+    model_input.kv_cache_block_id        = toCudaInt32(model_input.kv_cache_block_id, host_holder);
+    model_input.kv_cache_kernel_block_id = toCudaInt32(model_input.kv_cache_kernel_block_id, host_holder);
+    RTP_LLM_CHECK_WITH_INFO(model_input.kv_cache_block_id.defined() && model_input.kv_cache_block_id.is_cuda()
+                                && model_input.kv_cache_block_id.scalar_type() == torch::kInt32
+                                && model_input.kv_cache_block_id.dim() == 3
+                                && model_input.kv_cache_kernel_block_id.defined()
+                                && model_input.kv_cache_kernel_block_id.is_cuda()
+                                && model_input.kv_cache_kernel_block_id.scalar_type() == torch::kInt32
+                                && model_input.kv_cache_kernel_block_id.dim() == 3,
+                            "MTP cache snapshot overlay requires physical and kernel CUDA int32 destinations "
+                            "[group,batch,blocks]");
+
+    auto overlay = [](torch::Tensor& destination,
+                      const std::vector<torch::Tensor>& sources,
+                      const std::vector<int64_t>&       rows) {
+        auto source = torch::cat(sources, 1);
+        RTP_LLM_CHECK_WITH_INFO(source.size(0) == destination.size(0),
+                                "MTP cache snapshot group mismatch: source=%ld destination=%ld",
+                                source.size(0),
+                                destination.size(0));
+        const int64_t copy_width  = std::min(source.size(2), destination.size(2));
+        auto row_indices = torch::tensor(rows, torch::TensorOptions().dtype(torch::kInt64))
+                               .to(destination.device(), /*non_blocking=*/true);
+        destination.narrow(2, 0, copy_width)
+            .index_copy_(1, row_indices, source.narrow(2, 0, copy_width));
+    };
+
+    for (auto& [widths, bucket] : buckets) {
+        (void)widths;
+        overlay(model_input.kv_cache_block_id, bucket.physical_tables, bucket.rows);
+        overlay(model_input.kv_cache_kernel_block_id, bucket.kernel_tables, bucket.rows);
+    }
 }
 
 absl::StatusOr<SamplerInputs>
@@ -708,11 +905,15 @@ bool MtpBatchStreamProcessor::gatherMtpDecodeModelInputFromDeviceState(const Str
         return false;
     }
     const auto all_streams = stream_groups.allStreams();
+    std::vector<GenerateStream::MtpAsyncDeviceState> states;
+    states.reserve(batch_size);
     for (const auto& stream : all_streams) {
-        if (const char* reason = missingMtpStateReason(stream)) {
+        const auto state = stream->getMtpAsyncDeviceState();
+        if (const char* reason = missingMtpStateReason(state)) {
             logMtpStateFallback(stream, reason);
             return false;
         }
+        states.push_back(state);
     }
     g_mtp_device_state_success_count.fetch_add(1, std::memory_order_relaxed);
 
@@ -723,11 +924,11 @@ bool MtpBatchStreamProcessor::gatherMtpDecodeModelInputFromDeviceState(const Str
     propose_slices_gpu.reserve(batch_size);
     next_seq_len_slices_gpu.reserve(batch_size);
 
-    for (const auto& stream : all_streams) {
-        const auto& accept_tokens  = stream->getAcceptTokensGpu();   // [1, propose+1]
-        const auto& accept_len     = stream->getAcceptLenGpu();      // [1]
-        const auto& propose_tokens = stream->getProposeTokensGpu();  // [1, token_stride]
-        const auto& next_seq_len   = stream->getNextSeqLenGpu();     // [1]
+    for (const auto& state : states) {
+        const auto& accept_tokens  = state.accept_tokens_gpu;   // [1, propose+1]
+        const auto& accept_len     = state.accept_len_gpu;      // [1]
+        const auto& propose_tokens = state.propose_tokens_gpu;  // [1, token_stride]
+        const auto& next_seq_len   = state.next_seq_len_gpu;    // [1]
 
         auto idx_t       = (accept_len - 1).to(torch::kLong);
         auto target_last = accept_tokens.squeeze(0).index_select(/*dim=*/0, idx_t);
@@ -904,7 +1105,7 @@ torch::Tensor MtpBatchStreamProcessor::compactAcceptedPositionIds(const torch::T
 }
 
 torch::Tensor MtpBatchStreamProcessor::dsparkComboTokens(int64_t batch_size, const torch::Tensor& anchors) {
-    const int64_t draft_width = propose_step_;
+    const int64_t draft_width = dsparkQueryWidth();
     if (!dspark_combo_cache_.defined() || dspark_combo_cache_.size(0) < batch_size
         || dspark_combo_cache_.size(1) != draft_width) {
         dspark_combo_cache_ = fullInt32OnCuda({batch_size, draft_width}, dspark_mask_token_id_);
@@ -916,7 +1117,7 @@ torch::Tensor MtpBatchStreamProcessor::dsparkComboTokens(int64_t batch_size, con
 
 torch::Tensor MtpBatchStreamProcessor::dsparkDraftInputLengths(int64_t batch_size) {
     if (!dspark_input_lengths_cache_.defined() || dspark_input_lengths_cache_.size(0) < batch_size) {
-        dspark_input_lengths_cache_ = fullInt32OnCuda({batch_size}, propose_step_);
+        dspark_input_lengths_cache_ = fullInt32OnCuda({batch_size}, dsparkQueryWidth());
     }
     return dspark_input_lengths_cache_.narrow(0, 0, batch_size);
 }
@@ -924,7 +1125,16 @@ torch::Tensor MtpBatchStreamProcessor::dsparkDraftInputLengths(int64_t batch_siz
 torch::Tensor MtpBatchStreamProcessor::dsparkDraftLmIndexes(int64_t batch_size) {
     const int64_t token_count = batch_size * propose_step_;
     if (!dspark_lm_indexes_cache_.defined() || dspark_lm_indexes_cache_.size(0) < token_count) {
-        dspark_lm_indexes_cache_ = torch::arange(token_count, cudaInt32Options());
+        if (!dspark_sample_from_anchor_) {
+            dspark_lm_indexes_cache_ =
+                torch::arange(batch_size * dsparkQueryWidth(), cudaInt32Options())
+                    .view({batch_size, dsparkQueryWidth()})
+                    .narrow(1, 1, propose_step_)
+                    .contiguous()
+                    .view({-1});
+        } else {
+            dspark_lm_indexes_cache_ = torch::arange(token_count, cudaInt32Options());
+        }
     }
     return dspark_lm_indexes_cache_.narrow(0, 0, token_count);
 }
@@ -960,7 +1170,7 @@ void MtpBatchStreamProcessor::buildDSparkProposeInput(GptModelInputs&      model
     model_input.lm_output_indexes  = dsparkDraftLmIndexes(batch_size);
 }
 
-MtpBatchStreamProcessor::DSparkRoundHead MtpBatchStreamProcessor::buildDSparkRoundHead(
+MtpBatchStreamProcessor::DSparkRoundState MtpBatchStreamProcessor::buildDSparkRoundState(
     const StreamGroups& stream_groups, const GptModelInputs& model_input, TensorHolder& host_holder) const {
     if (stream_groups.size() == 0) {
         return {};
@@ -969,27 +1179,32 @@ MtpBatchStreamProcessor::DSparkRoundHead MtpBatchStreamProcessor::buildDSparkRou
     // prompt length in the same fields, so new and old streams take one
     // identical path here.
     auto [anchors, committed_ends] = dsparkRoundHeadState(stream_groups, model_input, host_holder);
-    return {std::move(anchors), std::move(committed_ends)};
+    auto position_bases            = collectDSparkPositionBases(stream_groups, host_holder);
+    return {std::move(anchors), std::move(committed_ends), std::move(position_bases)};
 }
 
-MtpBatchStreamProcessor::DSparkRoundHead MtpBatchStreamProcessor::prepareDSparkDraftModelInput(
-    const StreamGroups& stream_groups, GptModelInputs& model_input, TensorHolder& host_holder) {
-    auto round_head = buildDSparkRoundHead(stream_groups, model_input, host_holder);
-    if (!round_head.anchors.defined() || round_head.anchors.numel() == 0) {
-        return round_head;
-    }
-    buildDSparkProposeInput(model_input, round_head.anchors, round_head.committed_ends, host_holder);
-    return round_head;
-}
-
-void MtpBatchStreamProcessor::updateDSparkTargetVerifyModelInput(const DSparkRoundHead& round_head,
-                                                                 GptModelInputs&        model_input,
-                                                                 const torch::Tensor&   proposals,
-                                                                 TensorHolder&          host_holder) {
-    if (!round_head.anchors.defined() || round_head.anchors.numel() == 0) {
+void MtpBatchStreamProcessor::prepareDSparkProposeModelInput(const DSparkRoundState& round_state,
+                                                             GptModelInputs&         model_input,
+                                                             TensorHolder&           host_holder) {
+    if (!round_state.anchors.defined() || round_state.anchors.numel() == 0) {
         return;
     }
-    const int64_t batch_size = round_head.anchors.numel();
+    buildDSparkProposeInput(model_input, round_state.anchors, round_state.committed_ends, host_holder);
+    model_input.combo_position_ids = expandDSparkPositionIds(round_state.position_bases, dsparkQueryWidth());
+    // The fixed-width proposal CUDA graph uses the framework's multi-token
+    // graph geometry. This flag classifies that geometry; forward_propose is
+    // still the model-semantic phase selector.
+    model_input.is_target_verify = true;
+}
+
+void MtpBatchStreamProcessor::prepareDSparkTargetVerifyModelInput(const DSparkRoundState& round_state,
+                                                                  GptModelInputs&         model_input,
+                                                                  const torch::Tensor&    proposals,
+                                                                  TensorHolder&           host_holder) {
+    if (!round_state.anchors.defined() || round_state.anchors.numel() == 0) {
+        return;
+    }
+    const int64_t batch_size = round_state.anchors.numel();
 
     RTP_LLM_CHECK_WITH_INFO(proposals.defined() && proposals.dim() == 2 && proposals.size(0) == batch_size
                                 && proposals.size(1) == propose_step_,
@@ -997,10 +1212,32 @@ void MtpBatchStreamProcessor::updateDSparkTargetVerifyModelInput(const DSparkRou
                             batch_size,
                             propose_step_);
 
-    auto anchor_col            = round_head.anchors.reshape({batch_size, 1});
+    auto anchor_col            = round_state.anchors.reshape({batch_size, 1});
     auto verify                = torch::cat({anchor_col, proposals.to(torch::kInt32)}, 1).reshape({-1});
-    model_input.prefix_lengths = round_head.committed_ends;
+    model_input.prefix_lengths = round_state.committed_ends;
     setVerifyPairInputs(model_input, std::move(verify), batch_size, propose_step_ + 1, host_holder);
+    model_input.combo_position_ids = expandDSparkPositionIds(round_state.position_bases, propose_step_ + 1);
+    model_input.is_target_verify   = true;
+}
+
+void MtpBatchStreamProcessor::expandDSparkTargetVerifyPositionIdsFromProposal(GptModelInputs& model_input) const {
+    if (!model_input.combo_position_ids.defined() || model_input.combo_position_ids.numel() == 0) {
+        return;
+    }
+    const int64_t batch_size      = model_input.input_lengths.numel();
+    const int64_t proposal_width  = dsparkQueryWidth();
+    const int64_t position_factor = static_cast<int64_t>(model_input_gatherer_config_.position_id_len_factor);
+    const int64_t expected        = batch_size * proposal_width * position_factor;
+    RTP_LLM_CHECK_WITH_INFO(position_factor > 0 && model_input.combo_position_ids.numel() == expected,
+                            "DSpARK proposal position shape mismatch: got %ld, expected %ld "
+                            "(batch=%ld, width=%ld, factor=%ld)",
+                            model_input.combo_position_ids.numel(),
+                            expected,
+                            batch_size,
+                            proposal_width,
+                            position_factor);
+    auto bases = model_input.combo_position_ids.reshape({batch_size, proposal_width, position_factor}).select(1, 0);
+    model_input.combo_position_ids = expandDSparkPositionIds(bases, propose_step_ + 1);
 }
 
 void MtpBatchStreamProcessor::updateDecodePostDSparkCommitInput(GptModelInputs&      model_input,
@@ -1333,8 +1570,8 @@ void MtpBatchStreamProcessor::gatherHiddenStates(const StreamGroups& stream_grou
     // Prefer main-thread device-state hidden_states to avoid racing worker
     // writes to sp_output_buffer when DROP_BROAD_SYNC=1. Fallback covers older
     // or first-step streams without published device state.
-    auto pick_hidden_states = [](const GenerateStreamPtr& stream) -> const torch::Tensor& {
-        const auto& dev = stream->getLastHiddenStatesGpu();
+    auto pick_hidden_states = [](const GenerateStreamPtr& stream) -> torch::Tensor {
+        auto dev = stream->getLastHiddenStatesGpu();
         if (dev.defined()) {
             return dev;
         }

--- a/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.h
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.h
@@ -19,7 +19,8 @@ public:
         propose_step_(sp_config.gen_num_per_cycle),
         vocab_size_(model_config.vocab_size),
         is_dspark_(sp_config.type == SP_TYPE_DSPARK),
-        dspark_mask_token_id_(static_cast<int32_t>(sp_config.sp_dspark_mask_token_id)) {}
+        dspark_mask_token_id_(static_cast<int32_t>(sp_config.sp_dspark_mask_token_id)),
+        dspark_sample_from_anchor_(sp_config.sp_dspark_sample_from_anchor) {}
 
     absl::Status dispatchPrefill(const StreamGroups& stream_groups,
                                  const MergedOutput& prefill_output,
@@ -39,6 +40,16 @@ public:
 
     absl::StatusOr<GptModelInputs> gatherDecodeModelInput(const StreamGroups& stream_groups,
                                                           TensorHolder&       host_holder) const;
+
+    // Produce the next round's immutable page table by applying the exact
+    // linear-cache permutation used by GenerateStream::specUpdate.  FULL/SWA
+    // groups are copied unchanged.  Keeping this operation tensor-native lets
+    // proposal/verify overlap host bookkeeping without a per-round D2H join.
+    static torch::Tensor advanceLinearCacheBlockTable(const torch::Tensor&               current_table,
+                                                      const torch::Tensor&               previous_seq_lengths,
+                                                      const torch::Tensor&               accept_lengths,
+                                                      const std::vector<CacheGroupType>& group_types,
+                                                      int64_t                            seq_size_per_block);
 
     absl::StatusOr<SamplerInputs> gatherSpecSamplerInput(const StreamGroups&                         stream_groups,
                                                          const GptModelOutputs&                      model_output,
@@ -85,30 +96,32 @@ public:
                                  const torch::Tensor& committed_ends,
                                  TensorHolder&        host_holder);
 
-    // Round-head stream state (anchor = last accepted token, committed_end =
-    // committed length - 1), derived once per decode round and consumed by
-    // both the propose and verify input builders below; new PD streams and
-    // steady streams take the same path. Consumers must treat both tensors as
-    // immutable — propose and verify alias this one storage.
-    struct DSparkRoundHead {
+    // Immutable state shared by the proposal and target-verification phases of
+    // one DSpARK round. Position bases contain one MRoPE/default tuple per
+    // request; each phase expands them to its own token width, so batching
+    // cannot shift one request onto another request's positions.
+    struct DSparkRoundState {
         torch::Tensor anchors;
         torch::Tensor committed_ends;
+        torch::Tensor position_bases;
     };
-    DSparkRoundHead buildDSparkRoundHead(const StreamGroups&   stream_groups,
-                                         const GptModelInputs& model_input,
-                                         TensorHolder&         host_holder) const;
+    DSparkRoundState buildDSparkRoundState(const StreamGroups&   stream_groups,
+                                           const GptModelInputs& model_input,
+                                           TensorHolder&         host_holder) const;
 
-    // Prepare the fixed-width DSpARK proposal input from current stream state.
-    // The returned round head is reused after sampling to build target verify.
-    DSparkRoundHead prepareDSparkDraftModelInput(const StreamGroups& stream_groups,
-                                                 GptModelInputs&     model_input,
-                                                 TensorHolder&       host_holder);
+    void prepareDSparkProposeModelInput(const DSparkRoundState& round_state,
+                                        GptModelInputs&         model_input,
+                                        TensorHolder&           host_holder);
 
-    // Convert the proposal-stage input into dense target-verify rows.
-    void updateDSparkTargetVerifyModelInput(const DSparkRoundHead& round_head,
-                                            GptModelInputs&        model_input,
-                                            const torch::Tensor&   proposals,
-                                            TensorHolder&          host_holder);
+    void prepareDSparkTargetVerifyModelInput(const DSparkRoundState& round_state,
+                                             GptModelInputs&         model_input,
+                                             const torch::Tensor&    proposals,
+                                             TensorHolder&           host_holder);
+
+    // Async target preparation runs before proposal sampling completes. Build
+    // its verify-width positions locally from the TP-synchronized proposal
+    // metadata; no second pre-proposal broadcast is needed.
+    void expandDSparkTargetVerifyPositionIdsFromProposal(GptModelInputs& model_input) const;
 
     void updateDecodePostDSparkCommitInput(GptModelInputs&      model_input,
                                            const torch::Tensor& target_features,
@@ -134,6 +147,13 @@ public:
                                            std::vector<torch::Tensor>& draft_token_probs_list);
 
 protected:
+    void overlayMtpCacheSnapshots(const StreamGroups& stream_groups,
+                                  GptModelInputs&     model_input,
+                                  TensorHolder&       host_holder) const;
+
+    torch::Tensor collectDSparkPositionBases(const StreamGroups& stream_groups, TensorHolder& host_holder) const;
+    torch::Tensor expandDSparkPositionIds(const torch::Tensor& position_bases, int64_t width) const;
+
     void updateProposeTokens(const StreamGroups&                stream_groups,
                              const MergedOutput&                draft_prefill_output,
                              std::vector<StreamSpecUpdateInfo>& spec_update_infos) const;
@@ -160,11 +180,15 @@ protected:
     torch::Tensor dsparkComboTokens(int64_t batch_size, const torch::Tensor& anchors);
     torch::Tensor dsparkDraftInputLengths(int64_t batch_size);
     torch::Tensor dsparkDraftLmIndexes(int64_t batch_size);
+    int64_t dsparkQueryWidth() const {
+        return propose_step_ + static_cast<int64_t>(!dspark_sample_from_anchor_);
+    }
 
     int     propose_step_;
-    size_t  vocab_size_           = 0;
-    bool    is_dspark_            = false;
-    int32_t dspark_mask_token_id_ = -1;
+    size_t  vocab_size_                   = 0;
+    bool    is_dspark_                    = false;
+    int32_t dspark_mask_token_id_         = -1;
+    bool    dspark_sample_from_anchor_     = true;
 
     // Decode-round constants are grow-only device buffers.  Keeping them on
     // device is required by RTP_LLM_STREAM_ASYNC: no accept-length D2H is

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -1446,7 +1446,7 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
 
     // StreamGroups snapshots scheduling metadata. Wait for any mutable
     // bookkeeping/KV-swap state that has not yet reached a safe snapshot.
-    waitPreviousBookkeepingAndKvSwaps(streams);
+    waitPreviousBookkeepingBeforeStreamPreparation(streams);
     StreamGroups stream_groups(streams);
     prepareGrpcMtpDeviceState(streams, buffer_holder_);
 

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -12,6 +12,7 @@
 #include "rtp_llm/cpp/engine_base/system_prompt/SystemPromptConstructor.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
+#include "rtp_llm/cpp/utils/LinearBlocksUtil.h"
 #include "rtp_llm/cpp/utils/StringUtil.h"
 #include "rtp_llm/cpp/models/ModelInputsLogger.h"
 #include "rtp_llm/cpp/models/PyWrappedModel.h"
@@ -48,6 +49,10 @@ bool MtpExecutor::dsparkDraftGraphAllowed(bool is_dspark, RoleType role_type) {
     // memory (and can OOM CP-RR startup). Every other configuration keeps
     // graph capture available.
     return !(is_dspark && role_type == RoleType::PREFILL);
+}
+
+int MtpExecutor::selectMtpPreviousSeqLenUpperBound(bool pending, int previous_next_bound, int host_seq_len) {
+    return pending && previous_next_bound > 0 ? previous_next_bound : host_seq_len;
 }
 
 GptModelOutputs MtpExecutor::forwardModel(ModelBase* model, const GptModelInputs& inputs, ModelInputsModelRole role) {
@@ -108,6 +113,43 @@ bool hasSpecLogitsProcessor(const std::list<GenerateStreamPtr>& streams) {
     return false;
 }
 
+bool hasLinearCacheSnapshotCapacity(const std::list<GenerateStreamPtr>& streams,
+                                    int64_t                            table_width,
+                                    int                                max_accept_length,
+                                    int                                seq_size_per_block) {
+    if (table_width <= 0 || max_accept_length <= 0 || seq_size_per_block <= 0) {
+        return false;
+    }
+
+    const auto in_range = [table_width](int index) { return index >= 0 && index < table_width; };
+    for (const auto& stream : streams) {
+        // Snapshot publication normally happens after the narrow sampler join,
+        // so seqLength is exact here. If another commit is unexpectedly still
+        // pending, its upper bound does not identify the exact block offset;
+        // validating only that endpoint would miss a wrap-around swap for a
+        // shorter accepted length. Decline the optimization and let the next
+        // scheduler iteration join/regather instead.
+        if (stream->hasPendingAsyncBookkeeping()) {
+            return false;
+        }
+        const int previous_length = stream->seqLength();
+        if (previous_length <= 0) {
+            return false;
+        }
+
+        const int current_cached = previous_length - 1;
+        const int next_cached    = current_cached + max_accept_length;
+        const auto cached_swap =
+            getCachedTokenBlockSwapIdx(current_cached, next_cached, seq_size_per_block);
+        const auto final_swap = getFinalTokenBlockSwapIdx(current_cached, next_cached, seq_size_per_block);
+        if (!in_range(cached_swap.first) || !in_range(cached_swap.second) || !in_range(final_swap.first)
+            || !in_range(final_swap.second)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::optional<ErrorInfo> validateMtpCompatibility(const std::vector<BaseLogitsProcessorPtr>& processors) {
     for (size_t i = 0; i < processors.size(); ++i) {
         const auto capability = processors[i]->mtpCapability();
@@ -163,7 +205,7 @@ void applySpecLogitsAcceptLenCap(const SpecLogitsVerifyRunner::LaunchResult& ver
                                  int64_t                                     batch_size,
                                  int64_t                                     propose_step) {
     output.processor_errors = verify_result.processor_errors;
-    torch::Tensor cap_src = verify_result.spec_cap_gpu;
+    torch::Tensor cap_src   = verify_result.spec_cap_gpu;
     if (!cap_src.defined() && verify_result.spec_cap_cpu.defined()) {
         // Non-CUDA builds get no device mirror from the runner; upload the CPU
         // cap so accept-len capping still applies (main parity).
@@ -195,8 +237,7 @@ void applySpecLogitsAcceptLenCap(const SpecLogitsVerifyRunner::LaunchResult& ver
     auto          target_tokens = target_token_ids.reshape({batch_size, propose_step + 1, token_stride})
                              .select(2, token_stride - 1)
                              .to(output.accept_tokens.options());
-    auto cap_index =
-        cap_src.to(torch::TensorOptions().device(output.accept_tokens.device()).dtype(torch::kLong));
+    auto cap_index   = cap_src.to(torch::TensorOptions().device(output.accept_tokens.device()).dtype(torch::kLong));
     auto replacement = target_tokens.gather(1, cap_index.unsqueeze(1));
 
     auto cols = torch::arange(propose_step + 1,
@@ -319,6 +360,14 @@ void MtpExecutor::maybeOverrideLastHiddenWithMtpBuffer(GptModelInputs& model_inp
 void MtpExecutor::maybeOverrideLastHiddenWithMtpBuffer(GptModelOutputs& model_output,
                                                        ModelBase&       source,
                                                        int64_t          hidden_rows) {
+    if (model_output.mtp_target_hidden_states.defined()) {
+        RTP_LLM_CHECK_WITH_INFO(hidden_rows < 0 || model_output.mtp_target_hidden_states.size(0) == hidden_rows,
+                                "MTP target hidden output rows mismatch: got %ld, expected %ld",
+                                model_output.mtp_target_hidden_states.size(0),
+                                hidden_rows);
+        model_output.all_hidden_states = model_output.mtp_target_hidden_states;
+        return;
+    }
     if (hidden_rows == 0) {
         if (!model_output.all_hidden_states.defined() || model_output.all_hidden_states.size(0) == 0) {
             return;
@@ -374,6 +423,13 @@ void MtpExecutor::ensureModelInputsOnCuda(GptModelInputs& model_input, const cha
     to_cuda(model_input.prefix_lengths, "prefix_lengths");
     to_cuda(model_input.sequence_lengths_plus_1, "sequence_lengths_plus_1");
     to_cuda(model_input.lm_output_indexes, "lm_output_indexes");
+    // Keep the physical and kernel-granularity page tables on the same
+    // device.  Hybrid models consume them as one cache-mapping snapshot, and
+    // async MTP derives the next immutable snapshot from this pair after the
+    // round.  Publishing both here also lets TP synchronization preserve one
+    // residency contract on every rank from the first decode round onward.
+    to_cuda(model_input.kv_cache_block_id, "kv_cache_block_id");
+    to_cuda(model_input.kv_cache_kernel_block_id, "kv_cache_kernel_block_id");
     checkModelInputsOnCuda(model_input, tag);
 }
 
@@ -397,6 +453,8 @@ void MtpExecutor::checkModelInputsOnCuda(const GptModelInputs& model_input, cons
     check(model_input.sequence_lengths, "sequence_lengths");
     check(model_input.prefix_lengths, "prefix_lengths");
     check(model_input.sequence_lengths_plus_1, "sequence_lengths_plus_1");
+    check(model_input.kv_cache_block_id, "kv_cache_block_id");
+    check(model_input.kv_cache_kernel_block_id, "kv_cache_kernel_block_id");
     check(model_input.lm_output_indexes, "lm_output_indexes");
     RTP_LLM_LOG_DEBUG("[mtp-device-input] %s metadata tensors are CUDA", tag);
 }
@@ -520,8 +578,8 @@ static std::shared_ptr<NormalGenerateStream> makeFakeStream(int                 
     return fake_stream;
 }
 
-static SpeculativeExecutorStreamOutputPtr makeFakeSPOutputBuffer(
-    DataType data_type, size_t hidden_size, size_t vocab_size, size_t propose_step, bool is_dspark) {
+static SpeculativeExecutorStreamOutputPtr
+makeFakeSPOutputBuffer(DataType data_type, size_t hidden_size, size_t vocab_size, size_t propose_step, bool is_dspark) {
     auto sp_buffer = std::make_shared<SpeculativeExecutorStreamOutput>();
 
     sp_buffer->propose_step = propose_step;
@@ -587,10 +645,10 @@ GenerateStreamPtr MtpExecutor::createMinFakeDecodeStream(int                    
     auto seq_len = fake_stream->seqLength();
 
     // set device state
-    auto int32_gpu = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
-    auto accept_len_gpu = torch::ones({1}, int32_gpu);
-    auto accept_tokens_gpu = torch::zeros({1, max_new_tokens + 1}, int32_gpu);
-    auto next_seq_len_gpu = torch::ones({1}, int32_gpu) + 1;
+    auto int32_gpu          = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    auto accept_len_gpu     = torch::ones({1}, int32_gpu);
+    auto accept_tokens_gpu  = torch::zeros({1, max_new_tokens + 1}, int32_gpu);
+    auto next_seq_len_gpu   = torch::ones({1}, int32_gpu) + 1;
     auto propose_tokens_gpu = is_dspark ? torch::Tensor() : torch::zeros({1, 1}, int32_gpu);
 
     fake_stream->setMtpAsyncDeviceState(GenerateStream::MtpAsyncDeviceState{
@@ -601,8 +659,8 @@ GenerateStreamPtr MtpExecutor::createMinFakeDecodeStream(int                    
         .propose_tokens_gpu     = std::move(propose_tokens_gpu),
         .last_hidden_states_gpu = is_dspark ? torch::Tensor() : sp_buffer->hidden_states,
         .draft_all_probs_gpu    = is_dspark ? torch::Tensor() : sp_buffer->all_probs,
-        .last_real_seq_len      = seq_len,
-        .next_real_seq_len      = seq_len,
+        .previous_seq_len_upper_bound = seq_len,
+        .next_seq_len_upper_bound     = seq_len,
     });
 
     return fake_stream;
@@ -653,10 +711,6 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
         RTP_LLM_CHECK_WITH_INFO(params.sp_config.sp_dspark_mask_token_id >= 0,
                                 "dspark requires sp_dspark_mask_token_id, got %ld",
                                 params.sp_config.sp_dspark_mask_token_id);
-        RTP_LLM_CHECK_WITH_INFO(draft_vocab_size_ == vocab_size_,
-                                "dspark requires identical draft/target vocabularies, got %zu and %zu",
-                                draft_vocab_size_,
-                                vocab_size_);
         // The draft rides the standard prefill-CP split for its commit calls.
         // Its fixed-width decode-phase blocks (propose, tail commit) must stay
         // unsplit, so an enabled split is only legal on a pure prefill role:
@@ -771,10 +825,10 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
     }
 
     // when warmup, cache manager maybe nullptr
-    const auto& cache_config = cache_manager ? cache_manager->cacheConfig() : CacheConfig();
-    const auto  group_types  = cache_config.groupTypesSnapshot();
-    is_linear_attention_model_ =
-        std::any_of(group_types.begin(), group_types.end(), [](CacheGroupType type) { return type == CacheGroupType::LINEAR; });
+    const auto& cache_config   = cache_manager ? cache_manager->cacheConfig() : CacheConfig();
+    const auto  group_types    = cache_config.groupTypesSnapshot();
+    is_linear_attention_model_ = std::any_of(
+        group_types.begin(), group_types.end(), [](CacheGroupType type) { return type == CacheGroupType::LINEAR; });
     batch_stream_processor_.reset(new MtpBatchStreamProcessor(params.model_config_,
                                                               params.pd_sep_config,
                                                               params.profiling_debug_logging_config,
@@ -857,12 +911,31 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
         dspark_markov_w2_ = draft_weights.dspark_markov_w2;
         RTP_LLM_CHECK_WITH_INFO(dspark_markov_w1_.defined() && dspark_markov_w2_.defined(),
                                 "DSpARK requires markov_w1 and markov_w2 weights");
+        const int64_t padded_draft_vocab_size = (static_cast<int64_t>(draft_vocab_size_) + 127) / 128 * 128;
         RTP_LLM_CHECK_WITH_INFO(dspark_markov_w1_.is_cuda() && dspark_markov_w2_.is_cuda()
                                     && dspark_markov_w1_.dim() == 2 && dspark_markov_w2_.dim() == 2
-                                    && dspark_markov_w1_.sizes() == dspark_markov_w2_.sizes()
-                                    && dspark_markov_w1_.size(0) == static_cast<int64_t>(draft_vocab_size_)
-                                    && dspark_markov_w1_.scalar_type() == dspark_markov_w2_.scalar_type(),
-                                "DSpARK Markov weights must be matching CUDA [vocab,rank] tensors");
+                                    && dspark_markov_w1_.size(1) == dspark_markov_w2_.size(1)
+                                    && dspark_markov_w1_.size(0) >= static_cast<int64_t>(vocab_size_)
+                                    && dspark_markov_w2_.size(0) >= static_cast<int64_t>(draft_vocab_size_)
+                                     && dspark_markov_w2_.size(0) <= padded_draft_vocab_size
+                                     && dspark_markov_w1_.scalar_type() == dspark_markov_w2_.scalar_type(),
+                                "DSpARK Markov weights must be CUDA [target_vocab,rank] and "
+                                "[draft_vocab,rank] tensors with matching rank and dtype");
+        dspark_markov_w2_ = dspark_markov_w2_.narrow(0, 0, static_cast<int64_t>(draft_vocab_size_));
+        if (draft_vocab_size_ != vocab_size_) {
+            RTP_LLM_CHECK_WITH_INFO(d2t_map_.defined() && d2t_map_.is_cuda() && d2t_map_.dim() == 1
+                                        && d2t_map_.scalar_type() == torch::kInt64
+                                        && d2t_map_.numel() == static_cast<int64_t>(draft_vocab_size_),
+                                    "reduced-vocabulary DSpARK requires a CUDA int64 d2t map with one entry per "
+                                    "draft token");
+            const auto d2t_min = d2t_map_.min().item<int64_t>();
+            const auto d2t_max = d2t_map_.max().item<int64_t>();
+            RTP_LLM_CHECK_WITH_INFO(d2t_min >= 0 && d2t_max < static_cast<int64_t>(vocab_size_),
+                                    "DSpARK d2t target ids must be in [0,%zu), got range [%ld,%ld]",
+                                    vocab_size_,
+                                    d2t_min,
+                                    d2t_max);
+        }
     } else if (dspark_prefill_commit_only_) {
         RTP_LLM_LOG_INFO("[speculative decoding] DSpARK PREFILL commit-only worker: skipping proposal/Markov weights");
     }
@@ -872,7 +945,6 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
     }
 
     RTP_LLM_LOG_INFO("[speculative decoding] d2t_map size: %ld", d2t_map_.defined() ? d2t_map_.numel() : 0);
-
 }
 
 /*
@@ -1034,10 +1106,9 @@ absl::Status MtpExecutor::prefillStep(const std::list<GenerateStreamPtr>& stream
     {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.prefill_step(target_model_forward)");
         maybePrintModelInput(model_input, "prefill target model");
-        int64_t start_time_us               = autil::TimeUtility::currentTimeInMicroSeconds();
-        model_output = std::move(forwardModel(model_.get(), model_input, ModelInputsModelRole::TARGET));
-        maybeOverrideLastHiddenWithMtpBuffer(
-            model_output, *model_, cp_enabled ? -1 : model_input.combo_tokens.numel());
+        int64_t start_time_us = autil::TimeUtility::currentTimeInMicroSeconds();
+        model_output          = std::move(forwardModel(model_.get(), model_input, ModelInputsModelRole::TARGET));
+        maybeOverrideLastHiddenWithMtpBuffer(model_output, *model_, cp_enabled ? -1 : model_input.combo_tokens.numel());
         model_forward_us += autil::TimeUtility::currentTimeInMicroSeconds() - start_time_us;
     }
 
@@ -1331,8 +1402,8 @@ void MtpExecutor::prepareGrpcMtpDeviceState(const std::list<GenerateStreamPtr>& 
             .propose_tokens_gpu     = std::move(propose_tokens_gpu),
             .last_hidden_states_gpu = sp_output_buffer->hidden_states,
             .draft_all_probs_gpu    = sp_output_buffer->all_probs,
-            .last_real_seq_len      = seq_length,
-            .next_real_seq_len      = seq_length,
+            .previous_seq_len_upper_bound = seq_length,
+            .next_seq_len_upper_bound     = seq_length,
         });
 
         tensors_holder.clear();
@@ -1361,8 +1432,8 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     torch::Tensor              spec_token_ids_t;
     std::vector<torch::Tensor> draft_probs_list;
     torch::Event               accept_len_ready_event = cuda_graph::makeGraphEvent();
-    auto spec_logits_result = std::make_shared<SpecLogitsVerifyRunner::LaunchResult>();
-    int64_t model_forward_us = 0;
+    auto                       spec_logits_result     = std::make_shared<SpecLogitsVerifyRunner::LaunchResult>();
+    int64_t                    model_forward_us       = 0;
 
     // Stream-async events are recorded on the main stream as soon as tensors
     // become valid. rejection_event guards accept_len/tokens D2H; draft_event
@@ -1373,6 +1444,8 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     bool                          spec_logits_async_launched              = false;
     bool                          spec_logits_processor_present           = false;
 
+    // StreamGroups snapshots scheduling metadata. Wait for any mutable
+    // bookkeeping/KV-swap state that has not yet reached a safe snapshot.
     waitPreviousBookkeepingAndKvSwaps(streams);
     StreamGroups stream_groups(streams);
     prepareGrpcMtpDeviceState(streams, buffer_holder_);
@@ -1401,48 +1474,84 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
 
     // TODO(yinzhi): consider beam search & lora
 
-    MtpBatchStreamProcessor::DSparkRoundHead dspark_round_head;
-
-    {
-        RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(prepare_decode_input_and_tp_sync)");
-        // This is a round-level input contract, not per-forward phase state.
-        // Every TP rank sets it here, so proposal, target verify, and commit all
-        // observe one stable value without scalar broadcast or hot-path fixes.
-        model_input.is_target_verify = is_dspark_;
-        if (isTpRank0()) {
-            if (is_dspark_) {
-                dspark_round_head =
-                    batch_stream_processor_->prepareDSparkDraftModelInput(stream_groups, model_input, buffer_holder_);
-            } else if (propose_step_ == 1) {
-                batch_stream_processor_->prepareOneStepSpecDecodeModelInput(stream_groups, model_input, buffer_holder_);
-            } else {
-                batch_stream_processor_->prepareDecodeDraftModelInput(stream_groups, model_input, buffer_holder_);
-            }
-            ensureModelInputsOnCuda(model_input, "decode.prepare_decode_input");
-        }
-        tpSyncModelInputs(model_input, parallelism_config_);
-        if (model_input.skip_run) {
-            return absl::OkStatus();
-        }
-        ensureModelInputsOnCuda(model_input, "decode.after_tp_sync");
-    }
-    size_t batch_size             = model_input.input_lengths.size(0);
-    spec_logits_processor_present =
-        isTpRank0() && !warm_up_ && !model_input.is_fake_stream && hasSpecLogitsProcessor(streams);
-
-    // release hold buffers before draft model forward
-    releaseAllModelBuffers();
-
-    launchTargetVerifyPrepareAsync(model_input, batch_size);
+    MtpBatchStreamProcessor::DSparkRoundState dspark_round_state;
+    size_t                                    batch_size = 0;
 
     if (is_dspark_) {
-        dsparkModelDecode(
-            model_input, stream_groups, dspark_round_head, draft_sampler_output, draft_token_ids_t, model_forward_us);
-    } else if (propose_step_ > 1) {
-        RTP_LLM_LOG_DEBUG("[MTP decode] draftModelDecode start");
-        draftModelDecode(model_input, stream_groups, draft_probs_list, draft_token_ids_t, model_forward_us);
-        RTP_LLM_LOG_DEBUG("[MTP decode] draftModelDecode end");
+        // Proposal and target verification are two model phases with different
+        // token widths and cache roles. Keep the target gather output intact;
+        // both inputs are derived from one immutable round state on rank 0.
+        GptModelInputs proposal_input;
+        {
+            RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(prepare_dspark_proposal_and_tp_sync)");
+            if (isTpRank0()) {
+                dspark_round_state =
+                    batch_stream_processor_->buildDSparkRoundState(stream_groups, model_input, buffer_holder_);
+                proposal_input = model_input;
+                batch_stream_processor_->prepareDSparkProposeModelInput(
+                    dspark_round_state, proposal_input, buffer_holder_);
+                ensureModelInputsOnCuda(proposal_input, "decode.prepare_dspark_proposal");
+            }
+            tpSyncModelInputs(proposal_input, parallelism_config_);
+            if (proposal_input.skip_run) {
+                return absl::OkStatus();
+            }
+            ensureModelInputsOnCuda(proposal_input, "decode.dspark_proposal_after_tp_sync");
+        }
+        batch_size = proposal_input.input_lengths.size(0);
+
+        // Release previous-round staging, then overlap target metadata
+        // preparation with the proposal graph. The prepare path expands the
+        // synchronized proposal position bases to target-verify width locally.
+        releaseAllModelBuffers();
+        launchTargetVerifyPrepareAsync(proposal_input, batch_size);
+        runDSparkProposal(proposal_input, stream_groups, dspark_round_state, draft_sampler_output, model_forward_us);
+
+        {
+            RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(prepare_dspark_target_and_tp_sync)");
+            if (isTpRank0()) {
+                batch_stream_processor_->prepareDSparkTargetVerifyModelInput(
+                    dspark_round_state, model_input, draft_sampler_output.token_ids, buffer_holder_);
+                draft_token_ids_t = model_input.combo_tokens.reshape(
+                    {static_cast<int64_t>(batch_size), static_cast<int64_t>(propose_step_ + 1)});
+                ensureModelInputsOnCuda(model_input, "decode.prepare_dspark_target_verify");
+            }
+            applyCacheStrideToModelInput(model_input, cache_manager_->cacheConfig());
+            tpSyncModelInputs(model_input, parallelism_config_);
+            ensureModelInputsOnCuda(model_input, "decode.dspark_target_verify_after_tp_sync");
+        }
+    } else {
+        {
+            RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(prepare_decode_input_and_tp_sync)");
+            model_input.is_target_verify = false;
+            if (isTpRank0()) {
+                if (propose_step_ == 1) {
+                    batch_stream_processor_->prepareOneStepSpecDecodeModelInput(
+                        stream_groups, model_input, buffer_holder_);
+                } else {
+                    batch_stream_processor_->prepareDecodeDraftModelInput(stream_groups, model_input, buffer_holder_);
+                }
+                ensureModelInputsOnCuda(model_input, "decode.prepare_decode_input");
+            }
+            tpSyncModelInputs(model_input, parallelism_config_);
+            if (model_input.skip_run) {
+                return absl::OkStatus();
+            }
+            ensureModelInputsOnCuda(model_input, "decode.after_tp_sync");
+        }
+        batch_size = model_input.input_lengths.size(0);
+
+        releaseAllModelBuffers();
+        launchTargetVerifyPrepareAsync(model_input, batch_size);
+        if (propose_step_ > 1) {
+            RTP_LLM_LOG_DEBUG("[MTP decode] draftModelDecode start");
+            draftModelDecode(model_input, stream_groups, draft_probs_list, draft_token_ids_t, model_forward_us);
+            RTP_LLM_LOG_DEBUG("[MTP decode] draftModelDecode end");
+        }
     }
+
+    spec_logits_processor_present =
+        isTpRank0() && !warm_up_ && !model_input.is_fake_stream && hasSpecLogitsProcessor(streams);
 
     auto draft_tokens_ready_event = std::make_shared<torch::Event>(cuda_graph::makeGraphEvent());
     draft_tokens_ready_event->record(cuda_graph::graphGetCurrentStream());
@@ -1633,7 +1742,12 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
         rejection_event->record(cuda_graph::graphGetCurrentStream());
     }
 
-    maybeOverrideLastHiddenWithMtpBuffer(model_input, *model_);
+    // DSpARK commit input was bound from the explicit target-forward output
+    // above. Re-reading mutable Python model state here is both redundant and
+    // invalid for CUDA graph replay, where Python is not executed.
+    if (!is_dspark_) {
+        maybeOverrideLastHiddenWithMtpBuffer(model_input, *model_);
+    }
     broadcastPostRejectionInputs(model_input);
 
     draft_prefill_prepare_runner_.sync(cuda_graph::graphGetCurrentStream());
@@ -1683,35 +1797,43 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     return dispatchDecodeOutput(stream_groups,
                                 streams,
                                 speculative_sampler_output,
+                                model_input.combo_position_ids,
+                                model_input.kv_cache_block_id,
+                                model_input.kv_cache_kernel_block_id,
                                 std::move(draft_prefill_model_output),
                                 std::move(draft_prefill_sampler_output),
                                 std::move(rejection_event),
                                 std::move(draft_event));
 }
 
-void MtpExecutor::waitPreviousBookkeepingAndKvSwaps(const std::list<GenerateStreamPtr>& streams) {
-    // Cap outstanding stream-async bookkeeping to one step unless DROP_BROAD_SYNC
-    // is on. Device state handles host staleness; swap events handle linear KV.
-    if (useStreamAsync() && !useDropBroadSync()) {
-        RTP_LLM_PROFILE_SCOPE_DYNAMIC("executor.mtp.decode_step(wait_prev_bookkeeping,stream_count=%zu)",
-                                      streams.size());
-        spec_bookkeeping_runner_.sync(cuda_graph::graphGetCurrentStream());
-    }
-
-    // Linear attention may rewrite KV mappings via swapLinearBlocks; wait on
-    // producer events before target verify reads KV, even when broad sync is off.
-    {
-        RTP_LLM_PROFILE_SCOPE_DYNAMIC("executor.mtp.decode_step(wait_pending_linear_attn_swaps,stream_count=%zu)",
-                                      streams.size());
-        for (auto& stream : streams) {
-            auto event_handle = stream->getPendingSwapDoneEvent();
-            if (event_handle) {
-                auto event = std::static_pointer_cast<torch::Event>(event_handle);
-                event->block(cuda_graph::graphGetCurrentStream());
-                stream->clearPendingSwapDoneEvent();
-            }
+void MtpExecutor::waitPreviousBookkeepingBeforeStreamPreparation(const std::list<GenerateStreamPtr>& streams) {
+    bool cache_snapshot_ready = true;
+    for (const auto& stream : streams) {
+        if (stream->hasPendingAsyncBookkeeping() && (!useDeviceInput() || !stream->hasMtpCacheSnapshot())) {
+            cache_snapshot_ready = false;
+            break;
         }
     }
+    if (!mustWaitBeforeStreamPreparation(
+            useStreamAsync(), useDropBroadSync(), is_linear_attention_model_, cache_snapshot_ready)) {
+        return;
+    }
+
+    // Async bookkeeping mutates GenerateStream host state. Linear-attention
+    // models additionally swap the logical-to-kernel cache mapping every
+    // round. Both are inputs to prepareStreams/StreamGroups, so a CUDA event
+    // observed later in decodeStep cannot make an earlier host snapshot safe.
+    // Join the existing runner at the ownership boundary instead. Non-linear
+    // DROP_BROAD_SYNC keeps its device-state overlap unchanged.
+    RTP_LLM_PROFILE_SCOPE_DYNAMIC("executor.mtp.wait_prev_bookkeeping(stream_count=%zu)", streams.size());
+    spec_bookkeeping_runner_.sync(cuda_graph::graphGetCurrentStream());
+}
+
+bool MtpExecutor::mustWaitBeforeStreamPreparation(bool stream_async,
+                                                  bool drop_broad_sync,
+                                                  bool linear_attention,
+                                                  bool cache_snapshot_ready) {
+    return stream_async && (!drop_broad_sync || (linear_attention && !cache_snapshot_ready));
 }
 
 void MtpExecutor::launchTargetVerifyPrepareAsync(const GptModelInputs& model_input, size_t batch_size) {
@@ -1720,9 +1842,12 @@ void MtpExecutor::launchTargetVerifyPrepareAsync(const GptModelInputs& model_inp
     }
     const auto& cache_cfg = cache_manager_->cacheConfig();
     // NOTE: combo_tokens never used in prepare stage, so it is safe to use shallow copy
-    auto model_input_copy                    = model_input;
+    auto model_input_copy                  = model_input;
     model_input_copy.kv_block_stride_bytes = cache_cfg.kv_block_stride_bytes;
     model_input_copy.kv_scale_stride_bytes = cache_cfg.kv_scale_stride_bytes;
+    if (is_dspark_) {
+        batch_stream_processor_->expandDSparkTargetVerifyPositionIdsFromProposal(model_input_copy);
+    }
     {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(prepare_target_verify_input)");
         const auto cuda_i32 = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
@@ -1769,11 +1894,10 @@ void MtpExecutor::launchTargetVerifyPrepareAsync(const GptModelInputs& model_inp
                                                                static_cast<int64_t>(batch_size * (propose_step_ + 1)),
                                                                static_cast<int64_t>(propose_step_ + 1),
                                                                cuda_i32);
-            const auto& target_prefix_lengths = target_prefix_lengths_for_prepare.defined() ?
-                                                    target_prefix_lengths_for_prepare :
-                                                    model_input.prefix_lengths;
-            model_input_copy.prefix_lengths =
-                toCudaInt32WithHostHold(target_prefix_lengths, buffer_holder_);
+            const auto& target_prefix_lengths        = target_prefix_lengths_for_prepare.defined() ?
+                                                           target_prefix_lengths_for_prepare :
+                                                           model_input.prefix_lengths;
+            model_input_copy.prefix_lengths          = toCudaInt32WithHostHold(target_prefix_lengths, buffer_holder_);
             model_input_copy.sequence_lengths_plus_1 = model_input_copy.prefix_lengths + 1;
         }
     }
@@ -1836,42 +1960,11 @@ GptModelOutputs MtpExecutor::runTargetVerifyForward(GptModelInputs& model_input,
         model_input.sequence_lengths.size(0));
     target_verify_prepare_runner_.sync(cuda_graph::graphGetCurrentStream());
 
-    // Linear-attention only: page table advances every token. Standard paged
-    // attention (MHA/MLA) page table rarely changes within a propose+verify
-    // cycle, so the re-gather is skipped there.
+    // Linear-attention page tables are gathered once at the round boundary.
+    // Pending host swaps are represented by an immutable device snapshot, so
+    // proposal and verify share one coherent table without joining the worker.
     if (is_linear_attention_model_) {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(update_kv_cache_kernel_block_id)");
-        spec_bookkeeping_runner_.sync(cuda_graph::graphGetCurrentStream());
-
-        if (tp_rank_ == 0) {
-            model_input.kv_cache_kernel_block_id =
-                batch_stream_processor_->gatherKvCacheKernelBlockId(stream_groups, buffer_holder_).value();
-        }
-
-        if (parallelism_config_.tp_size > 1) {
-            execBroadcast({{model_input.kv_cache_kernel_block_id}, 0});
-        }
-
-        // gatherKvCacheKernelBlockId always publishes the table on CUDA (the
-        // device pipeline and the TP broadcast above need it), but main's
-        // default host pipeline kept this table host-resident: PyWrappedModel
-        // derives the per-tag host block tables from it, and the CUDA-graph
-        // replay prep refreshes the pinned host mirrors consumed by the host
-        // fill/plan path (FlashInfer fillParams) from those host tables. A
-        // CUDA-resident table skips that refresh and leaves the mirrors
-        // zeroed, so target verify replays with a corrupt page table. Lift it
-        // back to pinned host here; the blocking copy also guarantees the
-        // host bytes are ready for the downstream host memcpys.
-        if (!useDeviceInput() && model_input.kv_cache_kernel_block_id.defined()
-            && model_input.kv_cache_kernel_block_id.is_cuda()) {
-            RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(kv_cache_kernel_block_id_to_host)");
-            auto host_table =
-                torch::empty(model_input.kv_cache_kernel_block_id.sizes(),
-                             torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
-            host_table.copy_(model_input.kv_cache_kernel_block_id, /*non_blocking=*/false);
-            model_input.kv_cache_kernel_block_id = host_table;
-        }
-
         // Focused refresh of device block tables and graph-held buffers,
         // skipping unrelated prepareAttentionInputs work.
         model_->updateKVCacheKernelBlockId(model_input);
@@ -2068,7 +2161,10 @@ SamplerOutput MtpExecutor::sampleDSparkDraft(const StreamGroups&  stream_groups,
     int64_t         row                  = 0;
     constexpr float kMinDraftTemperature = 1.0e-6f;
     for (const auto& stream : stream_groups.allStreams()) {
-        RTP_LLM_CHECK_WITH_INFO(stream->maxBatchSize() == 1 && !stream->needTilingForSampling(),
+        // DSpARK admission is configuration-defined. needTilingForSampling()
+        // consults mutable output-token history and must not be called while
+        // the prior asynchronous commit owns that history.
+        RTP_LLM_CHECK_WITH_INFO(stream->maxBatchSize() == 1 && !stream->hasNumBeams(),
                                 "DSpARK does not support tiled or beam sampling");
         const auto config = stream->generateConfig();
         if (!std::isfinite(config->temperature) || config->temperature < 0.0f) {
@@ -2091,32 +2187,23 @@ SamplerOutput MtpExecutor::sampleDSparkDraft(const StreamGroups&  stream_groups,
         base_logits, anchors, temperature, dspark_markov_w1_, dspark_markov_w2_, draft_vocab_size_);
 }
 
-void MtpExecutor::dsparkModelDecode(GptModelInputs&                                 model_input,
-                                    const StreamGroups&                             stream_groups,
-                                    const MtpBatchStreamProcessor::DSparkRoundHead& round_head,
-                                    SamplerOutput&                                  draft_sampler_output,
-                                    torch::Tensor&                                  draft_token_ids_t,
-                                    int64_t&                                        model_forward_us) {
+void MtpExecutor::runDSparkProposal(GptModelInputs&                                  proposal_input,
+                                    const StreamGroups&                              stream_groups,
+                                    const MtpBatchStreamProcessor::DSparkRoundState& round_state,
+                                    SamplerOutput&                                   draft_sampler_output,
+                                    int64_t&                                         model_forward_us) {
     RTP_LLM_PROFILE_SCOPE_DYNAMIC("executor.mtp.dspark_model_decode(batch_size=%zu)",
-                                  model_input.input_lengths.size(0));
+                                  proposal_input.input_lengths.size(0));
 
     const auto& draft_cache_cfg = cache_manager_->getMTPModuleCacheConfig(0);
-    applyCacheStrideToModelInput(model_input, draft_cache_cfg);
+    applyCacheStrideToModelInput(proposal_input, draft_cache_cfg);
     int64_t start_time_us  = autil::TimeUtility::currentTimeInMicroSeconds();
-    auto    propose_output = runDSparkProposeForward(model_input);
+    auto    propose_output = runDSparkProposeForward(proposal_input);
     model_forward_us += autil::TimeUtility::currentTimeInMicroSeconds() - start_time_us;
 
     if (isTpRank0()) {
-        draft_sampler_output = sampleDSparkDraft(stream_groups, propose_output.logits, round_head.anchors);
-        batch_stream_processor_->updateDSparkTargetVerifyModelInput(
-            round_head, model_input, draft_sampler_output.token_ids, buffer_holder_);
-        draft_token_ids_t = model_input.combo_tokens.reshape(
-            {static_cast<int64_t>(model_input.input_lengths.size(0)), static_cast<int64_t>(propose_step_ + 1)});
+        draft_sampler_output = sampleDSparkDraft(stream_groups, propose_output.logits, round_state.anchors);
     }
-
-    applyCacheStrideToModelInput(model_input, cache_manager_->cacheConfig());
-    tpSyncModelInputs(model_input, parallelism_config_);
-    ensureModelInputsOnCuda(model_input, "decode.dspark_target_verify");
 }
 
 GptModelOutputs MtpExecutor::runDraftPrefillForward(GptModelInputs& model_input) {
@@ -2172,6 +2259,9 @@ void MtpExecutor::collectDecodeMetrics(const StreamGroups&                      
 absl::Status MtpExecutor::dispatchDecodeOutput(const StreamGroups&                          stream_groups,
                                                const std::list<GenerateStreamPtr>&          streams,
                                                const speculative::SpeculativeSamplerOutput& speculative_sampler_output,
+                                               const torch::Tensor&                         verify_position_ids,
+                                               const torch::Tensor&                         kv_cache_block_id,
+                                               const torch::Tensor&                         kv_cache_kernel_block_id,
                                                GptModelOutputs                              draft_prefill_model_output,
                                                SamplerOutput                 draft_prefill_sampler_output,
                                                std::shared_ptr<torch::Event> rejection_event,
@@ -2183,6 +2273,9 @@ absl::Status MtpExecutor::dispatchDecodeOutput(const StreamGroups&              
         // via cudaStreamWaitEvent; the main thread returns immediately.
         result = dispatchDecodeAsync(stream_groups,
                                      speculative_sampler_output,
+                                     verify_position_ids,
+                                     kv_cache_block_id,
+                                     kv_cache_kernel_block_id,
                                      {std::move(draft_prefill_model_output), std::move(draft_prefill_sampler_output)},
                                      std::move(rejection_event),
                                      std::move(draft_event));
@@ -2192,7 +2285,8 @@ absl::Status MtpExecutor::dispatchDecodeOutput(const StreamGroups&              
         result =
             batch_stream_processor_->dispatchDecode(stream_groups, speculative_sampler_output, draft_prefill_output);
         if (result.ok() && useAsyncDeviceState()) {
-            publishSyncMtpDeviceState(stream_groups, speculative_sampler_output, draft_prefill_output);
+            publishSyncMtpDeviceState(
+                stream_groups, speculative_sampler_output, verify_position_ids, draft_prefill_output);
         }
     }
     return result;
@@ -2227,12 +2321,21 @@ void MtpExecutor::prepareStreams(const std::list<GenerateStreamPtr>& streams,
             continue;
         }
 
+        // A steady decode stream may overlap this main-thread preparation
+        // with the previous bookkeeping worker. Its score/probability mode and
+        // speculative buffer were initialized before the first async round;
+        // repeated writes here would race the worker's specUpdate reads/writes.
+        const bool use_mtp_snapshot = stream->hasMtpCacheSnapshot();
+        const bool is_context       = use_mtp_snapshot ? false : stream->isContextStream();
+
         // split streams into prefill and decode
-        if (stream->isContextStream()) {
+        if (is_context) {
             prefill_streams.push_back(stream);
         } else {
-            stream->setScoreLen(propose_step_ + 1);
-            if (stream->getSPOutputBuffer() == nullptr && stream->isPerfTest()) {
+            if (!use_mtp_snapshot) {
+                stream->setScoreLen(propose_step_ + 1);
+            }
+            if (!use_mtp_snapshot && stream->getSPOutputBuffer() == nullptr && stream->isPerfTest()) {
                 auto sp_output_buffer =
                     makeFakeSPOutputBuffer(data_type_, hidden_size_, draft_vocab_size_, propose_step_, is_dspark_);
                 stream->setSPOutputBuffer(sp_output_buffer);
@@ -2241,8 +2344,10 @@ void MtpExecutor::prepareStreams(const std::list<GenerateStreamPtr>& streams,
         }
 
         // set base properties
-        stream->setReturnAllProbs(ReturnAllProbsMode::DEFAULT);
-        if (stream->getSPOutputBuffer() == nullptr) {
+        if (!use_mtp_snapshot) {
+            stream->setReturnAllProbs(ReturnAllProbsMode::DEFAULT);
+        }
+        if (!use_mtp_snapshot && stream->getSPOutputBuffer() == nullptr) {
             auto sp_output_buffer    = std::make_shared<SpeculativeExecutorStreamOutput>();
             sp_output_buffer->tokens = torch::zeros({1, static_cast<int64_t>(is_dspark_ ? 1 : 2)}, torch::kInt32);
 
@@ -2250,8 +2355,10 @@ void MtpExecutor::prepareStreams(const std::list<GenerateStreamPtr>& streams,
         }
 
         // set propose_step
-        auto sp_output_buffer          = stream->getSPOutputBuffer();
-        sp_output_buffer->propose_step = propose_step_;
+        if (!use_mtp_snapshot) {
+            auto sp_output_buffer          = stream->getSPOutputBuffer();
+            sp_output_buffer->propose_step = propose_step_;
+        }
     }
 }
 
@@ -2263,13 +2370,15 @@ absl::Status MtpExecutor::process(const std::list<GenerateStreamPtr>& streams, i
         schedule_time_us = process_start_time_us;
     }
     MtpMetricsCollector metrics_collector;
-    auto tps_active_guard =
+    auto                tps_active_guard =
         tps_reporter_.makeActiveGuard(metrics_reporter_ && isTpRank0() && !warm_up_ && !streams.empty());
     auto wall_tps_active_guard =
         wall_tps_reporter_.makeActiveGuard(metrics_reporter_ && isTpRank0() && !warm_up_ && !streams.empty());
 
     std::list<GenerateStreamPtr> prefill_streams;
     std::list<GenerateStreamPtr> decode_streams;
+
+    waitPreviousBookkeepingBeforeStreamPreparation(streams);
 
     // prepare streams
     prepareStreams(streams, prefill_streams, decode_streams);
@@ -2355,12 +2464,12 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
         tensor_d      = tensor_d.reshape({static_cast<int64_t>(batch_size)});
         return tensor_d.is_contiguous() ? tensor_d : tensor_d.contiguous();
     };
-    spec_prefix_lengths = model_input.prefix_lengths.defined() && model_input.prefix_lengths.numel() > 0 ?
-                              toCudaInt32WithHostHold(model_input.prefix_lengths, buffer_holder_) :
-                              (model_input.sequence_lengths.defined() ?
-                                   (toCudaInt32WithHostHold(model_input.sequence_lengths, buffer_holder_) - 1)
-                                       .to(torch::kInt32) :
-                                   torch::Tensor());
+    spec_prefix_lengths =
+        model_input.prefix_lengths.defined() && model_input.prefix_lengths.numel() > 0 ?
+            toCudaInt32WithHostHold(model_input.prefix_lengths, buffer_holder_) :
+            (model_input.sequence_lengths.defined() ?
+                 (toCudaInt32WithHostHold(model_input.sequence_lengths, buffer_holder_) - 1).to(torch::kInt32) :
+                 torch::Tensor());
     // prefix_lengths belongs to the eventual target verify input. Draft decode
     // attention metadata must be driven only by sequence_lengths.
     model_input.prefix_lengths = torch::empty({0}, cuda_i32);
@@ -2387,8 +2496,9 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
             accept_tokens_slices.reserve(batch_size);
             accept_len_slices.reserve(batch_size);
             for (const auto& stream : all_streams) {
-                const auto& accept_tokens = stream->getAcceptTokensGpu();
-                const auto& accept_len    = stream->getAcceptLenGpu();
+                const auto state          = stream->getMtpAsyncDeviceState();
+                const auto& accept_tokens = state.accept_tokens_gpu;
+                const auto& accept_len    = state.accept_len_gpu;
                 if (!accept_tokens.defined() || !accept_tokens.is_cuda() || !accept_len.defined()
                     || !accept_len.is_cuda()) {
                     all_device_state = false;
@@ -2401,11 +2511,9 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
                 // Batch gather: [batch, propose_step+1] -> pick column [accept_len-1] per row
                 auto accept_tokens_2d = torch::cat(accept_tokens_slices, 0);  // [batch, cols]
                 auto accept_len_batch = torch::cat(accept_len_slices, 0);     // [batch]
-                auto idx_long = (accept_len_batch.to(torch::kInt64) - 1)
-                                    .reshape({(int64_t)batch_size, 1});
-                pre_target_token_t = accept_tokens_2d.gather(1, idx_long)
-                                         .reshape({(int64_t)batch_size})
-                                         .to(torch::kInt32);
+                auto idx_long         = (accept_len_batch.to(torch::kInt64) - 1).reshape({(int64_t)batch_size, 1});
+                pre_target_token_t =
+                    accept_tokens_2d.gather(1, idx_long).reshape({(int64_t)batch_size}).to(torch::kInt32);
             }
         }
         if (!all_device_state && all_streams.empty()) {
@@ -2469,7 +2577,7 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
     {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.draft_model_decode(build_spec_decode_input)");
         // prepare spec decode input
-        const auto    tokens_per_batch = static_cast<int32_t>(propose_step_ + 1);
+        const auto tokens_per_batch = static_cast<int32_t>(propose_step_ + 1);
         (void)tokens_per_batch;  // consumed only by the USING_CUDA fused path
         torch::Tensor input_lengths;
 #if USING_CUDA
@@ -2511,8 +2619,8 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
 #endif
 
         model_input.input_lengths  = std::move(input_lengths);
-        model_input.prefix_lengths    = spec_prefix_lengths;
-        model_input.combo_tokens      = draft_token_ids_t.reshape({(int64_t)(batch_size * (propose_step_ + 1))});
+        model_input.prefix_lengths = spec_prefix_lengths;
+        model_input.combo_tokens   = draft_token_ids_t.reshape({(int64_t)(batch_size * (propose_step_ + 1))});
         batch_stream_processor_->expandTargetVerifyPositionIds(stream_groups, model_input);
         model_input.sequence_lengths =
             torch::empty({0}, torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
@@ -2562,8 +2670,34 @@ bool MtpExecutor::useAsyncPrepare() const {
     return enabled;
 }
 
+torch::Tensor MtpExecutor::advanceDSparkPositionIds(const torch::Tensor& verify_position_ids,
+                                                    const torch::Tensor& accept_len,
+                                                    int64_t              batch_size,
+                                                    int64_t              verify_width) {
+    if (!verify_position_ids.defined()) {
+        return torch::Tensor();
+    }
+    RTP_LLM_CHECK_WITH_INFO(batch_size > 0 && verify_width > 0,
+                            "DSpARK position advance requires positive batch and verify width");
+    RTP_LLM_CHECK_WITH_INFO(verify_position_ids.is_cuda() && accept_len.is_cuda(),
+                            "DSpARK position advance requires CUDA tensors");
+    RTP_LLM_CHECK_WITH_INFO(verify_position_ids.scalar_type() == torch::kInt32,
+                            "DSpARK verify positions must be int32");
+    RTP_LLM_CHECK_WITH_INFO(verify_position_ids.numel() % (batch_size * verify_width) == 0,
+                            "DSpARK verify position rows mismatch: numel=%ld batch=%ld width=%ld",
+                            verify_position_ids.numel(),
+                            batch_size,
+                            verify_width);
+    const int64_t position_factor = verify_position_ids.numel() / (batch_size * verify_width);
+    RTP_LLM_CHECK_WITH_INFO(position_factor > 0, "DSpARK verify position factor must be positive");
+    auto verify_positions = verify_position_ids.reshape({batch_size, verify_width, position_factor});
+    auto accept_offsets   = accept_len.to(torch::kInt32).reshape({batch_size, 1});
+    return (verify_positions.select(1, 0) + accept_offsets).to(torch::kInt32).contiguous();
+}
+
 void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                          stream_groups,
                                             const speculative::SpeculativeSamplerOutput& spec_decode_output,
+                                            const torch::Tensor&                         verify_position_ids,
                                             const MergedOutput&                          draft_prefill_output) {
     RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(publish_sync_mtp_device_state)");
 
@@ -2599,8 +2733,8 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     }
 
     // Batch compute next_seq_len from host seqLength (sync path: host is authoritative)
-    const auto pin_i32      = torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true);
-    const auto cuda_i32     = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    const auto pin_i32          = torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true);
+    const auto cuda_i32         = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
     auto       next_seq_len_cpu = torch::empty({batch_size}, pin_i32);
     {
         int64_t i = 0;
@@ -2617,13 +2751,12 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     torch::Tensor last_hidden_all;
     const auto    stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
     if (propose_step_ > 1 && !is_dspark_ && draft_all_hidden_full.defined()) {
-        const auto hidden_size  = draft_all_hidden_full.size(1);
-        auto       hidden_3d    = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
-        auto       accept_i32   = accept_len_all.to(torch::kInt32);
-        auto       idx_long     = (accept_i32.to(torch::kInt64) - 1)
-                                     .reshape({batch_size, 1, 1})
-                                     .expand({batch_size, 1, hidden_size});
-        last_hidden_all         = hidden_3d.gather(1, idx_long).squeeze(1);
+        const auto hidden_size = draft_all_hidden_full.size(1);
+        auto       hidden_3d   = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
+        auto       accept_i32  = accept_len_all.to(torch::kInt32);
+        auto       idx_long =
+            (accept_i32.to(torch::kInt64) - 1).reshape({batch_size, 1, 1}).expand({batch_size, 1, hidden_size});
+        last_hidden_all = hidden_3d.gather(1, idx_long).squeeze(1);
     }
 
     // One clone for all probs
@@ -2631,27 +2764,32 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     if (draft_all_probs_full.defined()) {
         draft_probs_all = draft_all_probs_full.clone();
     }
+    auto next_position_ids_all =
+        is_dspark_ ? advanceDSparkPositionIds(
+            verify_position_ids, accept_len_all, batch_size, static_cast<int64_t>(propose_step_ + 1)) :
+                     torch::Tensor();
 
     // Assign per-stream views
     int64_t probs_batch_off = 0;
     int64_t idx             = 0;
     for (auto& stream : all_streams) {
         GenerateStream::MtpAsyncDeviceState state;
-        state.accept_len_gpu     = accept_len_all.narrow(0, idx, 1);
-        state.accept_tokens_gpu  = accept_tokens_all.narrow(0, idx, 1);
+        state.accept_len_gpu    = accept_len_all.narrow(0, idx, 1);
+        state.accept_tokens_gpu = accept_tokens_all.narrow(0, idx, 1);
         state.propose_tokens_gpu =
             propose_tokens_all.defined() ? propose_tokens_all.narrow(0, idx, 1) : torch::Tensor();
-        state.next_seq_len_gpu   = next_seq_len_owned.narrow(0, idx, 1);
-        state.last_hidden_states_gpu =
-            last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
+        state.next_seq_len_gpu = next_seq_len_owned.narrow(0, idx, 1);
+        state.next_position_ids_gpu =
+            next_position_ids_all.defined() ? next_position_ids_all.narrow(0, idx, 1) : torch::Tensor();
+        state.last_hidden_states_gpu = last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
 
         const auto next_batch_size = stream->nextBatchSize();
         if (draft_probs_all.defined() && next_batch_size > 0) {
             state.draft_all_probs_gpu = draft_probs_all.narrow(0, probs_batch_off, next_batch_size);
         }
 
-        state.last_real_seq_len = stream->seqLength();
-        state.next_real_seq_len = state.last_real_seq_len;
+        state.previous_seq_len_upper_bound = stream->seqLength();
+        state.next_seq_len_upper_bound     = state.previous_seq_len_upper_bound;
         stream->setMtpAsyncDeviceState(std::move(state));
 
         probs_batch_off += next_batch_size;
@@ -2661,16 +2799,19 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
 
 absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&                          stream_groups,
                                               const speculative::SpeculativeSamplerOutput& spec_decode_output,
+                                              const torch::Tensor&                         verify_position_ids,
+                                              const torch::Tensor&                         kv_cache_block_id,
+                                              const torch::Tensor&                         kv_cache_kernel_block_id,
                                               MergedOutput                                 draft_prefill_output,
                                               std::shared_ptr<torch::Event>                rejection_event,
                                               std::shared_ptr<torch::Event>                draft_event) {
     RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(dispatch_output_async)");
 
-    const auto& accept_len_gpu_all    = spec_decode_output.accept_len;
-    const auto& accept_tokens_gpu_all = spec_decode_output.accept_tokens;
+    const auto& accept_len_gpu_all     = spec_decode_output.accept_len;
+    const auto& accept_tokens_gpu_all  = spec_decode_output.accept_tokens;
     const auto& propose_tokens_gpu_all = draft_prefill_output.sampler_output.token_ids;
-    const auto& draft_all_hidden_full = draft_prefill_output.model_output.all_hidden_states;
-    const auto& draft_all_probs_full  = draft_prefill_output.sampler_output.all_probs;
+    const auto& draft_all_hidden_full  = draft_prefill_output.model_output.all_hidden_states;
+    const auto& draft_all_probs_full   = draft_prefill_output.sampler_output.all_probs;
 
     auto       all_streams = stream_groups.allStreams();
     const auto batch_size  = static_cast<int64_t>(all_streams.size());
@@ -2693,23 +2834,22 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
             if (gpu_val.defined() && gpu_val.is_cuda()) {
                 prev_slices.push_back(gpu_val.reshape({1}));
             } else {
-                prev_slices.push_back(
-                    torch::tensor({static_cast<int32_t>(stream->seqLength())}, cuda_i32));
+                prev_slices.push_back(torch::tensor({static_cast<int32_t>(stream->seqLength())}, cuda_i32));
             }
         }
         prev_seq_len_all = torch::cat(prev_slices, 0);
 
         next_seq_len_all = torch::empty({batch_size}, cuda_i32);
-        hidden_idx_all = torch::empty({batch_size}, cuda_i64);
+        hidden_idx_all   = torch::empty({batch_size}, cuda_i64);
 
         auto accept_len_i32 = accept_len_gpu_all.to(torch::kInt32);
 #if USING_CUDA
         invokeMtpDispatchStatePrepare(accept_len_i32,
-                                       prev_seq_len_all,
-                                       next_seq_len_all,
-                                       hidden_idx_all,
-                                       batch_size,
-                                       at::cuda::getCurrentCUDAStream().stream());
+                                      prev_seq_len_all,
+                                      next_seq_len_all,
+                                      hidden_idx_all,
+                                      batch_size,
+                                      at::cuda::getCurrentCUDAStream().stream());
 #else
         next_seq_len_all = prev_seq_len_all + accept_len_i32;
         hidden_idx_all   = (accept_len_i32.to(torch::kInt64) - 1);
@@ -2718,7 +2858,7 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
 
     // 2. Batch gather hidden states (1 gather op instead of N index_selects)
     torch::Tensor last_hidden_all;
-    const auto stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
+    const auto    stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
     if (propose_step_ > 1 && !is_dspark_ && draft_all_hidden_full.defined()) {
         const auto hidden_size  = draft_all_hidden_full.size(1);
         auto       hidden_3d    = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
@@ -2731,6 +2871,43 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
     if (draft_all_probs_full.defined()) {
         draft_probs_all = draft_all_probs_full.clone();
     }
+    auto next_position_ids_all =
+        is_dspark_ ? advanceDSparkPositionIds(
+            verify_position_ids, accept_len_gpu_all, batch_size, static_cast<int64_t>(propose_step_ + 1)) :
+                     torch::Tensor();
+
+    torch::Tensor next_kv_cache_block_id;
+    torch::Tensor next_kv_cache_kernel_block_id;
+    if (is_linear_attention_model_ && useDeviceInput() && kv_cache_block_id.defined()
+        && kv_cache_block_id.is_cuda() && kv_cache_kernel_block_id.defined() && kv_cache_kernel_block_id.is_cuda()) {
+        RTP_LLM_CHECK_WITH_INFO(kv_cache_block_id.dim() == 3 && kv_cache_block_id.size(1) == batch_size,
+                                "MTP physical cache snapshot source must be [group,batch,blocks], batch=%ld",
+                                batch_size);
+        RTP_LLM_CHECK_WITH_INFO(kv_cache_kernel_block_id.dim() == 3 && kv_cache_kernel_block_id.size(1) == batch_size,
+                                "MTP kernel cache snapshot source must be [group,batch,blocks], batch=%ld",
+                                batch_size);
+        const auto group_types = cache_manager_->cacheConfig().groupTypesSnapshot();
+        const auto block_size  = static_cast<int>(cache_manager_->cacheConfig().seq_size_per_block);
+        const auto table_width = std::min(kv_cache_block_id.size(2), kv_cache_kernel_block_id.size(2));
+        if (hasLinearCacheSnapshotCapacity(
+                all_streams, table_width, static_cast<int>(propose_step_ + 1), block_size)) {
+            auto accept_i32 = accept_len_gpu_all.to(torch::kInt32);
+            next_kv_cache_block_id = MtpBatchStreamProcessor::advanceLinearCacheBlockTable(
+                kv_cache_block_id, prev_seq_len_all, accept_i32, group_types, block_size);
+            next_kv_cache_kernel_block_id = MtpBatchStreamProcessor::advanceLinearCacheBlockTable(
+                kv_cache_kernel_block_id, prev_seq_len_all, accept_i32, group_types, block_size);
+        } else {
+            // This should coincide with an allocator boundary. Publishing no
+            // snapshot makes the next scheduler iteration join bookkeeping and
+            // rebuild both tables from authoritative host state instead of
+            // risking an out-of-range CUDA gather.
+            RTP_LLM_LOG_DEBUG("MTP cache snapshot capacity exhausted: physical_width=%ld kernel_width=%ld "
+                              "batch=%ld; next round will synchronize and regather",
+                              kv_cache_block_id.size(2),
+                              kv_cache_kernel_block_id.size(2),
+                              batch_size);
+        }
+    }
 
     // 4. Assign per-stream views (narrow is metadata-only, no kernel launch)
     int64_t probs_batch_off = 0;
@@ -2742,16 +2919,28 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
         state.propose_tokens_gpu =
             propose_tokens_gpu_all.defined() ? propose_tokens_gpu_all.narrow(0, idx, 1) : torch::Tensor();
         state.next_seq_len_gpu       = next_seq_len_all.narrow(0, idx, 1);
-        state.last_hidden_states_gpu =
-            last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
+        state.next_position_ids_gpu =
+            next_position_ids_all.defined() ? next_position_ids_all.narrow(0, idx, 1) : torch::Tensor();
+        state.next_kv_cache_block_id_gpu =
+            next_kv_cache_block_id.defined() ? next_kv_cache_block_id.narrow(1, idx, 1) : torch::Tensor();
+        state.next_kv_cache_kernel_block_id_gpu =
+            next_kv_cache_kernel_block_id.defined() ? next_kv_cache_kernel_block_id.narrow(1, idx, 1) : torch::Tensor();
+        state.last_hidden_states_gpu = last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
 
         const auto next_batch_size = stream->nextBatchSize();
         if (draft_probs_all.defined() && next_batch_size > 0) {
             state.draft_all_probs_gpu = draft_probs_all.narrow(0, probs_batch_off, next_batch_size);
         }
 
-        state.last_real_seq_len = stream->seqLength();
-        state.next_real_seq_len = state.last_real_seq_len + static_cast<int>(propose_step_ + 1);
+        const auto previous_state = stream->getMtpAsyncDeviceState();
+        const bool  pending        = stream->hasPendingAsyncBookkeeping();
+        const int   host_seq_len    = pending ? -1 : stream->seqLength();
+        state.previous_seq_len_upper_bound = selectMtpPreviousSeqLenUpperBound(
+            pending, previous_state.next_seq_len_upper_bound, host_seq_len);
+        RTP_LLM_CHECK_WITH_INFO(state.previous_seq_len_upper_bound > 0,
+                                "pending MTP bookkeeping requires a published sequence-length upper bound");
+        state.next_seq_len_upper_bound =
+            state.previous_seq_len_upper_bound + static_cast<int>(propose_step_ + 1);
         stream->setMtpAsyncDeviceState(std::move(state));
 
         probs_batch_off += next_batch_size;
@@ -2795,12 +2984,6 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
         auto status = processor->dispatchDecode(stream_groups_copy, spec_decode_copy, draft_prefill_copy);
         if (!status.ok()) {
             RTP_LLM_LOG_ERROR("[stream-async] dispatchDecode (worker) failed: %s", status.ToString().c_str());
-        }
-
-        for (auto& stream : worker_streams) {
-            auto event = std::make_shared<torch::Event>(cuda_graph::makeGraphEvent());
-            event->record(cuda_graph::graphGetCurrentStream());
-            stream->setPendingSwapDoneEvent(std::static_pointer_cast<void>(event));
         }
     });
 

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.h
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.h
@@ -89,6 +89,11 @@ public:
                                                        const ResourceContext& resource_context,
                                                        int                    vocab_size,
                                                        bool                   is_dspark = false);
+    static bool              mustWaitBeforeStreamPreparation(bool stream_async,
+                                                             bool drop_broad_sync,
+                                                             bool linear_attention,
+                                                             bool cache_snapshot_ready = false);
+    static int selectMtpPreviousSeqLenUpperBound(bool pending, int previous_next_bound, int host_seq_len);
 
 protected:
     static bool dsparkPrefillCPRoleIsValid(const PrefillCPConfig& prefill_cp_config, RoleType role_type);
@@ -116,9 +121,8 @@ protected:
     // last_hidden_states hand-off. hidden_rows == 0 means "use the tensor's own
     // row count"; target verify passes the explicit combo row count because a
     // graph replay does not advance the Python-side row counter.
-    void maybeOverrideLastHiddenWithMtpBuffer(GptModelOutputs& model_output,
-                                              ModelBase&       source,
-                                              int64_t          hidden_rows = 0);
+    void
+    maybeOverrideLastHiddenWithMtpBuffer(GptModelOutputs& model_output, ModelBase& source, int64_t hidden_rows = 0);
 
     void maybePrintModelInput(const GptModelInputs& model_input, const std::string& prefix) const;
 
@@ -129,9 +133,9 @@ protected:
     absl::Status decodeStep(const std::list<GenerateStreamPtr>& streams, MtpMetricsCollector& metrics_collector);
 
     // decodeStep helpers — extracted to keep decodeStep readable. Each helper
-    // owns a single phase (sync, prepare, forward, broadcast, dispatch) and
+    // owns a single phase (prepare, forward, broadcast, dispatch) and
     // preserves the original PROFILE_SCOPE labels.
-    void            waitPreviousBookkeepingAndKvSwaps(const std::list<GenerateStreamPtr>& streams);
+    void            waitPreviousBookkeepingBeforeStreamPreparation(const std::list<GenerateStreamPtr>& streams);
     void            prepareGrpcMtpDeviceState(const std::list<GenerateStreamPtr>& streams, TensorHolder& host_holder);
     void            launchTargetVerifyPrepareAsync(const GptModelInputs& model_input, size_t batch_size);
     void            launchDraftPrefillPrepareAsync(const GptModelInputs& model_input);
@@ -143,12 +147,11 @@ protected:
     SamplerOutput   sampleDSparkDraft(const StreamGroups&  stream_groups,
                                       const torch::Tensor& base_logits,
                                       const torch::Tensor& anchors);
-    void            dsparkModelDecode(GptModelInputs&                                 model_input,
-                                      const StreamGroups&                             stream_groups,
-                                      const MtpBatchStreamProcessor::DSparkRoundHead& round_head,
-                                      SamplerOutput&                                  draft_sampler_output,
-                                      torch::Tensor&                                  draft_token_ids_t,
-                                      int64_t&                                        model_forward_us);
+    void            runDSparkProposal(GptModelInputs&                                  proposal_input,
+                                      const StreamGroups&                              stream_groups,
+                                      const MtpBatchStreamProcessor::DSparkRoundState& round_state,
+                                      SamplerOutput&                                   draft_sampler_output,
+                                      int64_t&                                         model_forward_us);
     GptModelOutputs runDraftPrefillForward(GptModelInputs& model_input);
     SpecLogitsVerifyRunner::LaunchResult
                  buildSpecLogitsVerifyInline(const std::list<GenerateStreamPtr>& streams,
@@ -162,6 +165,9 @@ protected:
     absl::Status dispatchDecodeOutput(const StreamGroups&                          stream_groups,
                                       const std::list<GenerateStreamPtr>&          streams,
                                       const speculative::SpeculativeSamplerOutput& speculative_sampler_output,
+                                      const torch::Tensor&                         verify_position_ids,
+                                      const torch::Tensor&                         kv_cache_block_id,
+                                      const torch::Tensor&                         kv_cache_kernel_block_id,
                                       GptModelOutputs                              draft_prefill_model_output,
                                       SamplerOutput                                draft_prefill_sampler_output,
                                       std::shared_ptr<torch::Event>                rejection_event,
@@ -208,6 +214,9 @@ protected:
     // the main thread.
     absl::Status dispatchDecodeAsync(const StreamGroups&                          stream_groups,
                                      const speculative::SpeculativeSamplerOutput& spec_decode_output,
+                                     const torch::Tensor&                         verify_position_ids,
+                                     const torch::Tensor&                         kv_cache_block_id,
+                                     const torch::Tensor&                         kv_cache_kernel_block_id,
                                      MergedOutput                                 draft_prefill_output,
                                      std::shared_ptr<torch::Event>                rejection_event,
                                      std::shared_ptr<torch::Event>                draft_event);
@@ -216,29 +225,35 @@ protected:
     // the async path, using the host seqLength after specUpdate as truth.
     void publishSyncMtpDeviceState(const StreamGroups&                          stream_groups,
                                    const speculative::SpeculativeSamplerOutput& spec_decode_output,
+                                   const torch::Tensor&                         verify_position_ids,
                                    const MergedOutput&                          draft_prefill_output);
 
+    static torch::Tensor advanceDSparkPositionIds(const torch::Tensor& verify_position_ids,
+                                                  const torch::Tensor& accept_len,
+                                                  int64_t              batch_size,
+                                                  int64_t              verify_width);
+
     void releaseAllModelBuffers();
+
 private:
     static torch::Tensor snapshotMutableHostInputToCuda(const torch::Tensor& tensor, TensorHolder& holder);
 
     GptModelOutputs forwardModel(ModelBase* model, const GptModelInputs& inputs, ModelInputsModelRole role);
 
-    std::unique_ptr<ModelBase>               model_;
-    std::unique_ptr<Sampler>                 sampler_;
-    std::unique_ptr<MtpBatchStreamProcessor> batch_stream_processor_;
-    std::shared_ptr<KVCacheManager>          cache_manager_;
-    std::shared_ptr<ModelInputsLogger>       model_inputs_logger_;
-    bool                                     enable_ffn_disaggregate_ = false;
-    bool                                     enable_detail_log_       = false;
-    int                                      tp_rank_                 = 0;
-    ParallelismConfig                        parallelism_config_;
-    kmonitor::MetricsReporterPtr             metrics_reporter_ = nullptr;
+    std::unique_ptr<ModelBase>                                               model_;
+    std::unique_ptr<Sampler>                                                 sampler_;
+    std::unique_ptr<MtpBatchStreamProcessor>                                 batch_stream_processor_;
+    std::shared_ptr<KVCacheManager>                                          cache_manager_;
+    std::shared_ptr<ModelInputsLogger>                                       model_inputs_logger_;
+    bool                                                                     enable_ffn_disaggregate_ = false;
+    bool                                                                     enable_detail_log_       = false;
+    int                                                                      tp_rank_                 = 0;
+    ParallelismConfig                                                        parallelism_config_;
+    kmonitor::MetricsReporterPtr                                             metrics_reporter_ = nullptr;
     MetricsLoopReporter<RtpLLMTokenPSMetrics, RtpLLMTokenPSMetricsCollector> tps_reporter_;
-    WallClockMetricsLoopReporter<RtpLLMWallClockTokenPSMetrics, RtpLLMTokenPSMetricsCollector>
-        wall_tps_reporter_;
-    std::shared_ptr<ExpertBalancer>                                          expert_balancer_;
-    size_t                                                                   vocab_size_;
+    WallClockMetricsLoopReporter<RtpLLMWallClockTokenPSMetrics, RtpLLMTokenPSMetricsCollector> wall_tps_reporter_;
+    std::shared_ptr<ExpertBalancer>                                                            expert_balancer_;
+    size_t                                                                                     vocab_size_;
 
     // for mtp
     DataType data_type_;

--- a/rtp_llm/cpp/normal_engine/speculative/SpeculativeSampler.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/SpeculativeSampler.cc
@@ -70,10 +70,14 @@ SamplerOutput SpeculativeSampler::sampleDSparkDraft(const torch::Tensor& base_lo
         // the same q to rejection sampling. Request top-k/top-p stay target-side.
         logits.div_(temperature_column);
         auto sampling_probabilities = torch::softmax(logits, -1);
-        auto sampled_tokens         = execSampleFromProbs(sampling_probabilities).to(torch::kInt32);
+        auto sampled_draft_tokens   = execSampleFromProbs(sampling_probabilities).to(torch::kInt32);
+        auto sampled_target_tokens  = sampled_draft_tokens;
+        if (d2t_map_.defined()) {
+            sampled_target_tokens = d2t_map_.index_select(0, sampled_draft_tokens.to(torch::kLong)).to(torch::kInt32);
+        }
         all_probabilities.select(1, step).copy_(sampling_probabilities);
-        token_columns.push_back(sampled_tokens);
-        previous_tokens = sampled_tokens.to(torch::kLong);
+        token_columns.push_back(sampled_target_tokens);
+        previous_tokens = sampled_target_tokens.to(torch::kLong);
     }
 
     SamplerOutput output;

--- a/rtp_llm/cpp/normal_engine/speculative/test/MtpBatchStreamProcessorTest.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/test/MtpBatchStreamProcessorTest.cc
@@ -20,6 +20,7 @@
 #include "rtp_llm/models_py/bindings/core/Types.h"
 #include "rtp_llm/cpp/testing/TestBase.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
+#include "rtp_llm/cpp/utils/LinearBlocksUtil.h"
 
 using namespace std;
 
@@ -148,6 +149,12 @@ public:
         auto last_hidden_states_h = last_hidden_states.is_cuda() ? last_hidden_states.cpu() : last_hidden_states;
         EXPECT_EQ(expect_last_hidden_states, toVec<float>(last_hidden_states_h));
     }
+};
+
+class TestableMtpBatchStreamProcessor: public MtpBatchStreamProcessor {
+public:
+    using MtpBatchStreamProcessor::MtpBatchStreamProcessor;
+    using MtpBatchStreamProcessor::overlayMtpCacheSnapshots;
 };
 
 TEST_F(MtpBatchStreamProcessorTest, DISABLED_benchmarkScoreTokenIdsTorchCopyVsMemcpy) {
@@ -853,6 +860,16 @@ TEST_F(MtpBatchStreamProcessorTest, testDSparkRuntimeGammaThreePrefillInputShape
     EXPECT_EQ((std::vector<int32_t>{10, 6}), toVec<int32_t>(model_input.prefix_lengths));
     EXPECT_EQ((std::vector<int32_t>{gamma, gamma}), toVec<int32_t>(model_input.input_lengths));
     EXPECT_EQ((std::vector<int32_t>{0, 1, 2, 3, 4, 5}), toVec<int32_t>(model_input.lm_output_indexes));
+    // Fill-in DSpark keeps the anchor as conditioning only, so it queries one
+    // extra row while still proposing gamma tokens.
+    sp_config.sp_dspark_sample_from_anchor = false;
+    MtpBatchStreamProcessor qwen_processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, sp_config, false);
+    qwen_processor.buildDSparkProposeInput(model_input, anchors, committed_ends, host_holder);
+    EXPECT_EQ((std::vector<int32_t>{101, mask_id, mask_id, mask_id, 202, mask_id, mask_id, mask_id}),
+              toVec<int32_t>(model_input.combo_tokens));
+    EXPECT_EQ((std::vector<int32_t>{gamma + 1, gamma + 1}), toVec<int32_t>(model_input.input_lengths));
+    EXPECT_EQ((std::vector<int32_t>{1, 2, 3, 5, 6, 7}), toVec<int32_t>(model_input.lm_output_indexes));
 }
 
 TEST_F(MtpBatchStreamProcessorTest, testDSparkPrepareAndVerifyUsePerStreamDeviceState) {
@@ -867,6 +884,8 @@ TEST_F(MtpBatchStreamProcessorTest, testDSparkPrepareAndVerifyUsePerStreamDevice
     model_config.max_seq_len          = 2048;
     model_config.vocab_size           = 256;
     model_config.num_layers           = 1;
+    model_config.mm_model_config.mm_position_ids_style = MROPE;
+    model_config.attn_config.rope_config.index_factor  = 3;
     sp_config.type                    = SP_TYPE_DSPARK;
     sp_config.gen_num_per_cycle       = gamma;
     sp_config.sp_dspark_mask_token_id = 255;
@@ -877,6 +896,8 @@ TEST_F(MtpBatchStreamProcessorTest, testDSparkPrepareAndVerifyUsePerStreamDevice
     auto fresh_stream  = createContextStream(model_config, runtime_config, resource_context, {20, 21, 22}, 2);
     steady_stream->setIsContextStream(false);
     fresh_stream->setIsContextStream(false);
+    steady_stream->setContextPositionIds(torch::tensor({1, 1, 1, 2, 2, 2}, torch::kInt32));
+    fresh_stream->setContextPositionIds(torch::tensor({100, 101, 102, 110, 111, 112, 120, 121, 122}, torch::kInt32));
 
     // The steady stream's host token/length deliberately trail the state
     // published before its previous bookkeeping worker. The fresh stream has
@@ -885,6 +906,7 @@ TEST_F(MtpBatchStreamProcessorTest, testDSparkPrepareAndVerifyUsePerStreamDevice
     steady_state.accept_len_gpu    = torch::tensor({2}, torch::kInt32).to(torch::kCUDA);
     steady_state.accept_tokens_gpu = torch::tensor({{101, 102, 0, 0}}, torch::kInt32).to(torch::kCUDA);
     steady_state.next_seq_len_gpu  = torch::tensor({10}, torch::kInt32).to(torch::kCUDA);
+    steady_state.next_position_ids_gpu = torch::tensor({30, 40, 50}, torch::kInt32).to(torch::kCUDA);
     steady_stream->setMtpAsyncDeviceState(std::move(steady_state));
 
     StreamGroups   stream_groups({steady_stream, fresh_stream});
@@ -894,20 +916,37 @@ TEST_F(MtpBatchStreamProcessorTest, testDSparkPrepareAndVerifyUsePerStreamDevice
     MtpBatchStreamProcessor processor(
         model_config, pd_sep_config, profiling_debug_logging_config, cache_config, sp_config, false);
     TensorHolder host_holder;
-    auto         round_head = processor.prepareDSparkDraftModelInput(stream_groups, model_input, host_holder);
+    auto         round_state    = processor.buildDSparkRoundState(stream_groups, model_input, host_holder);
+    auto         proposal_input = model_input;
+    processor.prepareDSparkProposeModelInput(round_state, proposal_input, host_holder);
 
-    EXPECT_EQ((std::vector<int32_t>{102, 22}), toVec<int32_t>(round_head.anchors));
-    EXPECT_EQ((std::vector<int32_t>{9, 2}), toVec<int32_t>(round_head.committed_ends));
-    EXPECT_EQ((std::vector<int32_t>{102, 255, 255, 22, 255, 255}), toVec<int32_t>(model_input.combo_tokens));
-    EXPECT_EQ((std::vector<int32_t>{gamma, gamma}), toVec<int32_t>(model_input.input_lengths));
-    EXPECT_EQ((std::vector<int32_t>{9, 2}), toVec<int32_t>(model_input.prefix_lengths));
+    EXPECT_EQ((std::vector<int32_t>{102, 22}), toVec<int32_t>(round_state.anchors));
+    EXPECT_EQ((std::vector<int32_t>{9, 2}), toVec<int32_t>(round_state.committed_ends));
+    EXPECT_EQ((std::vector<int32_t>{102, 255, 255, 22, 255, 255}), toVec<int32_t>(proposal_input.combo_tokens));
+    EXPECT_EQ((std::vector<int32_t>{gamma, gamma}), toVec<int32_t>(proposal_input.input_lengths));
+    EXPECT_EQ((std::vector<int32_t>{9, 2}), toVec<int32_t>(proposal_input.prefix_lengths));
+    EXPECT_EQ((std::vector<int32_t>{30, 40, 50, 31, 41, 51, 32, 42, 52, 122, 122, 122, 123, 123, 123, 124, 124, 124}),
+              toVec<int32_t>(proposal_input.combo_position_ids));
+    EXPECT_TRUE(proposal_input.combo_position_ids.is_cuda());
+    // Proposal preparation must not mutate the target gather input.
+    EXPECT_FALSE(model_input.combo_tokens.defined());
+    EXPECT_FALSE(model_input.combo_position_ids.defined());
+
+    auto target_prepare_input = proposal_input;
+    processor.expandDSparkTargetVerifyPositionIdsFromProposal(target_prepare_input);
+    EXPECT_EQ((std::vector<int32_t>{30,  40,  50,  31,  41,  51,  32,  42,  52,  33,  43,  53,
+                                    122, 122, 122, 123, 123, 123, 124, 124, 124, 125, 125, 125}),
+              toVec<int32_t>(target_prepare_input.combo_position_ids));
 
     auto proposals = torch::tensor({{31, 32, 33}, {41, 42, 43}}, torch::kInt32).to(torch::kCUDA);
-    processor.updateDSparkTargetVerifyModelInput(round_head, model_input, proposals, host_holder);
+    processor.prepareDSparkTargetVerifyModelInput(round_state, model_input, proposals, host_holder);
     EXPECT_EQ((std::vector<int32_t>{102, 31, 32, 33, 22, 41, 42, 43}), toVec<int32_t>(model_input.combo_tokens));
     EXPECT_EQ((std::vector<int32_t>{gamma + 1, gamma + 1}), toVec<int32_t>(model_input.input_lengths));
     EXPECT_EQ((std::vector<int32_t>{9, 2}), toVec<int32_t>(model_input.prefix_lengths));
     EXPECT_EQ((std::vector<int32_t>{0, 1, 2, 3, 4, 5, 6, 7}), toVec<int32_t>(model_input.lm_output_indexes));
+    EXPECT_EQ((std::vector<int32_t>{30,  40,  50,  31,  41,  51,  32,  42,  52,  33,  43,  53,
+                                    122, 122, 122, 123, 123, 123, 124, 124, 124, 125, 125, 125}),
+              toVec<int32_t>(model_input.combo_position_ids));
 }
 
 TEST_F(MtpBatchStreamProcessorTest, testDSparkDecodeCommitPreservesDenseVerifyGeometry) {
@@ -1583,5 +1622,141 @@ TEST_F(MtpBatchStreamProcessorTest, testDSparkCommitOnlyPrefillDispatch) {
     EXPECT_FALSE(stream->getSPOutputBuffer()->all_probs.defined());
     EXPECT_FALSE(stream->getSPOutputBuffer()->hidden_states.defined());
     EXPECT_FALSE(stream->getSPOutputBuffer()->propose_tokens_gpu.defined());
+}
+
+TEST_F(MtpBatchStreamProcessorTest, testAdvanceLinearCacheBlockTableMatchesHostCommitSemantics) {
+    const std::vector<int32_t> previous_lengths = {1, 63, 64, 65, 127, 128, 129, 191};
+    const std::vector<int32_t> accept_lengths   = {1, 2, 3, 4, 5, 6, 7, 8};
+    constexpr int64_t          group_count      = 3;
+    constexpr int64_t          block_count      = 12;
+    const int64_t              batch_size       = static_cast<int64_t>(previous_lengths.size());
+
+    auto current = torch::arange(group_count * batch_size * block_count, torch::kInt32)
+                       .reshape({group_count, batch_size, block_count});
+    auto actual = MtpBatchStreamProcessor::advanceLinearCacheBlockTable(
+                      current.to(torch::kCUDA),
+                      torch::tensor(previous_lengths, torch::kInt32).to(torch::kCUDA),
+                      torch::tensor(accept_lengths, torch::kInt32).to(torch::kCUDA),
+                      {CacheGroupType::LINEAR, CacheGroupType::FULL, CacheGroupType::LINEAR},
+                      /*seq_size_per_block=*/64)
+                      .cpu();
+
+    auto expected = current.clone();
+    for (int64_t batch = 0; batch < batch_size; ++batch) {
+        const int accept = accept_lengths[static_cast<size_t>(batch)];
+        if (accept <= 1) {
+            continue;
+        }
+        const int  current_cached = previous_lengths[static_cast<size_t>(batch)] - 1;
+        const int  next_cached    = current_cached + accept;
+        const auto cached_swap    = getCachedTokenBlockSwapIdx(current_cached, next_cached, 64);
+        const auto final_swap     = getFinalTokenBlockSwapIdx(current_cached, next_cached, 64);
+        for (const int64_t group : {0L, 2L}) {
+            auto* row = expected.select(0, group).select(0, batch).data_ptr<int32_t>();
+            std::swap(row[cached_swap.first], row[cached_swap.second]);
+            std::swap(row[final_swap.first], row[final_swap.second]);
+        }
+    }
+
+    EXPECT_TRUE(torch::equal(actual, expected));
+    EXPECT_TRUE(torch::equal(actual.select(0, 1), current.select(0, 1)));
+}
+
+TEST_F(MtpBatchStreamProcessorTest, testAdvanceLinearCacheBlockTableMatchesEveryBlockOffsetAndAcceptLength) {
+    constexpr int32_t block_size       = 64;
+    constexpr int32_t max_accept       = 8;
+    constexpr int64_t group_count      = 2;
+    constexpr int64_t block_count      = 16;
+    constexpr int64_t offsets          = block_size;
+    constexpr int64_t batch_size       = offsets * max_accept;
+    std::vector<int32_t> previous_lengths;
+    std::vector<int32_t> accept_lengths;
+    previous_lengths.reserve(batch_size);
+    accept_lengths.reserve(batch_size);
+    for (int32_t offset = 0; offset < block_size; ++offset) {
+        for (int32_t accept = 1; accept <= max_accept; ++accept) {
+            // previous_length - 1 covers every cached-token offset in a block.
+            previous_lengths.push_back(block_size + offset + 1);
+            accept_lengths.push_back(accept);
+        }
+    }
+
+    auto current = torch::arange(group_count * batch_size * block_count, torch::kInt32)
+                       .reshape({group_count, batch_size, block_count});
+    auto actual = MtpBatchStreamProcessor::advanceLinearCacheBlockTable(
+                      current.to(torch::kCUDA),
+                      torch::tensor(previous_lengths, torch::kInt32).to(torch::kCUDA),
+                      torch::tensor(accept_lengths, torch::kInt32).to(torch::kCUDA),
+                      {CacheGroupType::LINEAR, CacheGroupType::FULL},
+                      block_size)
+                      .cpu();
+
+    auto expected = current.clone();
+    for (int64_t batch = 0; batch < batch_size; ++batch) {
+        const int accept = accept_lengths[static_cast<size_t>(batch)];
+        if (accept <= 1) {
+            continue;
+        }
+        const int current_cached = previous_lengths[static_cast<size_t>(batch)] - 1;
+        const int next_cached    = current_cached + accept;
+        const auto cached_swap   = getCachedTokenBlockSwapIdx(current_cached, next_cached, block_size);
+        const auto final_swap    = getFinalTokenBlockSwapIdx(current_cached, next_cached, block_size);
+        auto*      row           = expected.select(0, 0).select(0, batch).data_ptr<int32_t>();
+        std::swap(row[cached_swap.first], row[cached_swap.second]);
+        std::swap(row[final_swap.first], row[final_swap.second]);
+    }
+
+    EXPECT_TRUE(torch::equal(actual, expected));
+}
+
+TEST_F(MtpBatchStreamProcessorTest, testCacheSnapshotOverlayKeepsPhysicalKernelPairAndFreshRows) {
+    ModelConfig                 model_config;
+    RuntimeConfig               runtime_config;
+    SpeculativeExecutionConfig  sp_config;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config = makeProcessorCacheConfig();
+    model_config.max_seq_len                 = 2048;
+    model_config.vocab_size                  = 8;
+    model_config.num_layers                  = 1;
+    sp_config.gen_num_per_cycle              = 3;
+
+    ResourceContext resource_context;
+    auto steady = createContextStream(model_config, runtime_config, resource_context, {1}, 1);
+    auto fresh  = createContextStream(model_config, runtime_config, resource_context, {2}, 2);
+    steady->setIsContextStream(false);
+    fresh->setIsContextStream(false);
+
+    const auto cuda_i32 = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    GenerateStream::MtpAsyncDeviceState state;
+    state.next_kv_cache_block_id_gpu =
+        torch::tensor({11, 12, 13}, torch::kInt32).reshape({1, 1, 3}).to(cuda_i32);
+    state.next_kv_cache_kernel_block_id_gpu =
+        torch::tensor({101, 102, 103, 104}, torch::kInt32).reshape({1, 1, 4}).to(cuda_i32);
+    steady->setMtpAsyncDeviceState(std::move(state));
+
+    GptModelInputs model_input;
+    auto pinned_i32 = torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true);
+    model_input.kv_cache_block_id = torch::zeros({1, 2, 5}, pinned_i32);
+    model_input.kv_cache_kernel_block_id = torch::zeros({1, 2, 7}, pinned_i32);
+    model_input.kv_cache_block_id.select(1, 1).copy_(torch::tensor({21, 22, 23, 24, 25}, torch::kInt32));
+    model_input.kv_cache_kernel_block_id.select(1, 1).copy_(
+        torch::tensor({201, 202, 203, 204, 205, 206, 207}, torch::kInt32));
+
+    TestableMtpBatchStreamProcessor processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, sp_config, false);
+    TensorHolder holder;
+    processor.overlayMtpCacheSnapshots(StreamGroups({steady, fresh}), model_input, holder);
+
+    ASSERT_TRUE(model_input.kv_cache_block_id.is_cuda());
+    ASSERT_TRUE(model_input.kv_cache_kernel_block_id.is_cuda());
+    EXPECT_EQ((std::vector<int32_t>{11, 12, 13, 0, 0}),
+              toVec<int32_t>(model_input.kv_cache_block_id.select(1, 0)));
+    EXPECT_EQ((std::vector<int32_t>{21, 22, 23, 24, 25}),
+              toVec<int32_t>(model_input.kv_cache_block_id.select(1, 1)));
+    EXPECT_EQ((std::vector<int32_t>{101, 102, 103, 104, 0, 0, 0}),
+              toVec<int32_t>(model_input.kv_cache_kernel_block_id.select(1, 0)));
+    EXPECT_EQ((std::vector<int32_t>{201, 202, 203, 204, 205, 206, 207}),
+              toVec<int32_t>(model_input.kv_cache_kernel_block_id.select(1, 1)));
 }
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
@@ -85,6 +85,55 @@ TEST(MtpExecutorPolicyTest, CpRestoreSnapshotOwnsMutableHostInput) {
     EXPECT_EQ(holder.tensors.size(), 1);
 }
 
+TEST(MtpExecutorPolicyTest, HybridCacheWaitsBeforeReadingNextRoundHostState) {
+    EXPECT_FALSE(MtpExecutor::mustWaitBeforeStreamPreparation(
+        /*stream_async=*/false, /*drop_broad_sync=*/false, /*linear_attention=*/true));
+    EXPECT_TRUE(MtpExecutor::mustWaitBeforeStreamPreparation(
+        /*stream_async=*/true, /*drop_broad_sync=*/false, /*linear_attention=*/false));
+    EXPECT_FALSE(MtpExecutor::mustWaitBeforeStreamPreparation(
+        /*stream_async=*/true, /*drop_broad_sync=*/true, /*linear_attention=*/false));
+    EXPECT_TRUE(MtpExecutor::mustWaitBeforeStreamPreparation(
+        /*stream_async=*/true, /*drop_broad_sync=*/true, /*linear_attention=*/true));
+    EXPECT_FALSE(MtpExecutor::mustWaitBeforeStreamPreparation(/*stream_async=*/true,
+                                                              /*drop_broad_sync=*/true,
+                                                              /*linear_attention=*/true,
+                                                              /*cache_snapshot_ready=*/true));
+}
+
+TEST(MtpExecutorPolicyTest, MtpSequenceUpperBoundChainsUntilBookkeepingCatchesUp) {
+    constexpr int width = 8;
+    const int first_next = MtpExecutor::selectMtpPreviousSeqLenUpperBound(
+                               /*pending=*/false, /*previous_next_bound=*/-1, /*host_seq_len=*/96)
+                           + width;
+    const int second_next = MtpExecutor::selectMtpPreviousSeqLenUpperBound(
+                                /*pending=*/true, /*previous_next_bound=*/first_next, /*host_seq_len=*/96)
+                            + width;
+    const int third_next = MtpExecutor::selectMtpPreviousSeqLenUpperBound(
+                               /*pending=*/true, /*previous_next_bound=*/second_next, /*host_seq_len=*/96)
+                           + width;
+    EXPECT_EQ(104, first_next);
+    EXPECT_EQ(112, second_next);
+    EXPECT_EQ(120, third_next);
+    EXPECT_EQ(96, MtpExecutor::selectMtpPreviousSeqLenUpperBound(
+                      /*pending=*/false, /*previous_next_bound=*/third_next, /*host_seq_len=*/96));
+    EXPECT_EQ(96, MtpExecutor::selectMtpPreviousSeqLenUpperBound(
+                      /*pending=*/true, /*previous_next_bound=*/-1, /*host_seq_len=*/96));
+}
+
+TEST(MtpExecutorPolicyTest, DSparkPositionStateAdvancesByAcceptedLength) {
+    auto verify_positions = torch::tensor(
+        {10, 20, 30, 11, 21, 31, 12, 22, 32, 13, 23, 33, 100, 200, 300, 101, 201, 301, 102, 202, 302, 103, 203, 303},
+        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA));
+    auto accept_len = torch::tensor({2, 4}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA));
+
+    auto next_positions =
+        MtpExecutor::advanceDSparkPositionIds(verify_positions, accept_len, /*batch_size=*/2, /*verify_width=*/4);
+
+    EXPECT_TRUE(
+        torch::equal(next_positions.reshape({-1}).cpu(), torch::tensor({12, 22, 32, 104, 204, 304}, torch::kInt32)));
+    EXPECT_TRUE(next_positions.is_cuda());
+}
+
 struct MtpExecutorTestConfig {
     size_t  max_seq_len            = 2048;
     size_t  vocab_size             = 4;
@@ -1254,10 +1303,9 @@ TEST_F(MtpExecutorTest, testDecodeSpecLogitsCapReplacesInvalidDraftWithTargetTok
     target_input.input_lengths     = torch::tensor({3}, torch::kInt32);
     target_input.prefix_lengths    = torch::tensor({2}, torch::kInt32);
     target_input.lm_output_indexes = torch::tensor({0, 1, 2}, torch::kInt32);
-    target_output.logits =
-        torch::tensor({0.1f, 0.9f, 0.2f, 0.3f, 0.2f, 0.1f, 0.8f, 0.4f, 0.7f, 0.2f, 0.1f, 0.0f})
-            .reshape({3, 4})
-            .to(torch::kCUDA);
+    target_output.logits = torch::tensor({0.1f, 0.9f, 0.2f, 0.3f, 0.2f, 0.1f, 0.8f, 0.4f, 0.7f, 0.2f, 0.1f, 0.0f})
+                               .reshape({3, 4})
+                               .to(torch::kCUDA);
     target_output.all_hidden_states = torch::tensor({0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.06f}).reshape({3, 2});
 
     auto next_draft_input               = GptModelInputs{};
@@ -1275,22 +1323,18 @@ TEST_F(MtpExecutorTest, testDecodeSpecLogitsCapReplacesInvalidDraftWithTargetTok
     components.fake_target_model->setInputs({target_input});
     components.fake_target_model->setOutputs({target_output});
 
-    auto draft_sampler_output_1 = spec::FastTopKSamplerOutput{
-        torch::tensor({1.0f, 0.0f, 0.0f, 0.0f}).reshape({1, 4}),
-        torch::tensor({0}, torch::kInt32).reshape({1, 1})};
+    auto draft_sampler_output_1 = spec::FastTopKSamplerOutput{torch::tensor({1.0f, 0.0f, 0.0f, 0.0f}).reshape({1, 4}),
+                                                              torch::tensor({0}, torch::kInt32).reshape({1, 1})};
     auto next_draft_sampler_output = spec::FastTopKSamplerOutput{
-        torch::tensor({0.0f, 0.0f, 1.0f, 0.0f}).reshape({1, 4}),
-        torch::tensor({2}, torch::kInt32).reshape({1, 1})};
+        torch::tensor({0.0f, 0.0f, 1.0f, 0.0f}).reshape({1, 4}), torch::tensor({2}, torch::kInt32).reshape({1, 1})};
     components.fake_fast_topk_sampler->setInputs({draft_output_1.logits, next_draft_output.logits});
     components.fake_fast_topk_sampler->setOutputs({draft_sampler_output_1, next_draft_sampler_output});
 
     auto sampler_input         = SamplerInputs{target_output.logits.clone()};
     sampler_input.logits[0][3] = BaseLogitsProcessor::neg_inf;
-    auto target_sampler_output  = SamplerOutput{torch::tensor({1, 2, 2}, torch::kInt32).reshape({3, 1})};
-    target_sampler_output.all_probs = torch::tensor({0.0f, 1.0f, 0.0f, 0.0f,
-                                                     0.0f, 0.0f, 1.0f, 0.0f,
-                                                     0.0f, 0.0f, 1.0f, 0.0f})
-                                          .reshape({3, 4});
+    auto target_sampler_output = SamplerOutput{torch::tensor({1, 2, 2}, torch::kInt32).reshape({3, 1})};
+    target_sampler_output.all_probs =
+        torch::tensor({0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f}).reshape({3, 4});
     components.fake_sampler->setInputs({sampler_input});
     components.fake_sampler->setOutputs({target_sampler_output});
 
@@ -1643,6 +1687,33 @@ TEST_F(MtpExecutorTest, testDSparkDraftUsesDenseSequentialMarkovDistribution) {
     }
 }
 
+TEST_F(MtpExecutorTest, testDSparkReducedVocabFeedsMappedTargetTokenIntoMarkovChain) {
+    constexpr int32_t gamma             = 2;
+    constexpr int32_t draft_vocab_size  = 3;
+    constexpr int32_t target_vocab_size = 6;
+
+    const auto cuda_float = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    auto       d2t        = torch::tensor({1, 3, 5}, torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    spec::SpeculativeSampler sampler(d2t, gamma);
+
+    auto base_logits = torch::tensor({-100.0f, -100.0f, 100.0f, 0.0f, 0.0f, 0.0f}, torch::kFloat32)
+                           .reshape({gamma, draft_vocab_size})
+                           .to(torch::kCUDA);
+    auto anchors     = torch::tensor({0}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA));
+    auto temperature = torch::ones({1}, cuda_float);
+    auto markov_w1   = torch::tensor({0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f}, torch::kFloat32)
+                         .reshape({target_vocab_size, 1})
+                         .to(torch::kCUDA);
+    auto markov_w2 =
+        torch::tensor({-100.0f, 0.0f, 100.0f}, torch::kFloat32).reshape({draft_vocab_size, 1}).to(torch::kCUDA);
+
+    auto output = sampler.sampleDSparkDraft(base_logits, anchors, temperature, markov_w1, markov_w2, draft_vocab_size);
+
+    EXPECT_EQ((std::vector<int32_t>{5, 5}), toVec<int32_t>(output.token_ids.cpu()));
+    auto expected_second_q = torch::softmax(torch::tensor({-100.0f, 0.0f, 100.0f}), -1);
+    EXPECT_TRUE(torch::allclose(output.all_probs[0][1].cpu(), expected_second_q));
+}
+
 TEST_F(MtpExecutorTest, testDecodeOneStepSpecLogitsCapReplacesInvalidDraftWithTargetToken) {
     size_t propose_step = 1;
     size_t vocab_size   = 4;
@@ -1668,9 +1739,8 @@ TEST_F(MtpExecutorTest, testDecodeOneStepSpecLogitsCapReplacesInvalidDraftWithTa
     target_input.input_lengths     = torch::tensor({2}, torch::kInt32);
     target_input.prefix_lengths    = torch::tensor({2}, torch::kInt32);
     target_input.lm_output_indexes = torch::tensor({0, 1}, torch::kInt32);
-    target_output.logits           = torch::tensor({0.1f, 0.9f, 0.2f, 0.3f, 0.7f, 0.2f, 0.1f, 0.0f})
-                               .reshape({2, 4})
-                               .to(torch::kCUDA);
+    target_output.logits =
+        torch::tensor({0.1f, 0.9f, 0.2f, 0.3f, 0.7f, 0.2f, 0.1f, 0.0f}).reshape({2, 4}).to(torch::kCUDA);
     target_output.all_hidden_states = torch::tensor({0.01f, 0.02f, 0.03f, 0.04f}).reshape({2, 2});
 
     auto next_draft_input               = GptModelInputs{};
@@ -1689,8 +1759,7 @@ TEST_F(MtpExecutorTest, testDecodeOneStepSpecLogitsCapReplacesInvalidDraftWithTa
     components.fake_draft_model->setOutputs({next_draft_output});
 
     auto next_draft_sampler_output = spec::FastTopKSamplerOutput{
-        torch::tensor({0.0f, 0.0f, 1.0f, 0.0f}).reshape({1, 4}),
-        torch::tensor({2}, torch::kInt32).reshape({1, 1})};
+        torch::tensor({0.0f, 0.0f, 1.0f, 0.0f}).reshape({1, 4}), torch::tensor({2}, torch::kInt32).reshape({1, 1})};
     components.fake_fast_topk_sampler->setInputs({next_draft_output.logits});
     components.fake_fast_topk_sampler->setOutputs({next_draft_sampler_output});
 
@@ -1995,7 +2064,8 @@ TEST_F(MtpExecutorTest, testDraftModelDecodeExpandsTargetVerifyPositionIds) {
     std::vector<torch::Tensor> draft_probs_list;
     torch::Tensor              draft_token_ids_t;
     int64_t                    model_forward_us = 0;
-    components.executor->draftModelDecode(model_input, stream_groups, draft_probs_list, draft_token_ids_t, model_forward_us);
+    components.executor->draftModelDecode(
+        model_input, stream_groups, draft_probs_list, draft_token_ids_t, model_forward_us);
 
     EXPECT_EQ((std::vector<int>{10, 11, 12, 13, 14, 20, 21, 22, 23, 24}), toVec<int>(model_input.combo_tokens));
     EXPECT_EQ((std::vector<int>{5, 5}), toVec<int>(model_input.input_lengths));
@@ -2103,18 +2173,16 @@ TEST_F(MtpExecutorTest, testDispatchStatePrepareKernel) {
     // Verify next_seq_len = prev_seq_len + accept_len
     auto expected_next = (prev_seq_len + accept_len).cpu();
     auto actual_next   = next_seq_len.cpu();
-    EXPECT_TRUE(torch::equal(actual_next, expected_next))
-        << "next_seq_len mismatch:\n"
-        << actual_next << "\nvs expected:\n"
-        << expected_next;
+    EXPECT_TRUE(torch::equal(actual_next, expected_next)) << "next_seq_len mismatch:\n"
+                                                          << actual_next << "\nvs expected:\n"
+                                                          << expected_next;
 
     // Verify hidden_idx = accept_len - 1
     auto expected_idx = (accept_len.to(torch::kInt64) - 1).cpu();
     auto actual_idx   = hidden_idx.cpu();
-    EXPECT_TRUE(torch::equal(actual_idx, expected_idx))
-        << "hidden_idx mismatch:\n"
-        << actual_idx << "\nvs expected:\n"
-        << expected_idx;
+    EXPECT_TRUE(torch::equal(actual_idx, expected_idx)) << "hidden_idx mismatch:\n"
+                                                        << actual_idx << "\nvs expected:\n"
+                                                        << expected_idx;
 }
 
 TEST_F(MtpExecutorTest, testDispatchStatePrepareBenchmark) {
@@ -2170,10 +2238,9 @@ TEST_F(MtpExecutorTest, testDispatchStatePrepareBenchmark) {
 
     double speedup = static_cast<double>(us_scalar) / static_cast<double>(us_batched);
     RTP_LLM_LOG_INFO("[dispatch-bench] batch_size=%ld iterations=%d", batch_size, iterations);
-    RTP_LLM_LOG_INFO("[dispatch-bench] batched: %ld us total, %.2f us/iter",
-                     us_batched, (double)us_batched / iterations);
-    RTP_LLM_LOG_INFO("[dispatch-bench] scalar:  %ld us total, %.2f us/iter",
-                     us_scalar, (double)us_scalar / iterations);
+    RTP_LLM_LOG_INFO(
+        "[dispatch-bench] batched: %ld us total, %.2f us/iter", us_batched, (double)us_batched / iterations);
+    RTP_LLM_LOG_INFO("[dispatch-bench] scalar:  %ld us total, %.2f us/iter", us_scalar, (double)us_scalar / iterations);
     RTP_LLM_LOG_INFO("[dispatch-bench] speedup: %.1fx", speedup);
 }
 
@@ -2207,9 +2274,9 @@ TEST_F(MtpExecutorTest, testErroredSpecLogitsStreamDoesNotAbortExecutor) {
     test_config.vocab_size_override = vocab_size;
     auto components                 = createMtpExecutorComponents(test_config);
 
-    auto stream_new_tokens        = torch::tensor({{2}}, torch::kInt32);
-    auto stream_hidden_states     = torch::tensor({{0.03f, 0.04f}});
-    auto stream_draft_token_probs = torch::tensor({{0.0f, 0.0f, 0.0f, 1.0f}});
+    auto                 stream_new_tokens        = torch::tensor({{2}}, torch::kInt32);
+    auto                 stream_hidden_states     = torch::tensor({{0.03f, 0.04f}});
+    auto                 stream_draft_token_probs = torch::tensor({{0.0f, 0.0f, 0.0f, 1.0f}});
     StreamSpecUpdateInfo spec_update_info{stream_new_tokens, 1, 3, stream_hidden_states, stream_draft_token_probs};
 
     GenerateStreamPtr stream = createDecodeStream(

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -968,6 +968,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("quantization", &SpeculativeExecutionConfig::quantization)
         .def_readwrite("checkpoint_path", &SpeculativeExecutionConfig::checkpoint_path)
         .def_readwrite("sp_dspark_mask_token_id", &SpeculativeExecutionConfig::sp_dspark_mask_token_id)
+        .def_readwrite("sp_dspark_sample_from_anchor", &SpeculativeExecutionConfig::sp_dspark_sample_from_anchor)
         .def("to_string", [](const SpeculativeExecutionConfig& self) { return self.to_string(); })
         .def(py::pickle(
             [](const SpeculativeExecutionConfig& self) {
@@ -981,10 +982,11 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.force_score_context_attention,
                                       self.quantization,
                                       self.checkpoint_path,
-                                      self.sp_dspark_mask_token_id);
+                                      self.sp_dspark_mask_token_id,
+                                      self.sp_dspark_sample_from_anchor);
             },
             [](py::tuple t) {
-                if (t.size() != 10 && t.size() != 11)
+                if (t.size() != 10 && t.size() != 11 && t.size() != 12)
                     throw std::runtime_error("Invalid state!");
                 SpeculativeExecutionConfig c;
                 try {
@@ -1000,6 +1002,10 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     c.checkpoint_path               = t[9].cast<std::string>();
                     if (t.size() == 11) {
                         c.sp_dspark_mask_token_id = t[10].cast<int64_t>();
+                    }
+                    if (t.size() == 12) {
+                        c.sp_dspark_mask_token_id = t[10].cast<int64_t>();
+                        c.sp_dspark_sample_from_anchor = t[11].cast<bool>();
                     }
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("SpeculativeExecutionConfig unpickle error: ") + e.what());

--- a/rtp_llm/device/device_base.py
+++ b/rtp_llm/device/device_base.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import torch
 
@@ -88,7 +89,10 @@ class DeviceBase:
         raise NotImplementedError("moe_apply_int8 is not implemented")
 
     def maybe_rewrite_weight_by_key(
-        self, key: str, weight: torch.Tensor
+        self,
+        key: str,
+        weight: torch.Tensor,
+        use_swizzle_a: Optional[bool] = None,
     ) -> torch.Tensor:
         return weight
 

--- a/rtp_llm/device/device_impl.py
+++ b/rtp_llm/device/device_impl.py
@@ -53,7 +53,10 @@ class ArmCpuImpl(CpuImpl):
         ]
 
     def maybe_rewrite_weight_by_key(
-        self, key: str, weight: torch.Tensor
+        self,
+        key: str,
+        weight: torch.Tensor,
+        use_swizzle_a: Optional[bool] = None,
     ) -> torch.Tensor:
         return preprocess_gemm_weight_by_key(
             key, weight, self.py_env_configs.py_hw_kernel_config.arm_gemm_use_kai
@@ -927,7 +930,10 @@ class RocmImpl(GpuImpl):
         return x_
 
     def maybe_rewrite_weight_by_key(
-        self, key: str, weight: torch.Tensor
+        self,
+        key: str,
+        weight: torch.Tensor,
+        use_swizzle_a: Optional[bool] = None,
     ) -> torch.Tensor:
         is_gfx950 = self._is_gfx950()
         if key == "weight":
@@ -954,14 +960,18 @@ class RocmImpl(GpuImpl):
             W.linear_attn_ba_w,
             W.linear_attn_out_w,
         ]:
-            use_swizzle = self.py_env_configs.py_hw_kernel_config.use_swizzleA
+            should_swizzle = (
+                self.py_env_configs.py_hw_kernel_config.use_swizzleA
+                if use_swizzle_a is None
+                else use_swizzle_a
+            )
             if key == W.linear_attn_ba_w:
                 # BA remains BF16 even when qkvz is quantized. Select its
                 # physical layout from the actual TP-local shape so aligned
                 # projections keep the fast path while N=24/12 safely fall
                 # back to the raw layout.
-                use_swizzle = use_swizzle and should_swizzle_linear_attn_ba(weight)
-            if use_swizzle:
+                should_swizzle = should_swizzle and should_swizzle_linear_attn_ba(weight)
+            if should_swizzle:
                 if weight.dtype != torch.float8_e4m3fn:
                     weight = swizzle_tensor(weight.t(), False).t()
                 else:

--- a/rtp_llm/model_factory.py
+++ b/rtp_llm/model_factory.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ from rtp_llm.config.py_config_modules import (
     RenderConfig,
     VitConfig,
 )
+from rtp_llm.device.device_type import is_hip
 from rtp_llm.model_factory_register import _model_factory, ensure_model_registered
 from rtp_llm.ops import (
     ProfilingDebugLoggingConfig,
@@ -180,10 +182,28 @@ class ModelFactory:
             if alias_names and target_model.weight is None:
                 raise RuntimeError("speculative shared-weight owner is not loaded")
 
+            propose_hw_kernel_config = engine_config.hw_kernel_config
+            if (
+                sp_type == SpeculativeType.DSPARK
+                and propose_model_config.model_type == "qwen_3_dspark"
+                and is_hip()
+                and propose_hw_kernel_config.use_swizzleA
+            ):
+                # The target's FP8 PTPC path benefits from ROCm swizzle, but the
+                # Qwen3 DSpark checkpoint is BF16.  hipBLASLt on MI308X has no
+                # preshuffled BF16 solution for the draft's 5120x5120 GEMMs.
+                # Keep the target config unchanged and give the draft an
+                # independent raw-layout config for both loading and dispatch.
+                propose_hw_kernel_config = copy.deepcopy(propose_hw_kernel_config)
+                propose_hw_kernel_config.use_swizzleA = False
+                logging.info(
+                    "disable ROCm swizzleA for BF16 qwen_3_dspark propose model"
+                )
+
             gpt_model = model_cls.from_config(
                 model_config=propose_model_config,
                 parallelism_config=engine_config.parallelism_config,
-                hw_kernel_config=engine_config.hw_kernel_config,
+                hw_kernel_config=propose_hw_kernel_config,
                 kv_cache_config=engine_config.kv_cache_config,
                 fmha_config=engine_config.fmha_config,
                 moe_config=engine_config.moe_config,

--- a/rtp_llm/model_factory.py
+++ b/rtp_llm/model_factory.py
@@ -525,10 +525,22 @@ class ModelFactory:
             )
 
         noise_token_id = int(propose_model_config.dspark_noise_token_id)
-        if noise_token_id < 0 or noise_token_id >= propose_model_config.vocab_size:
+        # The noise token is consumed by the draft backbone embedding, not by
+        # the reduced Markov output head.  Speculators checkpoints may expose
+        # a 20K draft output vocabulary while retaining the target-sized input
+        # embedding, so validate in the input-token id space.
+        # ModelConfig uses zero when the input vocabulary was not set
+        # separately; in that case the embedding spans the model vocabulary.
+        configured_input_vocab_size = getattr(
+            propose_model_config, "input_vocab_size", 0
+        )
+        input_vocab_size = int(
+            configured_input_vocab_size or propose_model_config.vocab_size
+        )
+        if noise_token_id < 0 or noise_token_id >= input_vocab_size:
             raise ValueError(
-                f"invalid dspark_noise_token_id {noise_token_id} for vocab_size "
-                f"{propose_model_config.vocab_size}"
+                f"invalid dspark_noise_token_id {noise_token_id} for "
+                f"input_vocab_size {input_vocab_size}"
             )
 
         target_layer_ids = [
@@ -536,6 +548,11 @@ class ModelFactory:
         ]
         if not target_layer_ids:
             raise ValueError("dspark_target_layer_ids must not be empty")
+        if target_layer_ids != sorted(set(target_layer_ids)):
+            raise ValueError(
+                "dspark_target_layer_ids must be unique and ordered by target "
+                f"layer boundary, got {target_layer_ids}"
+            )
         invalid_layer_ids = [
             layer_id
             for layer_id in target_layer_ids
@@ -552,6 +569,9 @@ class ModelFactory:
             raise ValueError(f"invalid dspark_markov_rank: {markov_rank}")
 
         sp_config.sp_dspark_mask_token_id = noise_token_id
+        sp_config.sp_dspark_sample_from_anchor = bool(
+            getattr(propose_model_config, "dspark_sample_from_anchor", True)
+        )
         # Both models carry the capture ids: the target uses them to capture
         # and to size the shared MTP hidden buffer rows; the draft only needs
         # them for the same row-width derivation (it never captures).

--- a/rtp_llm/model_factory_register.py
+++ b/rtp_llm/model_factory_register.py
@@ -244,6 +244,9 @@ def _register_builtin_lazy_models() -> None:
         "qwen_2_moe", "rtp_llm.models.qwen_v2_moe", ["Qwen2MoeForCausalLM"]
     )
     register_lazy_model("qwen_3", "rtp_llm.models.qwen_v3", ["Qwen3ForCausalLM"])
+    register_lazy_model(
+        "qwen_3_dspark", "rtp_llm.models.qwen_3_dspark", ["Qwen3DSparkForCausalLM"]
+    )
     register_lazy_model("qwen_3_tool", "rtp_llm.models.qwen_v3")
     register_lazy_model(
         "qwen_3_moe", "rtp_llm.models.qwen_v3_moe", ["Qwen3MoeForCausalLM"]

--- a/rtp_llm/model_loader/ffn_weight.py
+++ b/rtp_llm/model_loader/ffn_weight.py
@@ -398,7 +398,9 @@ class MoeAtomicWeight(AtomicWeight):
             )
         return {
             self.name: load_config.exported_device.maybe_rewrite_weight_by_key(
-                self.name, raw_tensor
+                self.name,
+                raw_tensor,
+                use_swizzle_a=load_config.use_swizzleA,
             )
         }
 

--- a/rtp_llm/model_loader/per_block_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_block_fp8_quant_weight.py
@@ -831,10 +831,14 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
                     else scale_weight
                 )
             kernel_weight = load_config.exported_device.maybe_rewrite_weight_by_key(
-                "weight", kernel_weight
+                "weight",
+                kernel_weight,
+                use_swizzle_a=load_config.use_swizzleA,
             )
             scale_weight = load_config.exported_device.maybe_rewrite_weight_by_key(
-                "scale", scale_weight
+                "scale",
+                scale_weight,
+                use_swizzle_a=load_config.use_swizzleA,
             )
             # kernel_weight, scale_weight = load_config.exported_device.convert_fp8_weight_params(kernel_weight, scale_weight)
 

--- a/rtp_llm/model_loader/test/BUILD
+++ b/rtp_llm/model_loader/test/BUILD
@@ -41,6 +41,13 @@ py_test(
 )
 
 py_test(
+    name = "test_swizzle_load_config",
+    srcs = ["test_swizzle_load_config.py"],
+    deps = py_test_deps,
+    exec_properties = {"gpu": "A10"},
+)
+
+py_test(
     name = "test_model_weight_info",
     srcs = ["test_model_weight_info.py"],
     deps = py_test_deps + [

--- a/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
+++ b/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
@@ -61,7 +61,8 @@ class _RecordingDevice:
         self.sentinel_kernel = torch.full((1, 1), 7, dtype=torch.int32)
         self.sentinel_scale = torch.full((1, 1), 9, dtype=torch.int32)
 
-    def maybe_rewrite_weight_by_key(self, key, tensor):
+    def maybe_rewrite_weight_by_key(self, key, tensor, use_swizzle_a=None):
+        del key, use_swizzle_a
         return tensor
 
     def convert_fp8_weight_params(self, kernel, scale):

--- a/rtp_llm/model_loader/test/test_model_weight_info.py
+++ b/rtp_llm/model_loader/test/test_model_weight_info.py
@@ -200,7 +200,7 @@ class AttentionOutputStaticQuantReciprocalTest(unittest.TestCase):
                 ep_size=1,
                 merge_lora=False,
                 exported_device=SimpleNamespace(
-                    maybe_rewrite_weight_by_key=lambda _, tensor: tensor
+                    maybe_rewrite_weight_by_key=lambda _, tensor, **kwargs: tensor
                 ),
             ),
         )

--- a/rtp_llm/model_loader/test/test_pure_tp_preshard.py
+++ b/rtp_llm/model_loader/test/test_pure_tp_preshard.py
@@ -21,7 +21,7 @@ from rtp_llm.utils.model_weight import W
 # Identity device stubs: parity vs legacy relies on no real post-processing here.
 _DEVICE = SimpleNamespace(
     shuffle_moe_weight=lambda tensor, *_: tensor,
-    maybe_rewrite_weight_by_key=lambda _, tensor: tensor,
+    maybe_rewrite_weight_by_key=lambda _, tensor, **kwargs: tensor,
 )
 
 

--- a/rtp_llm/model_loader/test/test_swizzle_load_config.py
+++ b/rtp_llm/model_loader/test/test_swizzle_load_config.py
@@ -1,0 +1,63 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from rtp_llm.device.device_impl import RocmImpl
+from rtp_llm.model_loader.load_config import LoadConfig
+from rtp_llm.model_loader.weight_module import AtomicWeight
+from rtp_llm.utils.model_weight import W
+
+
+class FakeRocmDevice:
+    maybe_rewrite_weight_by_key = RocmImpl.maybe_rewrite_weight_by_key
+
+    def __init__(self, global_use_swizzle_a: bool):
+        self.py_env_configs = SimpleNamespace(
+            py_hw_kernel_config=SimpleNamespace(
+                use_swizzleA=global_use_swizzle_a
+            )
+        )
+
+    def _is_gfx950(self) -> bool:
+        return False
+
+
+class SwizzleLoadConfigTest(unittest.TestCase):
+    def _postprocess(self, global_use_swizzle_a: bool, load_use_swizzle_a: bool):
+        device = FakeRocmDevice(global_use_swizzle_a)
+        load_config = LoadConfig.model_construct(
+            exported_device=device,
+            use_swizzleA=load_use_swizzle_a,
+        )
+        weight = AtomicWeight(W.attn_qkv_w, [])
+        tensor = torch.arange(12, dtype=torch.bfloat16).reshape(3, 4)
+        return weight._postprocess(tensor, "cpu", load_config), tensor
+
+    def test_per_model_false_keeps_draft_weight_raw(self):
+        with patch("rtp_llm.device.device_impl.swizzle_tensor") as swizzle:
+            result, tensor = self._postprocess(
+                global_use_swizzle_a=True,
+                load_use_swizzle_a=False,
+            )
+
+        swizzle.assert_not_called()
+        self.assertIs(result[W.attn_qkv_w], tensor)
+
+    def test_per_model_true_swizzles_target_weight(self):
+        with patch(
+            "rtp_llm.device.device_impl.swizzle_tensor",
+            side_effect=lambda tensor, _: tensor,
+        ) as swizzle:
+            result, tensor = self._postprocess(
+                global_use_swizzle_a=False,
+                load_use_swizzle_a=True,
+            )
+
+        swizzle.assert_called_once()
+        torch.testing.assert_close(result[W.attn_qkv_w], tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/model_loader/weight_module.py
+++ b/rtp_llm/model_loader/weight_module.py
@@ -670,7 +670,9 @@ class AtomicWeight(WeightModule):
         raw_tensor = tensor.get(self.name) if isinstance(tensor, dict) else tensor
         return {
             self.name: load_config.exported_device.maybe_rewrite_weight_by_key(
-                self.name, raw_tensor
+                self.name,
+                raw_tensor,
+                use_swizzle_a=load_config.use_swizzleA,
             )
         }
 

--- a/rtp_llm/models/__init__.py
+++ b/rtp_llm/models/__init__.py
@@ -45,6 +45,7 @@ _CLASS_TO_MODULE: Dict[str, str] = {
     "QWen3_VL": "rtp_llm.models.qwen3_vl",
     "QWen3_VL_MOE": "rtp_llm.models.qwen3_vl_moe",
     "QwenV3": "rtp_llm.models.qwen_v3",
+    "Qwen3DSpark": "rtp_llm.models.qwen_3_dspark",
     "StarCoder": "rtp_llm.models.starcoder",
     "StarCoder2": "rtp_llm.models.starcoder2",
 }

--- a/rtp_llm/models/deepseek_v4.py
+++ b/rtp_llm/models/deepseek_v4.py
@@ -1066,7 +1066,7 @@ class DeepSeekV4DSparkWeight(DeepSeekV4Weight):
                 identity,
             ),
             AtomicWeight(
-                W.v4_dspark_markov_w1,
+                W.dspark_markov_w1,
                 [
                     CkptWeightInfo(
                         f"mtp.{last_stage}.markov_head.markov_w1.weight", identity
@@ -1076,7 +1076,7 @@ class DeepSeekV4DSparkWeight(DeepSeekV4Weight):
                 data_type=torch.bfloat16,
             ),
             AtomicWeight(
-                W.v4_dspark_markov_w2,
+                W.dspark_markov_w2,
                 [
                     CkptWeightInfo(
                         f"mtp.{last_stage}.markov_head.markov_w2.weight", identity

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -2,7 +2,11 @@ import json
 import os
 from typing import Any, Dict, List
 
-from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.config.kv_cache_config import KVCacheConfig
+from rtp_llm.config.model_config import (
+    ModelConfig,
+    ssm_state_dtype_str_to_data_type,
+)
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.models.base_model import BaseModel
 from rtp_llm.models.hybrid_kv_cache import build_hybrid_kv_cache_spec_descs
@@ -12,7 +16,7 @@ from rtp_llm.models.qwen3_next.qwen3_next_weight import (
     Qwen35DenseWeight,
     Qwen35MoeWeight,
 )
-from rtp_llm.ops import HybridAttentionType, KVCacheSpecType
+from rtp_llm.ops import DataType, HybridAttentionType, KVCacheSpecType
 
 
 class Qwen3NextBase(BaseModel):
@@ -40,6 +44,32 @@ class Qwen3NextBase(BaseModel):
 
     def support_cuda_graph(self) -> bool:
         return True
+
+    @classmethod
+    def _apply_kv_cache_config(
+        cls, model_config: ModelConfig, kv_cache_config: KVCacheConfig
+    ) -> None:
+        remote_cache_enabled = (
+            kv_cache_config.reuse_cache and kv_cache_config.enable_remote_cache
+        )
+        if not remote_cache_enabled:
+            return
+
+        # The legacy remote connector registers one contiguous KV-cache
+        # allocation. Qwen3 Next normally uses one allocation per cache group,
+        # but its BF16 layout is also supported by the shared HybridType pool.
+        # build_model_config resolves SSM_STATE_DTYPE=auto to BF16 before this
+        # hook when remote cache is enabled, restoring the legacy-compatible
+        # layout without changing the default FP32 path used elsewhere.
+        if (
+            model_config.linear_attention_config.ssm_state_dtype
+            != DataType.TYPE_BF16
+        ):
+            raise ValueError(
+                "Qwen3 Next remote cache requires BF16 SSM state storage; "
+                "use --ssm_state_dtype bf16 or auto"
+            )
+        model_config.hybrid_attention_config.enable_independent_kv_cache_pools = False
 
     @classmethod
     def _create_config(cls, ckpt_path: str) -> ModelConfig:
@@ -116,6 +146,11 @@ class Qwen3NextBase(BaseModel):
     def _parse_hybrid_attention_config(cls, config_json: dict, config: ModelConfig):
         attention_step = config_json["full_attention_interval"]
         config.hybrid_attention_config.enable_hybrid_attention = True
+        # Full-attention KV pages and recurrent GDN states have different
+        # physical layouts.  Use the generic per-group allocator so each group
+        # keeps its native block representation while sharing the same logical
+        # 64-token cache/reuse granularity.
+        config.hybrid_attention_config.enable_independent_kv_cache_pools = True
         hybrid_layer_types: List[HybridAttentionType] = []
         for i in range(config.num_layers):
             if (i + 1) % attention_step == 0:
@@ -141,6 +176,11 @@ class Qwen3NextBase(BaseModel):
         config.linear_attention_config.linear_value_head_dim = config_json[
             "linear_value_head_dim"
         ]
+        model_ssm_state_dtype = config_json.get("mamba_ssm_dtype")
+        if model_ssm_state_dtype is not None:
+            config.linear_attention_config.ssm_state_dtype = (
+                ssm_state_dtype_str_to_data_type(model_ssm_state_dtype)
+            )
 
     @classmethod
     def _post_build_model_config(cls, model_config: ModelConfig) -> None:

--- a/rtp_llm/models/qwen3_next/test/qwen3_next_mtp_test.py
+++ b/rtp_llm/models/qwen3_next/test/qwen3_next_mtp_test.py
@@ -4,8 +4,10 @@ import unittest
 from pathlib import Path
 
 from rtp_llm.config.kv_cache_config import KVCacheConfig
+from rtp_llm.config.model_config import resolve_ssm_state_dtype
 from rtp_llm.model_factory_register import _model_factory
 from rtp_llm.model_loader.ffn_weight import FfnWeight, MoeWeight
+from rtp_llm.models.qwen3_next.qwen3_next import Qwen35Dense
 from rtp_llm.models.qwen3_next.qwen3_next_mtp import (
     Qwen35DenseMTP,
     Qwen35DenseMTPWeight,
@@ -15,6 +17,7 @@ from rtp_llm.multimodal.multimodal_mixins.qwen3_5_moe.qwen3_5_moe_mixin import (
     Qwen3_5MoeMixin,
 )
 from rtp_llm.ops import (
+    DataType,
     HWKernelConfig,
     HybridAttentionType,
     ParallelismConfig,
@@ -23,6 +26,72 @@ from rtp_llm.ops import (
 
 
 class Qwen35DenseMTPTest(unittest.TestCase):
+    def test_auto_ssm_state_dtype_preserves_model_value_without_remote_cache(self):
+        self.assertEqual(
+            resolve_ssm_state_dtype("auto", DataType.TYPE_FP32, False),
+            DataType.TYPE_FP32,
+        )
+
+    def test_auto_ssm_state_dtype_keeps_remote_cache_on_shared_bf16_pool(self):
+        self.assertEqual(
+            resolve_ssm_state_dtype("auto", DataType.TYPE_FP32, True),
+            DataType.TYPE_BF16,
+        )
+
+    def test_explicit_ssm_state_dtype_remains_authoritative_for_remote_cache(self):
+        self.assertEqual(
+            resolve_ssm_state_dtype("fp32", DataType.TYPE_BF16, True),
+            DataType.TYPE_FP32,
+        )
+
+    def test_target_uses_model_ssm_state_dtype_with_independent_hybrid_pools(self):
+        config_json = self._config()
+        config_json["text_config"]["mamba_ssm_dtype"] = "float32"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "config.json").write_text(json.dumps(config_json))
+            config = Qwen35Dense.create_config(temp_dir)
+
+        # The model keeps MHA pages and recurrent GDN states in their native
+        # per-group physical layouts.
+        self.assertTrue(
+            config.hybrid_attention_config.enable_independent_kv_cache_pools
+        )
+        self.assertEqual(
+            config.linear_attention_config.ssm_state_dtype, DataType.TYPE_FP32
+        )
+
+    def test_remote_cache_uses_shared_hybrid_pool_for_bf16_ssm_state(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "config.json").write_text(json.dumps(self._config()))
+            config = Qwen35Dense.create_config(temp_dir)
+
+        config.linear_attention_config.ssm_state_dtype = DataType.TYPE_BF16
+        kv_cache_config = KVCacheConfig()
+        kv_cache_config.reuse_cache = True
+        kv_cache_config.enable_remote_cache = True
+
+        Qwen35Dense._apply_kv_cache_config(config, kv_cache_config)
+
+        self.assertFalse(
+            config.hybrid_attention_config.enable_independent_kv_cache_pools
+        )
+
+    def test_remote_cache_rejects_explicit_fp32_ssm_state(self):
+        config_json = self._config()
+        config_json["text_config"]["mamba_ssm_dtype"] = "float32"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "config.json").write_text(json.dumps(config_json))
+            config = Qwen35Dense.create_config(temp_dir)
+
+        kv_cache_config = KVCacheConfig()
+        kv_cache_config.reuse_cache = True
+        kv_cache_config.enable_remote_cache = True
+
+        with self.assertRaisesRegex(
+            ValueError, "remote cache requires BF16 SSM state storage"
+        ):
+            Qwen35Dense._apply_kv_cache_config(config, kv_cache_config)
+
     def test_dense_mtp_config_and_registration(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             Path(temp_dir, "config.json").write_text(json.dumps(self._config()))

--- a/rtp_llm/models/qwen_3_dspark.py
+++ b/rtp_llm/models/qwen_3_dspark.py
@@ -1,0 +1,118 @@
+"""Qwen3 DSpark draft-model registration."""
+
+from typing import Any, List
+
+import torch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_factory_register import register_model
+from rtp_llm.model_loader.weight_module import AtomicWeight
+from rtp_llm.models.qwen_v3 import QwenV3, QWenV3Weight
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, transpose
+from rtp_llm.utils.util import get_config_from_path
+
+
+def dspark_offset_d2t_to_absolute(ts: List[torch.Tensor]) -> torch.Tensor:
+    """Normalize Speculators' offset d2t table to absolute target token ids."""
+    offsets = identity(ts).to(torch.int64)
+    return offsets + torch.arange(
+        offsets.numel(), dtype=offsets.dtype, device=offsets.device
+    )
+
+
+class Qwen3DSparkWeight(QWenV3Weight):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._d2t_path = None
+        self._hidden_norm_path = "model.hidden_norm.weight"
+
+    def _process_meta(self, meta_dicts: Any, weight_keys: List[str]):
+        super()._process_meta(meta_dicts, weight_keys)
+        if "hidden_norm.weight" in weight_keys:
+            self._hidden_norm_path = "hidden_norm.weight"
+        if "d2t" in weight_keys:
+            self._d2t_path = "d2t"
+        elif "model.d2t" in weight_keys:
+            self._d2t_path = "model.d2t"
+
+    def _get_weight_info(self):
+        info = super()._get_weight_info()
+        extras = (
+            (W.dspark_fc_w, "fc.weight", transpose),
+            (W.dspark_hidden_norm_gamma, self._hidden_norm_path, identity),
+            (W.dspark_markov_w1, "markov_head.markov_w1.weight", identity),
+            (W.dspark_markov_w2, "markov_head.markov_w2.weight", identity),
+        )
+        info.weights.extend(
+            AtomicWeight(name, [CkptWeightInfo(path, identity)], transform)
+            for name, path, transform in extras
+        )
+        if self._d2t_path is not None:
+            transform = (
+                dspark_offset_d2t_to_absolute
+                if self._d2t_path == "d2t"
+                else identity
+            )
+            info.weights.append(
+                AtomicWeight(
+                    W.multi_tokens_predict_d2t_map,
+                    [CkptWeightInfo(self._d2t_path, identity)],
+                    transform,
+                    data_type=torch.int64,
+                )
+            )
+        return info
+
+
+class Qwen3DSpark(QwenV3):
+    @classmethod
+    def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        dspark = get_config_from_path(ckpt_path)
+        assert dspark is not None, f"config.json missing under {ckpt_path}"
+        backbone = dspark.get("transformer_layer_config", dspark)
+        if not isinstance(backbone, dict):
+            raise TypeError("transformer_layer_config must be an object")
+        config = cls._create_config_from_json(ckpt_path, backbone)
+        config.attn_config.is_causal = False
+        config.input_vocab_size = int(backbone["vocab_size"])
+        config.vocab_size = int(dspark.get("draft_vocab_size", backbone["vocab_size"]))
+        config.dspark_noise_token_id = int(dspark["mask_token_id"])
+        target_layer_ids = [int(x) for x in dspark["aux_hidden_state_layer_ids"]]
+        if dspark.get("speculators_model_type") == "dspark":
+            target_layer_ids = [x - 1 for x in target_layer_ids]
+            if any(x < 0 for x in target_layer_ids):
+                raise ValueError(
+                    "Speculators DSpark aux_hidden_state_layer_ids must be positive"
+                )
+        config.dspark_target_layer_ids = target_layer_ids
+        config.dspark_markov_rank = int(dspark.get("markov_rank", 0) or 0)
+        if config.dspark_markov_rank <= 0:
+            raise ValueError("Qwen3 DSpark requires markov_rank > 0")
+        config.dspark_sample_from_anchor = bool(
+            dspark.get("sample_from_anchor", False)
+        )
+        return config
+
+    @staticmethod
+    def get_weight_cls():
+        return Qwen3DSparkWeight
+
+    def _create_python_model(self):
+        from rtp_llm.models_py.model_desc.qwen3_dspark_model import (
+            Qwen3DSparkModel,
+        )
+
+        self.py_model = Qwen3DSparkModel(
+            self.model_config,
+            self.parallelism_config,
+            self.weight,
+            max_generate_batch_size=self.max_generate_batch_size,
+            quant_config=self.model_config.quant_config,
+            fmha_config=self.fmha_config,
+            py_hw_kernel_config=self.hw_kernel_config,
+            device_resource_config=self.device_resource_config,
+        )
+        return self.py_model
+
+
+register_model("qwen_3_dspark", Qwen3DSpark, ["Qwen3DSparkForCausalLM"])

--- a/rtp_llm/models/qwen_v2.py
+++ b/rtp_llm/models/qwen_v2.py
@@ -338,6 +338,15 @@ class QWenV2Weight(ModelDeployWeightInfo):
 class QWenV2(QWen):
     @classmethod
     def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        config_path = os.path.join(ckpt_path, "config.json")
+        with open(config_path) as reader:
+            config_json = json.load(reader)
+        return cls._create_config_from_json(ckpt_path, config_json)
+
+    @classmethod
+    def _create_config_from_json(
+        cls, ckpt_path: str, config_json: Dict[str, Any]
+    ) -> ModelConfig:
         config = ModelConfig()
         config.ckpt_path = ckpt_path
         config.vocab_size = 152064
@@ -350,7 +359,7 @@ class QWenV2(QWen):
         # <|im_start|> and <|im_end|>
         config.special_tokens.stop_words_id_list = [[151645], [151644]]
 
-        QWenV2._from_hf(config, ckpt_path)
+        cls._from_config_json(config, config_json)
         assert (
             config.attn_config.head_num > 0
             and config.attn_config.kv_head_num > 0
@@ -388,14 +397,19 @@ class QWenV2(QWen):
         if config_json.get("hidden_size") is not None:
             config.hidden_size = config_json["hidden_size"]
         config.num_layers = config_json["num_hidden_layers"]
-        config.attn_config.rope_config.base = int(
-            config_json.get("rope_theta", config.attn_config.rope_config.base)
-        )
+        # Transformers 5.2 moved rope_theta under rope_parameters. Preserve
+        # the legacy top-level field's precedence when both are present.
+        rope_parameters = config_json.get("rope_parameters") or {}
+        rope_theta = config_json.get("rope_theta")
+        if rope_theta is None and isinstance(rope_parameters, dict):
+            rope_theta = rope_parameters.get("rope_theta")
+        if rope_theta is not None:
+            config.attn_config.rope_config.base = int(rope_theta)
         config.vocab_size = config_json["vocab_size"]
         config.attn_config.rope_config.dim = config.attn_config.size_per_head
         config.layernorm_eps = config_json.get("rms_norm_eps", 1e-06)
         config.tie_word_embeddings = config_json.get("tie_word_embeddings", False)
-        config.config_dtype = config_json.get("torch_dtype", None)
+        config.config_dtype = config_json.get("torch_dtype") or config_json.get("dtype")
         config.headwise_config = config_json.get("headwise_config", None)
 
     @staticmethod

--- a/rtp_llm/models/qwen_v3.py
+++ b/rtp_llm/models/qwen_v3.py
@@ -27,6 +27,12 @@ class QwenV3(QWenV2):
         config.qk_norm = True
         return config
 
+    @classmethod
+    def _create_config_from_json(cls, ckpt_path: str, config_json):
+        config = super()._create_config_from_json(ckpt_path, config_json)
+        config.qk_norm = True
+        return config
+
     def _init_custom_module(self) -> Optional[CustomModule]:
         logging.info(f"task_type : {self.model_config.task_type}")
         if self.model_config.task_type == TaskType.RERANKER:

--- a/rtp_llm/models/test/deepseek_v4_dspark_commit_only_test.py
+++ b/rtp_llm/models/test/deepseek_v4_dspark_commit_only_test.py
@@ -45,8 +45,8 @@ class DeepSeekV4DSparkCommitOnlyWeightTest(TestCase):
                 AtomicWeight(W.lm_head, [], identity),
                 AtomicWeight(W.v4_dspark_main_norm, [], identity),
                 main_proj,
-                AtomicWeight(W.v4_dspark_markov_w1, [], identity),
-                AtomicWeight(W.v4_dspark_markov_w2, [], identity),
+                AtomicWeight(W.dspark_markov_w1, [], identity),
+                AtomicWeight(W.dspark_markov_w2, [], identity),
             ],
         )
 

--- a/rtp_llm/models/test/moe_config_propagation_test.py
+++ b/rtp_llm/models/test/moe_config_propagation_test.py
@@ -243,7 +243,7 @@ class MoeConfigPropagationTest(unittest.TestCase):
         # Device-specific packing is outside this CPU loader contract.
         exported_device = SimpleNamespace(
             shuffle_moe_weight=lambda tensor, *_args: tensor,
-            maybe_rewrite_weight_by_key=lambda _name, tensor: tensor,
+            maybe_rewrite_weight_by_key=lambda _name, tensor, use_swizzle_a=None: tensor,
         )
         with tempfile.TemporaryDirectory() as checkpoint_path:
             save_file(checkpoint, os.path.join(checkpoint_path, "model.safetensors"))
@@ -307,7 +307,7 @@ class MoeConfigPropagationTest(unittest.TestCase):
 
         exported_device = SimpleNamespace(
             shuffle_moe_weight=lambda tensor, *_args: tensor,
-            maybe_rewrite_weight_by_key=lambda _name, tensor: tensor,
+            maybe_rewrite_weight_by_key=lambda _name, tensor, use_swizzle_a=None: tensor,
         )
         load_config = SimpleNamespace(
             compute_dtype=torch.float32,
@@ -316,6 +316,7 @@ class MoeConfigPropagationTest(unittest.TestCase):
             tp_size=1,
             dp_size=1,
             ep_size=1,
+            use_swizzleA=False,
             exported_device=exported_device,
             get_selected_experts=lambda _layer_id, expert_num: range(expert_num),
         )

--- a/rtp_llm/models_py/bindings/OpDefs.cc
+++ b/rtp_llm/models_py/bindings/OpDefs.cc
@@ -270,7 +270,14 @@ void registerPyOpDefs(pybind11::module& m) {
     pybind11::class_<PyModelOutputs>(m, "PyModelOutputs")
         .def(pybind11::init<>(), "Default constructor")
         .def(pybind11::init<torch::Tensor>(), pybind11::arg("hidden_states"), "Initialize with hidden states tensor")
-        .def_readwrite("hidden_states", &PyModelOutputs::hidden_states, "Hidden states output tensor");
+        .def(pybind11::init<torch::Tensor, torch::Tensor>(),
+             pybind11::arg("hidden_states"),
+             pybind11::arg("mtp_target_hidden_states"),
+             "Initialize with hidden states and speculative target features")
+        .def_readwrite("hidden_states", &PyModelOutputs::hidden_states, "Hidden states output tensor")
+        .def_readwrite("mtp_target_hidden_states",
+                       &PyModelOutputs::mtp_target_hidden_states,
+                       "Optional target features consumed by speculative decoding");
 }
 
 }  // namespace torch_ext

--- a/rtp_llm/models_py/bindings/OpDefs.h
+++ b/rtp_llm/models_py/bindings/OpDefs.h
@@ -367,10 +367,17 @@ struct PyModelInputs {
 
 struct PyModelOutputs {
     torch::Tensor hidden_states;
+    // Optional model-side features consumed by speculative decoders.  This is
+    // a first-class forward output because CUDA graph replay does not execute
+    // Python and therefore cannot safely recover it from mutable model state.
+    torch::Tensor mtp_target_hidden_states;
 
     PyModelOutputs() = default;
 
     PyModelOutputs(torch::Tensor hidden_states): hidden_states(std::move(hidden_states)) {}
+
+    PyModelOutputs(torch::Tensor hidden_states, torch::Tensor mtp_target_hidden_states):
+        hidden_states(std::move(hidden_states)), mtp_target_hidden_states(std::move(mtp_target_hidden_states)) {}
 };
 
 void registerPyOpDefs(pybind11::module& m);

--- a/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
+++ b/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
@@ -816,9 +816,15 @@ GreedyOutput sampleGreedy(const GreedyParams& params) {
     return GreedyOutput{};
 }
 
-torch::Tensor sampleFromProbs(const torch::Tensor&) {
-    RTP_LLM_CHECK_WITH_INFO(false, "DSpARK stochastic probability sampling currently requires CUDA");
-    return {};
+torch::Tensor sampleFromProbs(const torch::Tensor& probabilities) {
+    RTP_LLM_CHECK_WITH_INFO(probabilities.defined() && probabilities.is_cuda() && probabilities.dim() == 2
+                                && probabilities.scalar_type() == torch::kFloat32 && probabilities.is_contiguous(),
+                            "probability sampling expects contiguous CUDA/HIP FP32 [batch,vocab] probabilities");
+
+    // torch::multinomial dispatches to the active HIP stream and uses PyTorch's
+    // process-local default generator. The regular ROCm sampler above uses the
+    // same fallback because FlashInfer sampling is not stable for TP > 1.
+    return torch::multinomial(probabilities, 1, /*replacement=*/false).squeeze(-1).to(torch::kInt32);
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/core/OpData.h
+++ b/rtp_llm/models_py/bindings/core/OpData.h
@@ -74,9 +74,9 @@ struct GptModelInputs {
     torch::Tensor request_pd_separation;  // bool, [context_batch_size]
     torch::Tensor cache_keys;             // [context_batch_size]
     // Physical KV-manager block strides. These are independent of any kernel-block view exposed to attention ops.
-    size_t kv_block_stride_bytes;
-    size_t kv_scale_stride_bytes;
-    size_t seq_size_per_block;
+    size_t kv_block_stride_bytes     = 0;
+    size_t kv_scale_stride_bytes     = 0;
+    size_t seq_size_per_block        = 0;
     size_t kernel_seq_size_per_block = 0;  // 0 means same as seq_size_per_block
     bool   pd_separation             = false;
     bool   decode_entrance           = false;
@@ -113,6 +113,11 @@ struct GptModelOutputs {
     torch::Tensor softmax_result;
 
     std::vector<torch::Tensor> moe_gating;
+
+    // Explicit model-forward output for speculative target features.  Keeping
+    // this separate from all_hidden_states lets the executor distinguish a
+    // real graph-instance output from the ordinary decoder hidden tensor.
+    torch::Tensor mtp_target_hidden_states;
 };
 
 struct CopyParams {

--- a/rtp_llm/models_py/bindings/core/test/BUILD
+++ b/rtp_llm/models_py/bindings/core/test/BUILD
@@ -68,6 +68,27 @@ cc_test(
 )
 
 cc_test(
+    name = "sample_from_probs_test",
+    srcs = ["SampleFromProbsTest.cc"],
+    deps = [
+        # ExecOps state references the platform implementations even though
+        # this test only exercises sampleFromProbs. Keep ops before state so
+        # the standalone binary closes both sides of that dependency under
+        # the toolchain's as-needed linking.
+        "//rtp_llm/models_py/bindings/core:exec_ctx_ops",
+        "//rtp_llm/models_py/bindings/core:exec_ctx_state",
+        "@com_google_googletest//:gtest_main",
+    ] + torch_deps(),
+    copts = test_copts,
+    exec_properties = {"gpu": "MI308X-ROCM7"},
+    tags = ["rocm"],
+    target_compatible_with = select({
+        "@//:using_rocm": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+cc_test(
     name = "distributed_comm_test",
     deps = [
         "//rtp_llm/cpp/testing:distributed_test",

--- a/rtp_llm/models_py/bindings/core/test/SampleFromProbsTest.cc
+++ b/rtp_llm/models_py/bindings/core/test/SampleFromProbsTest.cc
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+namespace rtp_llm {
+torch::Tensor sampleFromProbs(const torch::Tensor& probabilities);
+}
+
+namespace {
+
+TEST(SampleFromProbsTest, HandlesSingleAndMultiBlockVocabulary) {
+    auto forced_probs  = torch::eye(4, torch::TensorOptions().dtype(torch::kFloat32)).to(torch::kCUDA);
+    auto forced_output = rtp_llm::sampleFromProbs(forced_probs);
+    EXPECT_TRUE(forced_output.is_cuda());
+    EXPECT_EQ(forced_output.scalar_type(), torch::kInt32);
+    EXPECT_TRUE(torch::equal(forced_output.cpu(), torch::arange(4, torch::kInt32)));
+
+    auto multi_block_probs     = torch::zeros({2, 2051}, torch::kFloat32);
+    multi_block_probs[0][2048] = 1.0f;
+    multi_block_probs[1][1024] = 1.0f;
+    auto multi_block_output    = rtp_llm::sampleFromProbs(multi_block_probs.to(torch::kCUDA));
+    EXPECT_TRUE(torch::equal(multi_block_output.cpu(), torch::tensor({2048, 1024}, torch::kInt32)));
+}
+
+TEST(SampleFromProbsTest, SamplesTheInputDistribution) {
+    constexpr int64_t row_count = 4096;
+    auto              probabilities =
+        torch::softmax(torch::tensor({1.0f, 0.0f, -1.0f}, torch::kFloat32), -1).repeat({row_count, 1}).to(torch::kCUDA);
+    auto output = rtp_llm::sampleFromProbs(probabilities);
+    auto frequencies =
+        torch::bincount(output.to(torch::kLong), {}, 3).to(torch::kFloat32) / static_cast<float>(row_count);
+    auto expected = torch::softmax(torch::tensor({1.0f, 0.0f, -1.0f}), -1);
+    EXPECT_TRUE(torch::allclose(frequencies.cpu(), expected, 0.05, 0.02)) << frequencies.cpu();
+}
+
+}  // namespace

--- a/rtp_llm/models_py/bindings/cuda/kernels/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/kernels/BUILD
@@ -209,11 +209,18 @@ cc_library(
     name = "cuda_graph_prepare",
     srcs = ["cuda_graph_prepare.cu"],
     hdrs = ["cuda_graph_prepare.h"],
-    deps = [
-        "@local_config_cuda//cuda:cuda_headers",
-        "@local_config_cuda//cuda:cudart",
-    ] + torch_deps(),
-    copts = cuda_copts(),
+    deps = torch_deps() + select({
+        "@//:using_cuda": [
+            "@local_config_cuda//cuda:cuda_headers",
+            "@local_config_cuda//cuda:cudart",
+        ],
+        "@//:using_rocm": [
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:hip",
+        ],
+        "//conditions:default": [],
+    }),
+    copts = any_cuda_copts(),
     visibility = ["//visibility:public"],
 )
 

--- a/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.cu
@@ -17,9 +17,10 @@ __global__ void cudaGraphPrepareFillKernel(CudaGraphPrepareFillParams params) {
         if (region.ptr == nullptr || region.count <= 0) {
             continue;
         }
-        const int32_t fill_value = region.value_ptr != nullptr ? *region.value_ptr : region.value;
+        const int32_t fill_value = (region.value_ptr != nullptr ? *region.value_ptr : region.value)
+                                 + region.value_offset;
         for (int64_t i = tid; i < region.count; i += stride) {
-            region.ptr[i] = fill_value;
+            region.ptr[i] = fill_value + region.step * i;
         }
     }
 }

--- a/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.cu
@@ -2,7 +2,11 @@
 
 #include <algorithm>
 #include <c10/util/Exception.h>
+#if USING_ROCM
+#include <hip/hip_runtime.h>
+#else
 #include <cuda_runtime.h>
+#endif
 
 namespace rtp_llm {
 
@@ -68,7 +72,7 @@ __global__ void prepareFlashInferDecodeParamsKernel(const int32_t* sequence_leng
 
 }  // namespace
 
-void invokeCudaGraphPrepareFill(CudaGraphPrepareFillParams params, cudaStream_t stream) {
+void invokeCudaGraphPrepareFill(CudaGraphPrepareFillParams params, CudaGraphPrepareStream stream) {
     TORCH_CHECK(params.region_count >= 0 && params.region_count <= kMaxCudaGraphPrepareFillRegions,
                 "invalid cuda graph prepare fill region count: ",
                 params.region_count);
@@ -84,8 +88,13 @@ void invokeCudaGraphPrepareFill(CudaGraphPrepareFillParams params, cudaStream_t 
     constexpr int block_size = 256;
     const int     blocks     = static_cast<int>(std::min<int64_t>((total_count + block_size - 1) / block_size, 1024));
     cudaGraphPrepareFillKernel<<<blocks, block_size, 0, stream>>>(params);
+#if USING_ROCM
+    const auto result = hipGetLastError();
+    TORCH_CHECK(result == hipSuccess, "cuda graph prepare fill kernel failed: ", hipGetErrorString(result));
+#else
     const auto result = cudaGetLastError();
     TORCH_CHECK(result == cudaSuccess, "cuda graph prepare fill kernel failed: ", cudaGetErrorString(result));
+#endif
 }
 
 void invokePrepareFlashInferDecodeParams(const int32_t* sequence_lengths_plus_1,
@@ -100,7 +109,7 @@ void invokePrepareFlashInferDecodeParams(const int32_t* sequence_lengths_plus_1,
                                          int32_t        batch_size,
                                          int32_t        max_blocks_per_batch,
                                          int32_t        seq_size_per_block,
-                                         cudaStream_t   stream) {
+                                         CudaGraphPrepareStream stream) {
     TORCH_CHECK(sequence_lengths_plus_1 != nullptr, "sequence_lengths_plus_1 is null");
     TORCH_CHECK(block_ids != nullptr, "block_ids is null");
     TORCH_CHECK(batch_indice != nullptr && page_indice != nullptr && decode_page_indptr != nullptr
@@ -122,9 +131,16 @@ void invokePrepareFlashInferDecodeParams(const int32_t* sequence_lengths_plus_1,
                                                              batch_size,
                                                              max_blocks_per_batch,
                                                              seq_size_per_block);
+#if USING_ROCM
+    const auto result = hipGetLastError();
+    TORCH_CHECK(result == hipSuccess,
+                "FlashInfer decode CUDA graph prepare kernel failed: ",
+                hipGetErrorString(result));
+#else
     const auto result = cudaGetLastError();
     TORCH_CHECK(
         result == cudaSuccess, "FlashInfer decode CUDA graph prepare kernel failed: ", cudaGetErrorString(result));
+#endif
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.h
@@ -12,6 +12,8 @@ struct CudaGraphPrepareFillRegion {
     const int32_t* value_ptr = nullptr;
     int64_t        count     = 0;
     int32_t        value     = 0;
+    int32_t        value_offset = 0;
+    int32_t        step         = 0;
 };
 
 struct CudaGraphPrepareFillParams {

--- a/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/cuda_graph_prepare.h
@@ -1,9 +1,19 @@
 #pragma once
 
 #include <cstdint>
+#if USING_ROCM
+#include <hip/hip_runtime.h>
+#else
 #include <cuda_runtime_api.h>
+#endif
 
 namespace rtp_llm {
+
+#if USING_ROCM
+using CudaGraphPrepareStream = hipStream_t;
+#else
+using CudaGraphPrepareStream = cudaStream_t;
+#endif
 
 constexpr int kMaxCudaGraphPrepareFillRegions = 32;
 
@@ -21,7 +31,7 @@ struct CudaGraphPrepareFillParams {
     CudaGraphPrepareFillRegion regions[kMaxCudaGraphPrepareFillRegions];
 };
 
-void invokeCudaGraphPrepareFill(CudaGraphPrepareFillParams params, cudaStream_t stream);
+void invokeCudaGraphPrepareFill(CudaGraphPrepareFillParams params, CudaGraphPrepareStream stream);
 
 void invokePrepareFlashInferDecodeParams(const int32_t* sequence_lengths_plus_1,
                                          const int32_t* block_ids,
@@ -35,6 +45,6 @@ void invokePrepareFlashInferDecodeParams(const int32_t* sequence_lengths_plus_1,
                                          int32_t        batch_size,
                                          int32_t        max_blocks_per_batch,
                                          int32_t        seq_size_per_block,
-                                         cudaStream_t   stream);
+                                         CudaGraphPrepareStream stream);
 
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/py_model_inputs_compat_test.py
+++ b/rtp_llm/models_py/bindings/py_model_inputs_compat_test.py
@@ -95,12 +95,19 @@ class PyModelInputsCompatTest(unittest.TestCase):
         self.assertTrue(inputs.attention_inputs.is_prefill)
         self.assertEqual(3, inputs.attention_inputs.input_lengths.item())
 
-    def test_model_outputs_only_exposes_hidden_states(self) -> None:
+    def test_model_outputs_exposes_explicit_speculative_features(self) -> None:
         hidden_states = torch.empty(0)
         outputs = PyModelOutputs(hidden_states)
 
         self.assertEqual(hidden_states.data_ptr(), outputs.hidden_states.data_ptr())
+        self.assertIsNone(outputs.mtp_target_hidden_states)
         self.assertFalse(hasattr(outputs, "params_ptr"))
+
+        target_features = torch.ones(2, 3)
+        outputs = PyModelOutputs(hidden_states, target_features)
+        self.assertEqual(
+            target_features.data_ptr(), outputs.mtp_target_hidden_states.data_ptr()
+        )
         with self.assertRaises(TypeError):
             PyModelOutputs(hidden_states, {"full": None})
 

--- a/rtp_llm/models_py/bindings/rocm/kernels/BUILD
+++ b/rtp_llm/models_py/bindings/rocm/kernels/BUILD
@@ -98,13 +98,23 @@ cc_library(
 )
 
 cc_library(
+    name = "rocm_trtllm_allreduce_sync",
+    hdrs = ["trtllm_allreduce_sync.cuh"],
+    deps = [
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:hip",
+    ],
+    copts = rocm_copts(),
+)
+
+cc_library(
     name = "rocm_trtllm_allreduce_fusion",
     srcs = ["trtllm_allreduce_fusion.cu"],
     hdrs = [
         "trtllm_allreduce_fusion.h",
         "hip_float8_impl.h",
     ],
-    deps = rocm_deps + torch_deps(),
+    deps = rocm_deps + torch_deps() + [":rocm_trtllm_allreduce_sync"],
     copts = rocm_copts(),
     visibility = ["//visibility:public"],
 )

--- a/rtp_llm/models_py/bindings/rocm/kernels/test/BUILD
+++ b/rtp_llm/models_py/bindings/rocm/kernels/test/BUILD
@@ -1,0 +1,20 @@
+load("//:def.bzl", "rocm_copts")
+
+cc_test(
+    name = "trtllm_allreduce_sync_test",
+    srcs = ["trtllm_allreduce_sync_test.cu"],
+    copts = rocm_copts(),
+    deps = [
+        "//rtp_llm/models_py/bindings/rocm/kernels:rocm_trtllm_allreduce_sync",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:hip",
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+    env = {"GPU_COUNT": "2"},
+    tags = ["rocm"],
+    timeout = "moderate",
+    exec_properties = {
+        "gpu": "MI308X-ROCM7",
+        "gpu_count": "2",
+    },
+)

--- a/rtp_llm/models_py/bindings/rocm/kernels/test/trtllm_allreduce_sync_test.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/test/trtllm_allreduce_sync_test.cu
@@ -1,0 +1,429 @@
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <tuple>
+
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_sync.cuh"
+
+namespace {
+
+constexpr int kWorldSize       = 2;
+constexpr int kBlocks          = 4;
+constexpr int kThreadsPerBlock = 64;
+constexpr int kSkewedReplays   = 64;
+constexpr int kChildTimeoutSec = 20;
+constexpr int kSkipExitCode    = 77;
+
+class HipError: public std::runtime_error {
+public:
+    explicit HipError(const std::string& message): std::runtime_error(message) {}
+};
+
+void hipCheck(hipError_t status, const char* expression, const char* file, int line) {
+    if (status != hipSuccess) {
+        throw HipError(std::string(file) + ":" + std::to_string(line) + " " + expression + ": "
+                       + hipGetErrorString(status));
+    }
+}
+
+#define HIP_CHECK(expression) hipCheck((expression), #expression, __FILE__, __LINE__)
+
+enum class ProbePath {
+    kOneStage,
+    kTwoStage,
+};
+
+__global__ void singleSyncProbe(rtp_llm::CommDeviceMeta<kWorldSize> meta, rtp_llm::SyncEpoch* observed) {
+    rtp_llm::SyncComm<kWorldSize> comm(meta);
+    comm.sync();
+    if (threadIdx.x == 0) {
+        observed[blockIdx.x] = comm.flag;
+    }
+}
+
+template<ProbePath Path>
+__global__ void syncProbe(rtp_llm::CommDeviceMeta<kWorldSize> meta, rtp_llm::SyncEpoch* observed) {
+    rtp_llm::SyncComm<kWorldSize> comm(meta);
+    if constexpr (Path == ProbePath::kOneStage) {
+        // Both 1-stage production kernels use this entry/exit sequence.
+        comm.sync();
+        comm.sync();
+    } else {
+        // Both 2-stage production kernels use this sequence: relaxed/non-final,
+        // acquire-release/final, then the workspace-protection exit barrier.
+        comm.template sync<true, false>();
+        comm.template sync<false, true>();
+        comm.sync();
+    }
+    if (threadIdx.x == 0) {
+        observed[blockIdx.x] = comm.flag;
+    }
+}
+
+struct DeviceBuffers {
+    rtp_llm::SyncEpoch* clock      = nullptr;
+    rtp_llm::SyncEpoch* flags      = nullptr;
+    rtp_llm::SyncEpoch* observed   = nullptr;
+    hipStream_t         stream     = nullptr;
+    hipGraph_t          graph      = nullptr;
+    hipGraphExec_t      graph_exec = nullptr;
+};
+
+class ScenarioSkip: public std::runtime_error {
+public:
+    explicit ScenarioSkip(const std::string& message): std::runtime_error(message) {}
+};
+
+void destroyBuffers(std::array<DeviceBuffers, kWorldSize>& buffers) {
+    for (int rank = 0; rank < kWorldSize; ++rank) {
+        hipSetDevice(rank);
+        if (buffers[rank].graph_exec != nullptr) {
+            hipGraphExecDestroy(buffers[rank].graph_exec);
+        }
+        if (buffers[rank].graph != nullptr) {
+            hipGraphDestroy(buffers[rank].graph);
+        }
+        if (buffers[rank].stream != nullptr) {
+            hipStreamDestroy(buffers[rank].stream);
+        }
+        if (buffers[rank].observed != nullptr) {
+            hipFree(buffers[rank].observed);
+        }
+        if (buffers[rank].flags != nullptr) {
+            hipFree(buffers[rank].flags);
+        }
+        if (buffers[rank].clock != nullptr) {
+            hipFree(buffers[rank].clock);
+        }
+    }
+}
+
+void enablePeerAccess() {
+    for (int device = 0; device < kWorldSize; ++device) {
+        const int peer = 1 - device;
+        int       can_access_peer{};
+        HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, device, peer));
+        if (!can_access_peer) {
+            throw ScenarioSkip("the selected GPUs do not support peer access");
+        }
+        HIP_CHECK(hipSetDevice(device));
+        const hipError_t status = hipDeviceEnablePeerAccess(peer, 0);
+        if (status != hipSuccess && status != hipErrorPeerAccessAlreadyEnabled) {
+            hipCheck(status, "hipDeviceEnablePeerAccess", __FILE__, __LINE__);
+        }
+    }
+}
+
+template<ProbePath Path>
+void launchProbe(const rtp_llm::CommDeviceMeta<kWorldSize>& meta, DeviceBuffers& buffers) {
+    syncProbe<Path><<<kBlocks, kThreadsPerBlock, 0, buffers.stream>>>(meta, buffers.observed);
+    HIP_CHECK(hipGetLastError());
+}
+
+void launchSingleProbe(const rtp_llm::CommDeviceMeta<kWorldSize>& meta, DeviceBuffers& buffers) {
+    singleSyncProbe<<<1, kThreadsPerBlock, 0, buffers.stream>>>(meta, buffers.observed);
+    HIP_CHECK(hipGetLastError());
+}
+
+void allocateBuffers(std::array<DeviceBuffers, kWorldSize>& buffers, rtp_llm::SyncEpoch seed) {
+    int device_count{};
+    HIP_CHECK(hipGetDeviceCount(&device_count));
+    if (device_count < kWorldSize) {
+        throw ScenarioSkip("requires two visible ROCm devices");
+    }
+    enablePeerAccess();
+    const std::array<rtp_llm::SyncEpoch, kBlocks>              clocks{seed, seed, seed, seed};
+    const std::array<rtp_llm::SyncEpoch, kBlocks * kWorldSize> flags{
+        seed,
+        seed,
+        seed,
+        seed,
+        seed,
+        seed,
+        seed,
+        seed,
+    };
+    for (int rank = 0; rank < kWorldSize; ++rank) {
+        HIP_CHECK(hipSetDevice(rank));
+        HIP_CHECK(hipMalloc(&buffers[rank].clock, sizeof(clocks)));
+        HIP_CHECK(hipMalloc(&buffers[rank].flags, sizeof(flags)));
+        HIP_CHECK(hipMalloc(&buffers[rank].observed, sizeof(clocks)));
+        HIP_CHECK(hipMemcpy(buffers[rank].clock, clocks.data(), sizeof(clocks), hipMemcpyHostToDevice));
+        HIP_CHECK(hipMemcpy(buffers[rank].flags, flags.data(), sizeof(flags), hipMemcpyHostToDevice));
+        HIP_CHECK(hipStreamCreate(&buffers[rank].stream));
+    }
+}
+
+std::array<rtp_llm::CommDeviceMeta<kWorldSize>, kWorldSize>
+makeMetas(const std::array<DeviceBuffers, kWorldSize>& buffers) {
+    std::array<rtp_llm::CommDeviceMeta<kWorldSize>, kWorldSize> metas{};
+    for (int rank = 0; rank < kWorldSize; ++rank) {
+        metas[rank].barrier_flag_ptrs[0] = buffers[0].flags;
+        metas[rank].barrier_flag_ptrs[1] = buffers[1].flags;
+        metas[rank].sync_clock           = buffers[rank].clock;
+        metas[rank].rank                 = rank;
+        metas[rank].nranks               = kWorldSize;
+    }
+    return metas;
+}
+
+template<ProbePath Path>
+void runScenario(rtp_llm::SyncEpoch seed, bool graph_capture, int rank_one_delay_ms) {
+    std::array<DeviceBuffers, kWorldSize> buffers{};
+    try {
+        allocateBuffers(buffers, seed);
+        const auto metas = makeMetas(buffers);
+
+        // Enqueue both ranks before synchronizing either stream. Rank 1 is delayed
+        // on every replay, so rank 0 can enter generation N+1 while rank 1 is
+        // retiring generation N. A clear-after-wait barrier loses rank 0's newer
+        // arrival and this scenario fails via the child-process timeout.
+        if (graph_capture) {
+            for (int rank = 0; rank < kWorldSize; ++rank) {
+                HIP_CHECK(hipSetDevice(rank));
+                HIP_CHECK(hipStreamBeginCapture(buffers[rank].stream, hipStreamCaptureModeGlobal));
+                launchProbe<Path>(metas[rank], buffers[rank]);
+                HIP_CHECK(hipStreamEndCapture(buffers[rank].stream, &buffers[rank].graph));
+                HIP_CHECK(hipGraphInstantiate(&buffers[rank].graph_exec, buffers[rank].graph, nullptr, nullptr, 0));
+            }
+            for (int replay = 0; replay < kSkewedReplays; ++replay) {
+                for (int rank = 0; rank < kWorldSize; ++rank) {
+                    HIP_CHECK(hipSetDevice(rank));
+                    if (rank == 1 && rank_one_delay_ms > 0) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(rank_one_delay_ms));
+                    }
+                    HIP_CHECK(hipGraphLaunch(buffers[rank].graph_exec, buffers[rank].stream));
+                }
+            }
+        } else {
+            for (int replay = 0; replay < kSkewedReplays; ++replay) {
+                for (int rank = 0; rank < kWorldSize; ++rank) {
+                    HIP_CHECK(hipSetDevice(rank));
+                    if (rank == 1 && rank_one_delay_ms > 0) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(rank_one_delay_ms));
+                    }
+                    launchProbe<Path>(metas[rank], buffers[rank]);
+                }
+            }
+        }
+        for (int rank = 0; rank < kWorldSize; ++rank) {
+            HIP_CHECK(hipSetDevice(rank));
+            HIP_CHECK(hipStreamSynchronize(buffers[rank].stream));
+        }
+
+        constexpr int            kSyncCallsPerReplay = Path == ProbePath::kOneStage ? 2 : 3;
+        const rtp_llm::SyncEpoch expected            = seed + kSkewedReplays * kSyncCallsPerReplay;
+        for (int rank = 0; rank < kWorldSize; ++rank) {
+            std::array<rtp_llm::SyncEpoch, kBlocks>              received_clocks{};
+            std::array<rtp_llm::SyncEpoch, kBlocks>              received_observed{};
+            std::array<rtp_llm::SyncEpoch, kBlocks * kWorldSize> received_flags{};
+            HIP_CHECK(hipSetDevice(rank));
+            HIP_CHECK(
+                hipMemcpy(received_clocks.data(), buffers[rank].clock, sizeof(received_clocks), hipMemcpyDeviceToHost));
+            HIP_CHECK(hipMemcpy(
+                received_observed.data(), buffers[rank].observed, sizeof(received_observed), hipMemcpyDeviceToHost));
+            HIP_CHECK(
+                hipMemcpy(received_flags.data(), buffers[rank].flags, sizeof(received_flags), hipMemcpyDeviceToHost));
+            for (rtp_llm::SyncEpoch value : received_clocks) {
+                if (value != expected) {
+                    throw std::runtime_error("sync clock did not advance through the expected modulo-2^32 epoch");
+                }
+            }
+            for (rtp_llm::SyncEpoch value : received_observed) {
+                if (value != expected) {
+                    throw std::runtime_error("probe observed an unexpected final epoch");
+                }
+            }
+            for (rtp_llm::SyncEpoch value : received_flags) {
+                if (value != expected) {
+                    throw std::runtime_error("barrier flag did not advance through the expected modulo-2^32 epoch");
+                }
+            }
+        }
+    } catch (...) {
+        destroyBuffers(buffers);
+        throw;
+    }
+    destroyBuffers(buffers);
+}
+
+void runStaleEpochGate() {
+    constexpr rtp_llm::SyncEpoch          kSeed = 0xffffffffu;
+    std::array<DeviceBuffers, kWorldSize> buffers{};
+    hipEvent_t                            rank_zero_done = nullptr;
+    try {
+        allocateBuffers(buffers, kSeed);
+        const auto metas = makeMetas(buffers);
+
+        HIP_CHECK(hipSetDevice(0));
+        HIP_CHECK(hipEventCreate(&rank_zero_done));
+        launchSingleProbe(metas[0], buffers[0]);
+        HIP_CHECK(hipEventRecord(rank_zero_done, buffers[0].stream));
+
+        // rank 0 stores the expected epoch (0) into rank 1's local slot before
+        // polling rank 0's still-stale slot. This copy does not synchronize rank
+        // 0's stream, so it distinguishes a stale-aware wait from unsigned '<'.
+        rtp_llm::SyncEpoch published        = kSeed;
+        const auto         publish_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (published != rtp_llm::SyncEpoch{0} && std::chrono::steady_clock::now() < publish_deadline) {
+            HIP_CHECK(hipSetDevice(1));
+            HIP_CHECK(hipMemcpy(&published, buffers[1].flags, sizeof(published), hipMemcpyDeviceToHost));
+            if (published != rtp_llm::SyncEpoch{0}) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+
+        bool        rank_zero_was_blocked = false;
+        std::string gate_error;
+        if (published != rtp_llm::SyncEpoch{0}) {
+            gate_error = "rank 0 did not publish epoch zero before the stale-gate deadline";
+        } else {
+            HIP_CHECK(hipSetDevice(0));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            const hipError_t event_status = hipEventQuery(rank_zero_done);
+            rank_zero_was_blocked         = event_status == hipErrorNotReady;
+            if (!rank_zero_was_blocked) {
+                gate_error = event_status == hipSuccess ?
+                                 "rank 0 completed while rank 1 still exposed the stale UINT_MAX flag" :
+                                 std::string("hipEventQuery failed: ") + hipGetErrorString(event_status);
+            }
+        }
+
+        // Always release rank 0 before reporting the stale-gate result. Otherwise
+        // cleanup could block behind the deliberately stalled peer kernel.
+        HIP_CHECK(hipSetDevice(1));
+        launchSingleProbe(metas[1], buffers[1]);
+        HIP_CHECK(hipSetDevice(0));
+        HIP_CHECK(hipStreamSynchronize(buffers[0].stream));
+        HIP_CHECK(hipSetDevice(1));
+        HIP_CHECK(hipStreamSynchronize(buffers[1].stream));
+
+        rtp_llm::SyncEpoch rank_zero_clock{};
+        rtp_llm::SyncEpoch rank_one_clock{};
+        rtp_llm::SyncEpoch rank_zero_flag{};
+        rtp_llm::SyncEpoch rank_one_flag{};
+        HIP_CHECK(hipSetDevice(0));
+        HIP_CHECK(hipMemcpy(&rank_zero_clock, buffers[0].clock, sizeof(rank_zero_clock), hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(&rank_one_flag, buffers[0].flags + 1, sizeof(rank_one_flag), hipMemcpyDeviceToHost));
+        HIP_CHECK(hipSetDevice(1));
+        HIP_CHECK(hipMemcpy(&rank_one_clock, buffers[1].clock, sizeof(rank_one_clock), hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(&rank_zero_flag, buffers[1].flags, sizeof(rank_zero_flag), hipMemcpyDeviceToHost));
+
+        if (!rank_zero_was_blocked) {
+            throw std::runtime_error(gate_error);
+        }
+        if (rank_zero_clock != rtp_llm::SyncEpoch{0} || rank_one_clock != rtp_llm::SyncEpoch{0}
+            || rank_zero_flag != rtp_llm::SyncEpoch{0} || rank_one_flag != rtp_llm::SyncEpoch{0}) {
+            throw std::runtime_error("the two ranks did not complete epoch zero after the peer was released");
+        }
+    } catch (...) {
+        if (rank_zero_done != nullptr) {
+            hipEventDestroy(rank_zero_done);
+        }
+        destroyBuffers(buffers);
+        throw;
+    }
+    HIP_CHECK(hipEventDestroy(rank_zero_done));
+    destroyBuffers(buffers);
+}
+
+template<typename Scenario>
+int runInChild(Scenario&& scenario) {
+    const pid_t child = fork();
+    if (child < 0) {
+        return EXIT_FAILURE;
+    }
+    if (child == 0) {
+        try {
+            scenario();
+            std::_Exit(EXIT_SUCCESS);
+        } catch (const ScenarioSkip& error) {
+            std::fprintf(stderr, "SKIP: %s\n", error.what());
+            std::_Exit(kSkipExitCode);
+        } catch (const std::exception& error) {
+            std::fprintf(stderr, "FAIL: %s\n", error.what());
+            std::_Exit(EXIT_FAILURE);
+        }
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(kChildTimeoutSec);
+    int        status{};
+    while (std::chrono::steady_clock::now() < deadline) {
+        const pid_t result = waitpid(child, &status, WNOHANG);
+        if (result == child) {
+            if (WIFEXITED(status)) {
+                return WEXITSTATUS(status);
+            }
+            return EXIT_FAILURE;
+        }
+        if (result < 0) {
+            return EXIT_FAILURE;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::fprintf(stderr, "FAIL: GPU sync child exceeded %d seconds; terminating it\n", kChildTimeoutSec);
+    kill(child, SIGKILL);
+    waitpid(child, &status, 0);
+    return EXIT_FAILURE;
+}
+
+class TrtllmAllReduceSyncTest: public ::testing::TestWithParam<std::tuple<ProbePath, bool, rtp_llm::SyncEpoch>> {};
+
+TEST(SyncEpochReachedTest, AcceptsEqualAndBoundedAheadEpochs) {
+    using rtp_llm::SyncEpoch;
+    EXPECT_TRUE(rtp_llm::details::syncEpochReached(SyncEpoch{0}, SyncEpoch{0}));
+    EXPECT_TRUE(rtp_llm::details::syncEpochReached(SyncEpoch{0}, SyncEpoch{0xffffffffu}));
+    EXPECT_TRUE(rtp_llm::details::syncEpochReached(SyncEpoch{0x80000000u}, SyncEpoch{0x7fffffffu}));
+    EXPECT_FALSE(rtp_llm::details::syncEpochReached(SyncEpoch{0xffffffffu}, SyncEpoch{0}));
+    EXPECT_FALSE(rtp_llm::details::syncEpochReached(SyncEpoch{0x7fffffffu}, SyncEpoch{0x80000000u}));
+}
+
+TEST(TrtllmAllReduceSyncTest, RejectsStaleUintMaxUntilPeerPublishesEpochZero) {
+    const int exit_code = runInChild([] { runStaleEpochGate(); });
+    if (exit_code == kSkipExitCode) {
+        GTEST_SKIP() << "two ROCm devices with P2P access are required";
+    }
+    EXPECT_EQ(exit_code, EXIT_SUCCESS);
+}
+
+TEST_P(TrtllmAllReduceSyncTest, AdvancesEqualClocksAndFlagsAcrossCounterBoundaries) {
+    const auto [path, graph_capture, seed] = GetParam();
+    const int exit_code                    = path == ProbePath::kOneStage ?
+                                                 runInChild([&] { runScenario<ProbePath::kOneStage>(seed, graph_capture, 10); }) :
+                                                 runInChild([&] { runScenario<ProbePath::kTwoStage>(seed, graph_capture, 10); });
+    if (exit_code == kSkipExitCode) {
+        GTEST_SKIP() << "two ROCm devices with P2P access are required";
+    }
+    EXPECT_EQ(exit_code, EXIT_SUCCESS);
+}
+
+std::string parameterName(const ::testing::TestParamInfo<TrtllmAllReduceSyncTest::ParamType>& info) {
+    const auto [path, graph_capture, seed] = info.param;
+    const char* path_name                  = path == ProbePath::kOneStage ? "OneStage" : "TwoStage";
+    const char* graph_name                 = graph_capture ? "Graph" : "Eager";
+    const char* epoch_name = seed == rtp_llm::SyncEpoch{0x7ffffffd} ? "IntMaxMinusTwo" : "UintMaxMinusTwo";
+    return std::string(path_name) + graph_name + epoch_name;
+}
+
+INSTANTIATE_TEST_SUITE_P(AllReduceKernelSyncSequences,
+                         TrtllmAllReduceSyncTest,
+                         ::testing::Combine(::testing::Values(ProbePath::kOneStage, ProbePath::kTwoStage),
+                                            ::testing::Bool(),
+                                            ::testing::Values(rtp_llm::SyncEpoch{0x7ffffffd},
+                                                              rtp_llm::SyncEpoch{0xfffffffdu})),
+                         parameterName);
+
+}  // namespace

--- a/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.cu
@@ -7,7 +7,10 @@
 #include <limits>
 #include <vector>
 #include <array>
+#include <string>
 #include <tuple>
+#include <unordered_map>
+#include <utility>
 #include "rtp_llm/models_py/bindings/rocm/kernels/hip_float8_impl.h"
 
 #include <hip/hip_bf16.h>
@@ -21,6 +24,7 @@
 #include <torch/all.h>
 
 #include "rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.h"
+#include "rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_sync.cuh"
 
 using namespace std;
 using namespace at;
@@ -41,18 +45,6 @@ static_assert(!shouldUseOneStageAllReduce(64, 8, 80 * 1024));
 namespace details {
 
 static constexpr int kBytesPerAccess = 16;
-
-template<bool RELAXED = true>
-__device__ __forceinline__ void st_flag(int* addr, int flag) {
-    __scoped_atomic_store_n(addr, flag, RELAXED ? __ATOMIC_RELAXED : __ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
-}
-
-template<bool RELAXED = true>
-__device__ __forceinline__ int ld_flag(int* addr) {
-    int flag;
-    flag = __scoped_atomic_load_n(addr, RELAXED ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE, __MEMORY_SCOPE_SYSTEM);
-    return flag;
-}
 
 }  // namespace details
 
@@ -256,14 +248,6 @@ using namespace kernel_utils;
 #define WARP_SIZE 32
 #define MAX_RANKS 8
 
-template<int NRanks>
-struct CommDeviceMeta {
-    void* barrier_flag_ptrs[NRanks];
-    void* sync_clock;
-    int   rank;
-    int   nranks;
-};
-
 struct CommMeta {
     void* barrier_flag_ptrs[MAX_RANKS];
     void* sync_clock;
@@ -273,52 +257,6 @@ struct CommMeta {
 
 struct CommPtrs {
     void* data_ptrs[MAX_RANKS];
-};
-
-// Cached IPC slot entry: pairs the device-side CommPtrs pointer with the
-// allocation range that was current when the slot was registered.  On cache
-// hit we re-query the HIP runtime and compare — if the caching allocator
-// freed and reused the same data_ptr inside a different allocation block,
-// range_start / range_size will differ and we invalidate the stale entry.
-struct CachedSlot {
-    CommPtrs* comm_ptrs;
-    void*     range_start;
-    size_t    range_size;
-};
-
-template<int NRanks>
-struct SyncComm {
-    __device__ __forceinline__ SyncComm(CommDeviceMeta<NRanks>& meta) {
-        flag_ptr = ((int*)meta.sync_clock) + blockIdx.x;
-        int rank = meta.rank;
-        if (threadIdx.x < NRanks) {
-            int target_rank = threadIdx.x;
-            target_flag     = reinterpret_cast<int*>(meta.barrier_flag_ptrs[target_rank]) + blockIdx.x * NRanks + rank;
-            current_flag    = reinterpret_cast<int*>(meta.barrier_flag_ptrs[rank]) + blockIdx.x * NRanks + target_rank;
-        }
-        flag = *flag_ptr;
-    }
-
-    template<bool RELAXED = true, bool FINAL = true>
-    __device__ __forceinline__ void sync() {
-        __syncthreads();
-        flag += 1;
-        if (threadIdx.x < NRanks) {
-            details::st_flag<RELAXED>(target_flag, flag);
-            while (details::ld_flag<RELAXED>(current_flag) < flag) {}
-        }
-        __syncthreads();
-        if constexpr (FINAL) {
-            if (threadIdx.x == 0) {
-                *flag_ptr = flag;
-            }
-        }
-    }
-
-    int* flag_ptr;
-    int* target_flag;
-    int* current_flag;
-    int  flag;
 };
 
 enum QuantType {
@@ -976,6 +914,10 @@ void open_handles(int rank, std::vector<Tensor>& handles, void* ptr, std::vector
     ipc_ptrs.swap(opened);
 }
 
+std::string handle_generation(const gpuIpcMemHandle_t& handle) {
+    return std::string(reinterpret_cast<const char*>(&handle), sizeof(handle));
+}
+
 void create_base_ptr(void** base_ptr, void* ptr) {
     if (gpuPointerGetAttribute(base_ptr, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR, (gpuDeviceptr_t)ptr) != gpuSuccess) {
         throw std::runtime_error("failed to get pointer attr");
@@ -1016,8 +958,8 @@ public:
                         hipGetErrorString(err));
         };
 
-        size_t sync_clock_bytes    = max_thread_blocks_ * sizeof(int);
-        size_t barrier_flags_bytes = max_thread_blocks_ * world_size_ * sizeof(int);
+        size_t sync_clock_bytes    = max_thread_blocks_ * sizeof(SyncEpoch);
+        size_t barrier_flags_bytes = max_thread_blocks_ * world_size_ * sizeof(SyncEpoch);
         size_t data_bytes          = static_cast<size_t>(size_in_bytes_) * 2;
         size_t comm_ptrs_bytes     = comm_ptrs_buf_len_ * sizeof(CommPtrs);
 
@@ -1030,6 +972,7 @@ public:
         gpuMemset(barrier_flags_, 0, barrier_flags_bytes);
         used_comm_ptrs_ = 0;
         round_robin_    = round_robin;
+        captured_ipc_by_rank_.resize(world_size_);
     }
 
     ~CommWorkspace() {
@@ -1044,11 +987,15 @@ public:
                 hipIpcCloseMemHandle(ipc_data_[i]);
             }
         }
-        // Close IPC handles from CUDA Graph captured pointers
-        for (auto& handles : captured_ipc_handles_) {
-            for (size_t i = 0; i < handles.size(); ++i) {
-                if (static_cast<int>(i) != rank_) {
-                    hipIpcCloseMemHandle(handles[i]);
+        // Capture mappings are keyed by the exporting rank and the opaque IPC
+        // handle bytes, which identify that rank's allocation generation even
+        // when its caching allocator reuses the same address.
+        for (int i = 0; i < world_size_; ++i) {
+            if (i == rank_)
+                continue;
+            for (const auto& entry : captured_ipc_by_rank_[i]) {
+                if (entry.second != nullptr) {
+                    hipIpcCloseMemHandle(entry.second);
                 }
             }
         }
@@ -1096,45 +1043,28 @@ public:
         meta.rank       = rank_;
         meta.nranks     = world_size_;
 
-        int64_t   token_num    = input.numel() / input.size(-1);
-        bool      direct_input = shouldUseOneStageAllReduce(token_num, world_size_, size);
-        CommPtrs* cptrs;
-        bool      cache_hit = false;
-        auto      it        = direct_input ? ptr_to_comm_ptrs_.find(ptr) : ptr_to_comm_ptrs_.end();
-        if (it != ptr_to_comm_ptrs_.end()) {
-            // Validate that the allocation backing this data_ptr hasn't
-            // changed (freed + reused by the caching allocator).  If the
-            // range no longer matches, the cached IPC slot is stale.
-            auto&  slot      = it->second;
-            void*  cur_start = nullptr;
-            size_t cur_size  = 0;
-            hipPointerGetAttribute(
-                &cur_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR, reinterpret_cast<hipDeviceptr_t>(ptr));
-            hipPointerGetAttribute(&cur_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE, reinterpret_cast<hipDeviceptr_t>(ptr));
-            if (cur_start == slot.range_start && cur_size == slot.range_size) {
-                cptrs     = slot.comm_ptrs;
-                cache_hit = true;
-            } else {
-                // Stale entry — allocation was recycled.  Erase so we fall
-                // through to the capture / copy-fallback path below.
-                ptr_to_comm_ptrs_.erase(it);
-            }
-        }
-        if (!cache_hit) {
-            // One-stage graph replay reads peer inputs directly; other paths use the workspace.
-            gpuStreamCaptureStatus status = gpuStreamCaptureStatusNone;
-            if (gpuStreamIsCapturing(stream, &status) != gpuSuccess)
-                status = gpuStreamCaptureStatusNone;
-            int remaining = comm_ptrs_buf_len_ - used_comm_ptrs_ - static_cast<int>(unregistered_ptrs_.size());
-            if (direct_input && status == gpuStreamCaptureStatusActive && size < size_in_bytes_ && remaining > 0) {
-                unregistered_ptrs_.push_back(ptr);
-                cptrs = comm_ptrs_ + used_comm_ptrs_ + static_cast<int>(unregistered_ptrs_.size()) - 1;
-            } else {
-                cptrs = comm_ptrs_ + 0;
-                TORCH_CHECK(size <= size_in_bytes_, "allreduce input exceeds comm workspace capacity");
-                TORCH_CHECK(gpuMemcpyAsync(data_, ptr, size, gpuMemcpyDeviceToDevice, stream) == gpuSuccess,
-                            "failed to stage allreduce input into the comm workspace");
-            }
+        int64_t                token_num    = input.numel() / input.size(-1);
+        bool                   direct_input = shouldUseOneStageAllReduce(token_num, world_size_, size);
+        CommPtrs*              cptrs;
+        gpuStreamCaptureStatus status = gpuStreamCaptureStatusNone;
+        if (gpuStreamIsCapturing(stream, &status) != gpuSuccess)
+            status = gpuStreamCaptureStatusNone;
+        int remaining = comm_ptrs_buf_len_ - used_comm_ptrs_ - static_cast<int>(unregistered_ptrs_.size());
+        if (direct_input && status == gpuStreamCaptureStatusActive && size < size_in_bytes_ && remaining > 0) {
+            // Treat every graph capture as a new collective generation. All
+            // ranks therefore exchange the complete current handle sequence;
+            // no rank can silently choose an old slot from its local data_ptr
+            // while another rank registers a replacement allocation.
+            unregistered_ptrs_.push_back(ptr);
+            cptrs = comm_ptrs_ + used_comm_ptrs_ + static_cast<int>(unregistered_ptrs_.size()) - 1;
+        } else {
+            // Eager execution cannot collectively validate peer allocation
+            // generations, so use the stable workspace instead of a captured
+            // direct-input slot.
+            cptrs = comm_ptrs_ + 0;
+            TORCH_CHECK(size <= size_in_bytes_, "allreduce input exceeds comm workspace capacity");
+            TORCH_CHECK(gpuMemcpyAsync(data_, ptr, size, gpuMemcpyDeviceToDevice, stream) == gpuSuccess,
+                        "failed to stage allreduce input into the comm workspace");
         }
 
         return {meta, cptrs};
@@ -1178,8 +1108,8 @@ public:
         void* ptr      = unregistered_ptrs_[ptr_idx];
         void* base_ptr = unregistered_base_ptrs_[ptr_idx];
 
-        // Defensive check: verify the cached pointer still belongs to a valid
-        // device allocation.  The caching allocator may have freed and re-used
+        // Defensive check: verify the captured pointer still belongs to a valid
+        // device allocation. The caching allocator may have freed and re-used
         // the underlying block between capture and consume.
         // TORCH_CHECK hard-fails instead of early-return because the captured
         // graph already has kernel launches bound to this comm_ptrs slot; an
@@ -1194,7 +1124,7 @@ public:
         hipPointerAttribute_t ptr_attrs = {};
         hipError_t            attr_err  = hipPointerGetAttributes(&ptr_attrs, base_ptr);
         TORCH_CHECK(attr_err == hipSuccess,
-                    "[TrtllmAllreduce] cached base_ptr ",
+                    "[TrtllmAllreduce] captured base_ptr ",
                     base_ptr,
                     " (ptr_idx=",
                     ptr_idx,
@@ -1203,7 +1133,7 @@ public:
                     "). The pointer is no longer valid — "
                     "discard the captured graph and re-capture.");
         TORCH_CHECK(ptr_attrs.type == hipMemoryTypeDevice || ptr_attrs.type == hipMemoryTypeUnified,
-                    "[TrtllmAllreduce] cached base_ptr ",
+                    "[TrtllmAllreduce] captured base_ptr ",
                     base_ptr,
                     " (ptr_idx=",
                     ptr_idx,
@@ -1232,7 +1162,7 @@ public:
                     "and re-capture.");
         TORCH_CHECK(reinterpret_cast<char*>(base_ptr) >= reinterpret_cast<char*>(range_start)
                         && reinterpret_cast<char*>(ptr) < reinterpret_cast<char*>(range_start) + range_size,
-                    "[TrtllmAllreduce] cached ptr ",
+                    "[TrtllmAllreduce] captured ptr ",
                     ptr,
                     " (base_ptr=",
                     base_ptr,
@@ -1246,10 +1176,57 @@ public:
                     "). The allocation was likely freed and re-used. "
                     "Discard the captured graph and re-capture.");
 
-        std::vector<void*> ipc_data;
-        ipc_details::open_handles(rank_, handles, base_ptr, ipc_data);
-        // Store opened IPC handles so they can be closed in the destructor.
-        captured_ipc_handles_.push_back(ipc_data);
+        TORCH_CHECK(static_cast<int>(handles.size()) == world_size_,
+                    "captured IPC handle count does not match world size");
+        TORCH_CHECK(offsets.size() == handles.size(), "captured IPC handle/offset count mismatch");
+        TORCH_CHECK(used_comm_ptrs_ == capture_snapshot_used_ + ptr_idx,
+                    "captured IPC slots must be registered in capture order");
+
+        std::vector<gpuIpcMemHandle_t> ipc_handles;
+        std::vector<void*>             ipc_data(world_size_, nullptr);
+        struct NewlyOpened {
+            int         rank;
+            std::string generation;
+            void*       ptr;
+        };
+        std::vector<NewlyOpened> newly_opened;
+        ipc_handles.reserve(world_size_);
+        newly_opened.reserve(world_size_ - 1);
+        for (auto& handle : handles) {
+            gpuIpcMemHandle_t ipc_handle;
+            std::memcpy(&ipc_handle, handle.data_ptr(), sizeof(gpuIpcMemHandle_t));
+            ipc_handles.push_back(ipc_handle);
+        }
+
+        for (int i = 0; i < world_size_; ++i) {
+            if (i == rank_) {
+                ipc_data[i] = base_ptr;
+                continue;
+            }
+            std::string generation = ipc_details::handle_generation(ipc_handles[i]);
+            auto&       rank_cache = captured_ipc_by_rank_[i];
+            auto        cached     = rank_cache.find(generation);
+            if (cached != rank_cache.end()) {
+                ipc_data[i] = cached->second;
+                continue;
+            }
+
+            void* opened = nullptr;
+            auto  err    = gpuIpcOpenMemHandle(&opened, ipc_handles[i], gpuIpcMemLazyEnablePeerAccess);
+            if (err != gpuSuccess) {
+                for (const auto& entry : newly_opened) {
+                    hipIpcCloseMemHandle(entry.ptr);
+                }
+                TORCH_CHECK(false,
+                            "hipIpcOpenMemHandle failed for captured allocation generation from rank ",
+                            i,
+                            ": ",
+                            hipGetErrorString(err));
+            }
+            ipc_data[i] = opened;
+            newly_opened.push_back(NewlyOpened{i, std::move(generation), opened});
+        }
+
         CommPtrs cptrs;
         for (size_t i = 0; i < offsets.size(); ++i) {
             ipc_data[i] = (void*)((char*)ipc_data[i] + offsets[i]);
@@ -1258,21 +1235,17 @@ public:
             int r              = round_robin_ ? ((rank_ + i) % world_size_) : i;
             cptrs.data_ptrs[i] = ipc_data[r];
         }
-        gpuMemcpy(comm_ptrs_ + used_comm_ptrs_, &cptrs, sizeof(CommPtrs), gpuMemcpyHostToDevice);
-
-        // Record allocation range at registration time so that cache hits
-        // can detect freed-and-reused data_ptrs (same address, different
-        // allocation block).
-        void*  reg_start = nullptr;
-        size_t reg_size  = 0;
-        hipPointerGetAttribute(
-            &reg_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR, reinterpret_cast<hipDeviceptr_t>(ptr));
-        hipPointerGetAttribute(&reg_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE, reinterpret_cast<hipDeviceptr_t>(ptr));
-        ptr_to_comm_ptrs_[ptr] = CachedSlot{comm_ptrs_ + used_comm_ptrs_, reg_start, reg_size};
-
-        // Track every ptr registered in this session (vector, NOT set) so
-        // that duplicate data_ptrs are counted correctly for rollback.
-        pending_capture_ptrs_.push_back(ptr);
+        auto copy_err = gpuMemcpy(comm_ptrs_ + used_comm_ptrs_, &cptrs, sizeof(CommPtrs), gpuMemcpyHostToDevice);
+        if (copy_err != gpuSuccess) {
+            for (const auto& entry : newly_opened) {
+                hipIpcCloseMemHandle(entry.ptr);
+            }
+            TORCH_CHECK(false, "failed to publish captured IPC pointers: ", hipGetErrorString(copy_err));
+        }
+        for (auto& entry : newly_opened) {
+            captured_ipc_by_rank_[entry.rank].emplace(entry.generation, entry.ptr);
+            pending_capture_generations_.emplace_back(entry.rank, std::move(entry.generation));
+        }
         used_comm_ptrs_++;
     }
 
@@ -1280,19 +1253,17 @@ public:
     // to committed state.  After this call, invalidate_capture() will NOT
     // touch these slots — only future (failed) capture sessions are rolled back.
     void commit_capture() {
-        pending_capture_ptrs_.clear();
+        pending_capture_generations_.clear();
         // Reset snapshot — nothing to roll back.
-        capture_snapshot_used_      = used_comm_ptrs_;
-        capture_snapshot_ipc_count_ = static_cast<int>(captured_ipc_handles_.size());
+        capture_snapshot_used_ = used_comm_ptrs_;
     }
 
     // Begin a new capture session: snapshot the current high-water marks so
     // that invalidate_capture() can rewind to exactly this point.
     // Called from Python before the per-handle open loop begins.
     void begin_capture_session() {
-        capture_snapshot_used_      = used_comm_ptrs_;
-        capture_snapshot_ipc_count_ = static_cast<int>(captured_ipc_handles_.size());
-        pending_capture_ptrs_.clear();
+        capture_snapshot_used_ = used_comm_ptrs_;
+        pending_capture_generations_.clear();
     }
 
     // Transactional rollback: undo IPC slot registrations made during the
@@ -1305,23 +1276,20 @@ public:
         // 1. Rewind used_comm_ptrs_ to the snapshot watermark.
         used_comm_ptrs_ = capture_snapshot_used_;
 
-        // 2. Erase ptr_to_comm_ptrs_ entries registered in this session.
-        //    Use the vector (may contain duplicates — erase is idempotent).
-        for (void* ptr : pending_capture_ptrs_) {
-            ptr_to_comm_ptrs_.erase(ptr);
-        }
-        pending_capture_ptrs_.clear();
-
-        // 3. Close and remove IPC handles opened during this session.
-        while (static_cast<int>(captured_ipc_handles_.size()) > capture_snapshot_ipc_count_) {
-            auto& last = captured_ipc_handles_.back();
-            for (int i = 0; i < world_size_; ++i) {
-                if (i != rank_ && last[i] != nullptr) {
-                    hipIpcCloseMemHandle(last[i]);
+        // 2. Close only mappings first opened by this capture session.
+        //    Mappings committed by earlier graphs remain valid, so those
+        //    graphs can coexist with a recapture that uses new allocations.
+        for (auto it = pending_capture_generations_.rbegin(); it != pending_capture_generations_.rend(); ++it) {
+            auto& rank_cache = captured_ipc_by_rank_[it->first];
+            auto  cached     = rank_cache.find(it->second);
+            if (cached != rank_cache.end()) {
+                if (cached->second != nullptr) {
+                    hipIpcCloseMemHandle(cached->second);
                 }
+                rank_cache.erase(cached);
             }
-            captured_ipc_handles_.pop_back();
         }
+        pending_capture_generations_.clear();
     }
 
 private:
@@ -1339,13 +1307,11 @@ private:
     std::vector<void*>                    ipc_data_;
     std::vector<void*>                    unregistered_ptrs_;
     std::vector<void*>                    unregistered_base_ptrs_;
-    std::vector<std::vector<void*>>       captured_ipc_handles_;
-    CommPtrs*                             comm_ptrs_;
-    int                                   used_comm_ptrs_;
-    std::unordered_map<void*, CachedSlot> ptr_to_comm_ptrs_;
-    std::vector<void*> pending_capture_ptrs_;            // ptrs registered in current session (allows duplicates)
-    int                capture_snapshot_used_      = 0;  // used_comm_ptrs_ at session start
-    int                capture_snapshot_ipc_count_ = 0;  // captured_ipc_handles_.size() at session start
+    std::vector<std::unordered_map<std::string, void*>> captured_ipc_by_rank_;
+    CommPtrs*                                             comm_ptrs_;
+    int                                                   used_comm_ptrs_;
+    std::vector<std::pair<int, std::string>> pending_capture_generations_;
+    int                                      capture_snapshot_used_ = 0;
 };
 
 // ============================================================================

--- a/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_sync.cuh
+++ b/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_sync.cuh
@@ -1,0 +1,83 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#include <cstdint>
+#include <hip/hip_runtime.h>
+
+namespace rtp_llm {
+
+using SyncEpoch = uint32_t;
+
+namespace details {
+
+// Ranks use the same ordered barrier sequence per block. A peer may already
+// have published the next epoch when we read its slot, so equality is not
+// sufficient. Compare modulo 2^32, assuming the epoch distance is below 2^31.
+// Unsigned addition and subtraction also keep both counter boundaries defined.
+__host__ __device__ constexpr bool syncEpochReached(SyncEpoch observed, SyncEpoch expected) {
+    return SyncEpoch(observed - expected) < (SyncEpoch{1} << 31);
+}
+
+template<bool RELAXED = true>
+__device__ __forceinline__ void st_flag(SyncEpoch* addr, SyncEpoch flag) {
+    __scoped_atomic_store_n(addr, flag, RELAXED ? __ATOMIC_RELAXED : __ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
+}
+
+template<bool RELAXED = true>
+__device__ __forceinline__ SyncEpoch ld_flag(SyncEpoch* addr) {
+    SyncEpoch flag;
+    flag = __scoped_atomic_load_n(addr, RELAXED ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE, __MEMORY_SCOPE_SYSTEM);
+    return flag;
+}
+
+}  // namespace details
+
+template<int NRanks>
+struct CommDeviceMeta {
+    void* barrier_flag_ptrs[NRanks];
+    void* sync_clock;
+    int   rank;
+    int   nranks;
+};
+
+template<int NRanks>
+struct SyncComm {
+    __device__ __forceinline__ SyncComm(CommDeviceMeta<NRanks>& meta) {
+        flag_ptr = static_cast<SyncEpoch*>(meta.sync_clock) + blockIdx.x;
+        int rank = meta.rank;
+        if (threadIdx.x < NRanks) {
+            int target_rank = threadIdx.x;
+            target_flag     = static_cast<SyncEpoch*>(meta.barrier_flag_ptrs[target_rank]) + blockIdx.x * NRanks + rank;
+            current_flag    = static_cast<SyncEpoch*>(meta.barrier_flag_ptrs[rank]) + blockIdx.x * NRanks + target_rank;
+        }
+        flag = *flag_ptr;
+    }
+
+    template<bool RELAXED = true, bool FINAL = true>
+    __device__ __forceinline__ void sync() {
+        __syncthreads();
+        flag += SyncEpoch{1};
+        if (threadIdx.x < NRanks) {
+            // This is a generation barrier: peer slots are never cleared after
+            // initialization. A fast rank may publish a later generation while
+            // a slow rank still waits for this one; syncEpochReached accepts the
+            // bounded-ahead value, so that newer arrival cannot be erased.
+            details::st_flag<RELAXED>(target_flag, flag);
+            while (!details::syncEpochReached(details::ld_flag<RELAXED>(current_flag), flag)) {}
+        }
+        __syncthreads();
+        if constexpr (FINAL) {
+            if (threadIdx.x == 0) {
+                *flag_ptr = flag;
+            }
+        }
+    }
+
+    SyncEpoch* flag_ptr;
+    SyncEpoch* target_flag;
+    SyncEpoch* current_flag;
+    SyncEpoch  flag;
+};
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/distributed/BUILD
+++ b/rtp_llm/models_py/distributed/BUILD
@@ -6,6 +6,7 @@ py_library(
     name = "collective_torch",
     srcs = [
         "collective_torch.py",
+        "flashinfer_all_reduce.py",
         "rocm_rccl.py",
         "symm_mem.py",
     ],

--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -36,6 +36,7 @@ _initialized: bool = False  # Track if we've initialized (to prevent double init
 _cpu_tp_broadcaster_base_path: Optional[str] = None
 _rocm_rccl = None
 _symm_mem = None
+_flashinfer_allreduce = None
 
 
 def _get_rocm_rccl():
@@ -60,6 +61,25 @@ def _get_symm_mem():
 
         _symm_mem = symm_mem
     return _symm_mem
+
+
+def _get_flashinfer_allreduce():
+    global _flashinfer_allreduce
+    if _flashinfer_allreduce is None:
+        from rtp_llm.models_py.distributed import flashinfer_all_reduce
+
+        _flashinfer_allreduce = flashinfer_all_reduce
+    return _flashinfer_allreduce
+
+
+def _init_flashinfer_allreduce(parallelism_config: ParallelismConfig) -> None:
+    if parallelism_config.tp_size <= 1:
+        return
+    _get_flashinfer_allreduce().init_flashinfer_allreduce(
+        _get_group(Group.TP),
+        torch.device("cuda", parallelism_config.local_rank),
+        single_node=parallelism_config.tp_size <= parallelism_config.local_world_size,
+    )
 
 
 def _make_cpu_tp_broadcaster_base_path(
@@ -152,6 +172,7 @@ def init_distributed_environment(
         rocm_rccl = _get_rocm_rccl()
         if rocm_rccl is not None and parallelism_config.tp_size > 1:
             rocm_rccl.prepare_comm_if_needed(parallelism_config, _get_group(Group.TP))
+        _init_flashinfer_allreduce(parallelism_config)
         return
 
     _normalize_parallelism_ranks(parallelism_config)
@@ -181,6 +202,7 @@ def init_distributed_environment(
         _register_process_groups_to_cpp()
         if rocm_rccl is not None and parallelism_config.tp_size > 1:
             rocm_rccl.prepare_comm_if_needed(parallelism_config, _get_group(Group.TP))
+        _init_flashinfer_allreduce(parallelism_config)
         return
 
     logging.info(
@@ -216,6 +238,7 @@ def init_distributed_environment(
     if rocm_rccl is not None and parallelism_config.tp_size > 1:
         rocm_rccl.prepare_comm_if_needed(parallelism_config, _get_group(Group.TP))
     init_user_buffers_environment(parallelism_config)
+    _init_flashinfer_allreduce(parallelism_config)
 
 
 def _create_process_groups(
@@ -354,6 +377,17 @@ def _register_process_groups_to_cpp():
         if pg_world is not None:
             mode_to_group[_CPP_PARALLEL_MODE_TP] = pg_world
 
+    # If world_size == dp_size, WORLD is also the only DP group.
+    if (
+        _parallelism_config is not None
+        and _parallelism_config.dp_size > 1
+        and _parallelism_config.world_size == _parallelism_config.dp_size
+        and _CPP_PARALLEL_MODE_DP not in registered_modes
+    ):
+        pg_world = _group_map.get(Group.DP_AND_TP)
+        if pg_world is not None:
+            mode_to_group[_CPP_PARALLEL_MODE_DP] = pg_world
+
     # NOTE: These callbacks are NOT thin wrappers around the module-level broadcast()/
     # all_reduce()/all_gather() because the C++ calling convention differs significantly:
     #   - C++ uses int mode (ParallelMode enum ordinal) instead of Group enum
@@ -411,7 +445,10 @@ def _register_process_groups_to_cpp():
         """
         pg = mode_to_group.get(mode)
         if pg is None or pg.size() < 2:
-            return tensor if dest is None else tensor
+            if dest is None:
+                return tensor
+            dest.copy_(tensor)
+            return dest
         target = dest if dest is not None else tensor
         if dest is not None:
             target.copy_(tensor)
@@ -441,6 +478,9 @@ def _register_process_groups_to_cpp():
         """
         pg = mode_to_group.get(mode)
         if pg is None or pg.size() < 2:
+            if not inplace:
+                for i, recv_buf in enumerate(recv_buffers):
+                    recv_buf.copy_(send_buffers[i].reshape(recv_buf.shape))
             return
         world_size = pg.size()
         device_id: Optional[int] = None
@@ -565,6 +605,7 @@ def destroy_distributed_environment():
         )
 
         destroy_user_buffers_communicator()
+        _get_flashinfer_allreduce().destroy_flashinfer_allreduce()
 
     try:
         import librtp_compute_ops
@@ -691,13 +732,14 @@ def broadcast(tensor: torch.Tensor, src: int, group: Group) -> None:
     torch.distributed.broadcast(tensor, src, group=process_group)
 
 
-def all_reduce(tensor: torch.Tensor, group: Group, *, inplace: bool = False) -> torch.Tensor:
+def all_reduce(tensor: torch.Tensor, group: Group, *, inplace: bool = True) -> torch.Tensor:
     """All-reduce a tensor across all ranks in the group.
 
     Args:
         tensor: Tensor to all-reduce.
         group: Process group to use
-        inplace: If true, write the symmetric-memory fast-path result back to ``tensor``.
+        inplace: If true, write fast-path results back to ``tensor``. Defaults to
+            true to preserve the in-place contract of torch.distributed.all_reduce.
 
     Returns:
         All-reduced tensor.
@@ -706,20 +748,30 @@ def all_reduce(tensor: torch.Tensor, group: Group, *, inplace: bool = False) -> 
     if rocm_rccl is not None:
         rocm_rccl.ensure_capture_comm_ready(group == Group.TP)
         if rocm_rccl.should_use_capture_collectives(group == Group.TP):
-            return rocm_rccl.capture_all_reduce(tensor, _get_group(group))
+            target = tensor if inplace else tensor.clone()
+            return rocm_rccl.capture_all_reduce(target, _get_group(group))
 
     if group == Group.TP:
+        flashinfer_ar = _get_flashinfer_allreduce().get_flashinfer_allreduce()
+        if flashinfer_ar is not None and flashinfer_ar.should_use(tensor):
+            result = flashinfer_ar.all_reduce(tensor)
+            if inplace:
+                tensor.copy_(result)
+                return tensor
+            return result
+
         symm_mem_comm = _get_symm_mem().get_symm_mem_communicator()
         if symm_mem_comm is not None and symm_mem_comm.should_torch_symm_mem_allreduce(
             tensor
         ):
             return symm_mem_comm.all_reduce(tensor, out=tensor if inplace else None)
 
+    target = tensor if inplace else tensor.clone()
     process_group = _get_group(group)
     torch.distributed.all_reduce(
-        tensor, op=torch.distributed.ReduceOp.SUM, group=process_group
+        target, op=torch.distributed.ReduceOp.SUM, group=process_group
     )
-    return tensor
+    return target
 
 
 def all_gather(tensor: torch.Tensor, group: Group) -> torch.Tensor:

--- a/rtp_llm/models_py/distributed/flashinfer_all_reduce.py
+++ b/rtp_llm/models_py/distributed/flashinfer_all_reduce.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional FlashInfer TRT-LLM all-reduce for single-node CUDA TP groups.
+
+The adapter stays behind the generic ``collective_torch.all_reduce`` API.
+Unsupported devices, topologies, shapes, or initialization failures fall back
+to NCCL before CUDA graph capture starts.
+"""
+
+import logging
+import os
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+
+_MIB = 1024 * 1024
+_MAX_WORKSPACE_BYTES = {
+    2: 64 * _MIB,
+    4: 2 * _MIB,
+    8: _MIB // 2,
+}
+
+
+def _env_is_false(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return not default
+    return value.strip().lower() in ("0", "false", "off", "no")
+
+
+def enabled_by_env() -> bool:
+    """Use the server-wide custom AllReduce switch."""
+    return _env_is_false("FT_DISABLE_CUSTOM_AR", default=True)
+
+
+class FlashInferAllReduce:
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: torch.device,
+        *,
+        single_node: bool,
+    ) -> None:
+        self.group = group
+        self.device = device
+        self.world_size = dist.get_world_size(group)
+        self.rank = dist.get_rank(group)
+        self.disabled = True
+        self._workspace = None
+        self._hidden_dim = 0
+        self._dtype: Optional[torch.dtype] = None
+        self._max_num_tokens = 0
+        self._flashinfer_comm = None
+
+        if not enabled_by_env() or not single_node:
+            return
+        if self.world_size not in _MAX_WORKSPACE_BYTES:
+            logging.info(
+                "FlashInfer all-reduce disabled for unsupported TP size %s",
+                self.world_size,
+            )
+            return
+        try:
+            import flashinfer.comm as flashinfer_comm
+
+            if not hasattr(flashinfer_comm, "allreduce_fusion") or not hasattr(
+                flashinfer_comm, "create_allreduce_fusion_workspace"
+            ):
+                return
+            self._flashinfer_comm = flashinfer_comm
+            self.disabled = False
+        except ImportError:
+            logging.info("FlashInfer all-reduce unavailable; using NCCL")
+
+    def _create_workspace(self, tensor: torch.Tensor) -> bool:
+        if self.disabled or self._flashinfer_comm is None:
+            return False
+        if torch.cuda.is_current_stream_capturing():
+            return False
+
+        workspace = None
+        local_success = False
+        local_error: Optional[Exception] = None
+        try:
+            from flashinfer.comm.mnnvl import TorchDistBackend
+
+            hidden_dim = tensor.shape[1]
+            max_num_tokens = _MAX_WORKSPACE_BYTES[self.world_size] // (
+                hidden_dim * tensor.element_size()
+            )
+            workspace = self._flashinfer_comm.create_allreduce_fusion_workspace(
+                backend="trtllm",
+                world_size=self.world_size,
+                rank=self.rank,
+                max_token_num=max_num_tokens,
+                hidden_dim=hidden_dim,
+                dtype=tensor.dtype,
+                comm_backend=TorchDistBackend(group=self.group),
+            )
+            local_success = True
+        except Exception as exc:
+            local_error = exc
+
+        # Every rank must choose the same collective implementation.  A local
+        # fallback on only one peer would mismatch FlashInfer and NCCL launches.
+        success = torch.tensor(
+            int(local_success), dtype=torch.int32, device=self.device
+        )
+        dist.all_reduce(success, op=dist.ReduceOp.MIN, group=self.group)
+        global_success = bool(success.item())
+        if not global_success:
+            if workspace is not None:
+                workspace.destroy()
+            self.disabled = True
+            logging.warning(
+                "FlashInfer TRT-LLM all-reduce initialization failed on at "
+                "least one TP rank; using NCCL%s",
+                f": {local_error}" if local_error is not None else "",
+            )
+            return False
+
+        assert workspace is not None
+        self._workspace = workspace
+        self._hidden_dim = tensor.shape[1]
+        self._dtype = tensor.dtype
+        self._max_num_tokens = _MAX_WORKSPACE_BYTES[self.world_size] // (
+            self._hidden_dim * tensor.element_size()
+        )
+        logging.info(
+            "Initialized FlashInfer TRT-LLM all-reduce: rank=%s, tp=%s, "
+            "hidden=%s, max_tokens=%s",
+            self.rank,
+            self.world_size,
+            self._hidden_dim,
+            self._max_num_tokens,
+        )
+        return True
+
+    def should_use(self, tensor: torch.Tensor) -> bool:
+        if self.disabled:
+            return False
+        if (
+            not tensor.is_cuda
+            or tensor.dtype != torch.bfloat16
+            or tensor.dim() != 2
+            or not tensor.is_contiguous()
+        ):
+            return False
+        if self._workspace is None:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "FlashInfer all-reduce workspace was not initialized before "
+                    "CUDA graph capture"
+                )
+            if not self._create_workspace(tensor):
+                return False
+
+        # The workspace has a fixed dtype, hidden width, and token capacity.
+        # Reject incompatible calls before entering FlashInfer's validator: in
+        # addition to logging on every layer, older FlashInfer releases warn
+        # that an oversized launch can access memory beyond the workspace.
+        # NCCL remains the generic fallback for large prefill tensors, while
+        # decode tensors retain the graph-safe fast path.
+        if (
+            tensor.shape[1] != self._hidden_dim
+            or tensor.dtype != self._dtype
+            or tensor.shape[0] > self._max_num_tokens
+        ):
+            return False
+
+        if hasattr(self._workspace, "is_buffer_size_sufficient"):
+            return self._workspace.is_buffer_size_sufficient(
+                self.world_size,
+                tensor.shape[0],
+                tensor.shape[1],
+                tensor.dtype,
+            )
+        return True
+
+    def all_reduce(self, tensor: torch.Tensor) -> torch.Tensor:
+        assert self._workspace is not None
+        assert self._flashinfer_comm is not None
+        return self._flashinfer_comm.allreduce_fusion(
+            input=tensor,
+            workspace=self._workspace,
+            pattern=self._flashinfer_comm.AllReduceFusionPattern.kAllReduce,
+            launch_with_pdl=True,
+            # FlashInfer 0.6.9 can expose one-shot output too early when PDL is
+            # chained. Completion-at-end is the graph replay safety contract.
+            trigger_completion_at_end=True,
+        )
+
+    def destroy(self) -> None:
+        if self._workspace is not None:
+            self._workspace.destroy()
+        self._workspace = None
+
+
+_communicator: Optional[FlashInferAllReduce] = None
+
+
+def init_flashinfer_allreduce(
+    group: ProcessGroup,
+    device: torch.device,
+    *,
+    single_node: bool,
+) -> Optional[FlashInferAllReduce]:
+    global _communicator
+    communicator = FlashInferAllReduce(group, device, single_node=single_node)
+    _communicator = None if communicator.disabled else communicator
+    return _communicator
+
+
+def get_flashinfer_allreduce() -> Optional[FlashInferAllReduce]:
+    return _communicator
+
+
+def destroy_flashinfer_allreduce() -> None:
+    global _communicator
+    if _communicator is not None:
+        _communicator.destroy()
+    _communicator = None

--- a/rtp_llm/models_py/distributed/symm_mem.py
+++ b/rtp_llm/models_py/distributed/symm_mem.py
@@ -1,6 +1,7 @@
 # Adapted from https://github.com/vllm-project/vllm/blob/bf214ca22625e311a2c4c0dfbf7af19128f4919c/vllm/distributed/device_communicators/symm_mem.py
 import logging
 import math
+import os
 from datetime import timedelta
 from typing import Optional, Union
 
@@ -346,6 +347,12 @@ class TorchSymmMemCommunicator:
 _symm_mem_comm: Optional[TorchSymmMemCommunicator] = None
 
 
+def _custom_all_reduce_enabled() -> bool:
+    """Honor the server-wide custom AllReduce kill switch."""
+    value = os.getenv("FT_DISABLE_CUSTOM_AR")
+    return value is None or value.strip().lower() not in ("1", "true", "on", "yes")
+
+
 def init_symm_mem_communicator(
     tp_group: ProcessGroup,
 ) -> Optional[TorchSymmMemCommunicator]:
@@ -362,6 +369,12 @@ def init_symm_mem_communicator(
     startup fails fast, on every rank, with the real reason.
     """
     global _symm_mem_comm
+    if not _custom_all_reduce_enabled():
+        logging.info(
+            "TorchSymmMemCommunicator disabled by FT_DISABLE_CUSTOM_AR"
+        )
+        _symm_mem_comm = None
+        return None
     symm_mem_comm = TorchSymmMemCommunicator(tp_group, torch.cuda.current_device())
     if symm_mem_comm.disabled:
         logging.warning("TorchSymmMemCommunicator is disabled, skipping initialization")

--- a/rtp_llm/models_py/distributed/test/BUILD
+++ b/rtp_llm/models_py/distributed/test/BUILD
@@ -58,6 +58,16 @@ py_test(
     timeout = "short",
 )
 
+py_test(
+    name = "collective_torch_comm_ops_unit_test",
+    srcs = ["collective_torch_comm_ops_unit_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    timeout = "short",
+)
+
 # Kept on H20: this one needs 4 devices that can address each other, not just 4
 # visible devices. allocate_shared_buffer/open_ipc_handle go through
 # cudaIpcGetMemHandle + cudaIpcOpenMemHandle(cudaIpcMemLazyEnablePeerAccess)
@@ -71,6 +81,39 @@ py_test(
 # 2/2 errors -- it fails loudly rather than skipping, but it does fail. A10 has
 # no NVLink and the peer-access/native-peer-atomic status of the A10 CI pool
 # could not be established, so moving this is not yet safe.
+py_test(
+    name = "symm_mem_unit_test",
+    srcs = ["symm_mem_unit_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    timeout = "short",
+)
+
+py_test(
+    name = "flashinfer_all_reduce_unit_test",
+    srcs = ["flashinfer_all_reduce_unit_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    timeout = "short",
+)
+
+py_test(
+    name = "flashinfer_all_reduce_integration_test",
+    srcs = ["flashinfer_all_reduce_integration_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    env = {"GPU_COUNT": "2"},
+    exec_properties = {"gpu": "H20", "gpu_count": "2"},
+    tags = ["H20", "open_skip"],
+    timeout = "moderate",
+)
+
 py_test(
    name = "user_buffers_test",
    srcs = ["user_buffers_test.py"],

--- a/rtp_llm/models_py/distributed/test/collective_torch_comm_ops_unit_test.py
+++ b/rtp_llm/models_py/distributed/test/collective_torch_comm_ops_unit_test.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from rtp_llm.models_py.distributed import collective_torch as collective
+
+
+class CollectiveTorchCommOpsUnitTest(unittest.TestCase):
+    def _registered_callbacks(self, config=None, process_group=None):
+        if process_group is None:
+            process_group = MagicMock()
+            process_group.size.return_value = 1
+        if config is None:
+            config = SimpleNamespace(
+                tp_size=1,
+                dp_size=1,
+                world_size=1,
+                local_world_size=1,
+                tp_rank=0,
+            )
+        compute_ops = SimpleNamespace(register_comm_ops=MagicMock())
+
+        with patch.dict(sys.modules, {"librtp_compute_ops": compute_ops}), patch.object(
+            collective,
+            "_group_map",
+            {collective.Group.DP_AND_TP: process_group},
+        ), patch.object(collective, "_parallelism_config", config):
+            collective._register_process_groups_to_cpp()
+
+        compute_ops.register_comm_ops.assert_called_once()
+        return compute_ops.register_comm_ops.call_args.args
+
+    def _registered_allreduce(self):
+        return self._registered_callbacks()[1]
+
+    def test_single_rank_allreduce_returns_input_without_dest(self):
+        allreduce = self._registered_allreduce()
+        tensor = torch.tensor([1.0, 2.0])
+
+        result = allreduce(
+            tensor,
+            0,
+            collective._CPP_PARALLEL_MODE_DP_AND_TP,
+            None,
+        )
+
+        self.assertIs(result, tensor)
+
+    def test_single_rank_allreduce_copies_into_dest(self):
+        allreduce = self._registered_allreduce()
+        tensor = torch.tensor([1.0, 2.0])
+        dest = torch.full_like(tensor, -1)
+
+        result = allreduce(
+            tensor,
+            0,
+            collective._CPP_PARALLEL_MODE_DP_AND_TP,
+            dest,
+        )
+
+        self.assertIs(result, dest)
+        torch.testing.assert_close(dest, tensor)
+
+    def test_single_rank_allgather_copies_explicit_send_buffer(self):
+        allgather = self._registered_callbacks()[2]
+        send = torch.tensor([1.0, 2.0])
+        recv = torch.full((1, 2), -1.0)
+
+        allgather(
+            [recv],
+            collective._CPP_PARALLEL_MODE_DP_AND_TP,
+            [send],
+            False,
+        )
+
+        torch.testing.assert_close(recv, send.reshape_as(recv))
+
+    def test_pure_dp_registers_world_group_for_cpp_callback(self):
+        process_group = MagicMock()
+        process_group.size.return_value = 2
+        config = SimpleNamespace(
+            tp_size=1,
+            dp_size=2,
+            world_size=2,
+            local_world_size=2,
+            tp_rank=0,
+        )
+
+        broadcast = self._registered_callbacks(config, process_group)[0]
+        with patch.object(
+            torch.distributed, "get_global_rank", return_value=0
+        ) as get_global_rank, patch.object(torch.cuda, "current_device", return_value=0):
+            broadcast([], 0, collective._CPP_PARALLEL_MODE_DP)
+
+        get_global_rank.assert_called_once_with(process_group, 0)
+
+    def test_regular_allreduce_supports_explicit_out_of_place(self):
+        tensor = torch.tensor([1.0, 2.0])
+
+        def reduce_in_place(target, **_kwargs):
+            target.add_(10)
+
+        with (
+            patch.object(collective, "_get_rocm_rccl", return_value=None),
+            patch.object(
+                collective, "_get_flashinfer_allreduce"
+            ) as flashinfer,
+            patch.object(collective, "_get_symm_mem") as symm_mem,
+            patch.object(collective, "_get_group", return_value=object()),
+            patch.object(
+                torch.distributed, "all_reduce", side_effect=reduce_in_place
+            ),
+        ):
+            flashinfer.return_value.get_flashinfer_allreduce.return_value = None
+            symm_mem.return_value.get_symm_mem_communicator.return_value = None
+            result = collective.all_reduce(
+                tensor, collective.Group.TP, inplace=False
+            )
+
+        self.assertIsNot(result, tensor)
+        torch.testing.assert_close(tensor, torch.tensor([1.0, 2.0]))
+        torch.testing.assert_close(result, torch.tensor([11.0, 12.0]))
+
+    def test_capture_allreduce_supports_explicit_out_of_place(self):
+        tensor = torch.tensor([1.0, 2.0])
+        capture = MagicMock()
+        capture.ensure_capture_comm_ready.return_value = None
+        capture.should_use_capture_collectives.return_value = True
+        capture.capture_all_reduce.side_effect = lambda target, _group: target.add_(
+            10
+        )
+
+        with (
+            patch.object(collective, "_get_rocm_rccl", return_value=capture),
+            patch.object(collective, "_get_group", return_value=object()),
+        ):
+            result = collective.all_reduce(
+                tensor, collective.Group.TP, inplace=False
+            )
+
+        self.assertIsNot(result, tensor)
+        torch.testing.assert_close(tensor, torch.tensor([1.0, 2.0]))
+        torch.testing.assert_close(result, torch.tensor([11.0, 12.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/distributed/test/flashinfer_all_reduce_integration_test.py
+++ b/rtp_llm/models_py/distributed/test/flashinfer_all_reduce_integration_test.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import multiprocessing as mp
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from rtp_llm.models_py.distributed.flashinfer_all_reduce import FlashInferAllReduce
+from rtp_llm.test.utils.port_util import PortManager
+
+
+def _worker(rank: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["FT_DISABLE_CUSTOM_AR"] = "0"
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=2)
+    communicator = FlashInferAllReduce(
+        dist.group.WORLD, torch.device("cuda", rank), single_node=True
+    )
+    assert not communicator.disabled
+
+    try:
+        for tokens in (1, 4, 16, 128):
+            base = torch.arange(
+                tokens * 5120, device="cuda", dtype=torch.float32
+            ).reshape(tokens, 5120)
+            input_tensor = (
+                ((base.remainder(251) - 125) / 64).to(torch.bfloat16)
+                * (rank + 1)
+            )
+            reference = input_tensor.clone()
+            dist.all_reduce(reference)
+            assert communicator.should_use(input_tensor)
+            output = communicator.all_reduce(input_tensor)
+            torch.cuda.synchronize()
+            torch.testing.assert_close(output, reference, rtol=0, atol=0)
+
+        static_input = torch.full(
+            (16, 5120), rank + 1, device="cuda", dtype=torch.bfloat16
+        )
+        capture_stream = torch.cuda.Stream()
+        capture_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(capture_stream):
+            for _ in range(3):
+                communicator.all_reduce(static_input)
+        torch.cuda.current_stream().wait_stream(capture_stream)
+        torch.cuda.synchronize()
+        dist.barrier()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=capture_stream):
+            graph_output = communicator.all_reduce(static_input)
+
+        for value in (2, 5, -3, 7, 11):
+            static_input.fill_(value * (rank + 1))
+            dist.barrier()
+            graph.replay()
+            torch.cuda.synchronize()
+            expected = torch.full_like(graph_output, value * 3)
+            torch.testing.assert_close(graph_output, expected, rtol=0, atol=0)
+    finally:
+        communicator.destroy()
+        dist.destroy_process_group()
+
+
+class FlashInferAllReduceIntegrationTest(unittest.TestCase):
+    def test_tp2_eager_and_graph_replay_match_nccl(self):
+        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+            self.skipTest("requires two CUDA GPUs")
+
+        port_manager = PortManager()
+        ports, locks = port_manager.get_consecutive_ports(1)
+        processes: list[mp.Process] = []
+        exitcodes: list[int | None] = []
+        try:
+            context = mp.get_context("spawn")
+            processes = [
+                context.Process(target=_worker, args=(rank, ports[0]))
+                for rank in range(2)
+            ]
+            for process in processes:
+                process.start()
+            for process in processes:
+                process.join(timeout=120)
+            exitcodes = [process.exitcode for process in processes]
+        finally:
+            # A failed rank can leave its peer blocked in a collective. Always
+            # reap the whole process group before releasing the port lock.
+            for process in processes:
+                if process.is_alive():
+                    process.terminate()
+            for process in processes:
+                process.join(timeout=5)
+            for process in processes:
+                if process.is_alive():
+                    process.kill()
+                    process.join(timeout=5)
+            for lock in locks:
+                lock.__exit__(None, None, None)
+        self.assertEqual(exitcodes, [0, 0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/distributed/test/flashinfer_all_reduce_unit_test.py
+++ b/rtp_llm/models_py/distributed/test/flashinfer_all_reduce_unit_test.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from rtp_llm.models_py.distributed import collective_torch as collective
+from rtp_llm.models_py.distributed import flashinfer_all_reduce as flashinfer_ar
+
+
+class _FakeTensor:
+    is_cuda = True
+    dtype = torch.bfloat16
+    shape = (8, 5120)
+
+    def dim(self):
+        return 2
+
+    def is_contiguous(self):
+        return True
+
+    def element_size(self):
+        return 2
+
+
+def _make_communicator(workspace=None):
+    communicator = flashinfer_ar.FlashInferAllReduce.__new__(
+        flashinfer_ar.FlashInferAllReduce
+    )
+    communicator.group = object()
+    communicator.device = torch.device("cuda", 0)
+    communicator.world_size = 2
+    communicator.rank = 0
+    communicator.disabled = False
+    communicator._workspace = workspace
+    communicator._hidden_dim = 5120
+    communicator._dtype = torch.bfloat16
+    communicator._max_num_tokens = 6553
+    communicator._flashinfer_comm = MagicMock()
+    return communicator
+
+
+class FlashInferAllReduceUnitTest(unittest.TestCase):
+    def tearDown(self):
+        flashinfer_ar.destroy_flashinfer_allreduce()
+
+    def test_existing_custom_ar_switch_is_opt_in(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(flashinfer_ar.enabled_by_env())
+        for value in ("0", "false", "off", "no"):
+            with self.subTest(value=value), patch.dict(
+                os.environ, {"FT_DISABLE_CUSTOM_AR": value}, clear=True
+            ):
+                self.assertTrue(flashinfer_ar.enabled_by_env())
+        with patch.dict(os.environ, {"FT_DISABLE_CUSTOM_AR": "1"}, clear=True):
+            self.assertFalse(flashinfer_ar.enabled_by_env())
+
+    def test_shape_and_dtype_eligibility(self):
+        workspace = MagicMock()
+        workspace.is_buffer_size_sufficient.return_value = True
+        communicator = _make_communicator(workspace)
+        tensor = _FakeTensor()
+
+        self.assertTrue(communicator.should_use(tensor))
+        workspace.is_buffer_size_sufficient.assert_called_once_with(
+            2, 8, 5120, torch.bfloat16
+        )
+
+        tensor.dtype = torch.float32
+        self.assertFalse(communicator.should_use(tensor))
+
+    def test_oversized_prefill_falls_back_before_flashinfer_validation(self):
+        workspace = MagicMock()
+        communicator = _make_communicator(workspace)
+        tensor = _FakeTensor()
+        tensor.shape = (communicator._max_num_tokens + 1, 5120)
+
+        self.assertFalse(communicator.should_use(tensor))
+        workspace.is_buffer_size_sufficient.assert_not_called()
+
+    def test_capture_never_silently_selects_nccl_before_warmup(self):
+        communicator = _make_communicator()
+        with patch("torch.cuda.is_current_stream_capturing", return_value=True):
+            with self.assertRaisesRegex(RuntimeError, "before CUDA graph capture"):
+                communicator.should_use(_FakeTensor())
+
+    def test_all_reduce_uses_safe_flashinfer_replay_contract(self):
+        workspace = object()
+        communicator = _make_communicator(workspace)
+        communicator._flashinfer_comm.AllReduceFusionPattern.kAllReduce = 17
+        output = object()
+        communicator._flashinfer_comm.allreduce_fusion.return_value = output
+        tensor = object()
+
+        self.assertIs(communicator.all_reduce(tensor), output)
+        communicator._flashinfer_comm.allreduce_fusion.assert_called_once_with(
+            input=tensor,
+            workspace=workspace,
+            pattern=17,
+            launch_with_pdl=True,
+            trigger_completion_at_end=True,
+        )
+
+    def test_collective_default_preserves_inplace_contract(self):
+        tensor = torch.ones((2, 4))
+        fast_path = MagicMock()
+        fast_path.should_use.return_value = True
+        reduced = torch.full_like(tensor, 2)
+        fast_path.all_reduce.return_value = reduced
+        module = SimpleNamespace(get_flashinfer_allreduce=lambda: fast_path)
+
+        with patch.object(collective, "_get_flashinfer_allreduce", return_value=module):
+            result = collective.all_reduce(tensor, collective.Group.TP)
+        self.assertIs(result, tensor)
+        torch.testing.assert_close(tensor, reduced)
+        fast_path.should_use.assert_called_once_with(tensor)
+        fast_path.all_reduce.assert_called_once_with(tensor)
+
+    def test_collective_supports_explicit_out_of_place(self):
+        tensor = torch.ones((2, 4))
+        original = tensor.clone()
+        fast_path = MagicMock()
+        fast_path.should_use.return_value = True
+        reduced = torch.full_like(tensor, 2)
+        fast_path.all_reduce.return_value = reduced
+        module = SimpleNamespace(get_flashinfer_allreduce=lambda: fast_path)
+
+        with patch.object(collective, "_get_flashinfer_allreduce", return_value=module):
+            result = collective.all_reduce(
+                tensor, collective.Group.TP, inplace=False
+            )
+        self.assertIs(result, reduced)
+        torch.testing.assert_close(tensor, original)
+
+    def test_collective_preserves_inplace_contract(self):
+        tensor = torch.ones((2, 4))
+        fast_path = MagicMock()
+        fast_path.should_use.return_value = True
+        fast_path.all_reduce.return_value = torch.full_like(tensor, 2)
+        module = SimpleNamespace(get_flashinfer_allreduce=lambda: fast_path)
+
+        with patch.object(collective, "_get_flashinfer_allreduce", return_value=module):
+            result = collective.all_reduce(tensor, collective.Group.TP, inplace=True)
+        self.assertIs(result, tensor)
+        torch.testing.assert_close(tensor, torch.full_like(tensor, 2))
+
+    def test_destroy_is_idempotent(self):
+        workspace = MagicMock()
+        communicator = _make_communicator(workspace)
+        communicator.destroy()
+        communicator.destroy()
+        workspace.destroy.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/distributed/test/symm_mem_unit_test.py
+++ b/rtp_llm/models_py/distributed/test/symm_mem_unit_test.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from rtp_llm.models_py.distributed import symm_mem
+
+
+class SymmMemConfigurationTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        symm_mem._symm_mem_comm = None
+
+    def test_custom_all_reduce_switch_accepts_standard_true_values(self) -> None:
+        for value in ("1", "true", "TRUE", "on", "yes"):
+            with self.subTest(value=value), patch.dict(
+                os.environ, {"FT_DISABLE_CUSTOM_AR": value}, clear=False
+            ):
+                self.assertFalse(symm_mem._custom_all_reduce_enabled())
+
+    def test_custom_all_reduce_is_enabled_when_switch_is_absent_or_false(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(symm_mem._custom_all_reduce_enabled())
+        for value in ("0", "false", "off", "no"):
+            with self.subTest(value=value), patch.dict(
+                os.environ, {"FT_DISABLE_CUSTOM_AR": value}, clear=False
+            ):
+                self.assertTrue(symm_mem._custom_all_reduce_enabled())
+
+    def test_disabled_switch_skips_communicator_construction(self) -> None:
+        sentinel = object()
+        symm_mem._symm_mem_comm = sentinel
+        with patch.dict(
+            os.environ, {"FT_DISABLE_CUSTOM_AR": "1"}, clear=False
+        ), patch.object(
+            symm_mem,
+            "TorchSymmMemCommunicator",
+            side_effect=AssertionError("communicator must not be constructed"),
+        ):
+            self.assertIsNone(symm_mem.init_symm_mem_communicator(object()))
+            self.assertIsNone(symm_mem.get_symm_mem_communicator())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any, Optional
 
+import torch
 from torch import nn
 
 from rtp_llm.config.model_config import ModelConfig
@@ -53,6 +54,18 @@ class GptModelBase(nn.Module):
 
         self.kv_cache: Optional[KVCache] = None
         self.device_type: DeviceType = get_device_type()
+        self._mtp_aux_capture_layer_ids = tuple(
+            config.capture_aux_hidden_layer_ids or ()
+        )
+        self._mtp_aux_capture_layer_id_set = frozenset(
+            self._mtp_aux_capture_layer_ids
+        )
+        self._mtp_target_hidden_states: Optional[torch.Tensor] = None
+        self._mtp_target_graph_buffer: Optional[torch.Tensor] = None
+        self._mtp_target_prompt_buffer: Optional[torch.Tensor] = None
+        self._mtp_aux_capture_buffer: Optional[torch.Tensor] = None
+        self._mtp_aux_capture_rows = 0
+        self._mtp_aux_capture_index = 0
 
     def initialize(self, init_resource: PyModelInitResources) -> bool:
         self.kv_cache = init_resource.kv_cache
@@ -111,6 +124,104 @@ class GptModelBase(nn.Module):
     def _get_fmha_group_tags(self) -> Optional[list[str]]:
         """Model hook: None means every attention-input tag requires FMHA."""
         return None
+
+    def begin_aux_hidden_capture(
+        self, hidden_states: torch.Tensor, is_target_verify: bool
+    ) -> None:
+        """Start one target auxiliary-hidden capture.
+
+        Decode graphs keep one grow-only buffer so every captured batch bucket
+        writes to a stable address. Prompt prefill owns a separate grow-only
+        buffer because its token count can exceed the decode graph capacity.
+        """
+        self._mtp_target_hidden_states = None
+        self._mtp_aux_capture_buffer = None
+        self._mtp_aux_capture_rows = int(hidden_states.shape[0])
+        self._mtp_aux_capture_index = 0
+
+        layer_ids = self._mtp_aux_capture_layer_ids
+        if not layer_ids:
+            return
+
+        width = len(layer_ids) * int(hidden_states.shape[-1])
+        buffer = (
+            self._mtp_target_graph_buffer
+            if is_target_verify
+            else self._mtp_target_prompt_buffer
+        )
+        if (
+            buffer is None
+            or int(buffer.shape[0]) < self._mtp_aux_capture_rows
+            or int(buffer.shape[1]) != width
+            or buffer.dtype != hidden_states.dtype
+            or buffer.device != hidden_states.device
+        ):
+            buffer = torch.empty(
+                (self._mtp_aux_capture_rows, width),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            if is_target_verify:
+                self._mtp_target_graph_buffer = buffer
+            else:
+                self._mtp_target_prompt_buffer = buffer
+        self._mtp_aux_capture_buffer = buffer
+
+    def capture_aux_hidden(
+        self,
+        layer_id: int,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Materialize one configured decoder-layer boundary into the capture."""
+        if layer_id not in self._mtp_aux_capture_layer_id_set:
+            return
+
+        buffer = self._mtp_aux_capture_buffer
+        if buffer is None:
+            raise RuntimeError(
+                "auxiliary hidden capture was not initialized for this forward"
+            )
+        hidden_width = int(hidden_states.shape[-1])
+        start = self._mtp_aux_capture_index * hidden_width
+        target = buffer[: self._mtp_aux_capture_rows, start : start + hidden_width]
+        if residual is None:
+            target.copy_(hidden_states)
+        else:
+            # Qwen3Next keeps the layer-boundary value split between the fused
+            # residual and hidden tensors. DSpARK was trained on their sum.
+            torch.add(hidden_states, residual, out=target)
+        self._mtp_aux_capture_index += 1
+
+    def finish_aux_hidden_capture(self) -> None:
+        expected_parts = len(self._mtp_aux_capture_layer_ids)
+        if expected_parts == 0:
+            return
+        if self._mtp_aux_capture_index != expected_parts:
+            raise RuntimeError(
+                "auxiliary hidden capture missed configured layers: "
+                f"captured={self._mtp_aux_capture_index}, expected={expected_parts}"
+            )
+        if self._mtp_aux_capture_buffer is None:
+            raise RuntimeError("auxiliary hidden capture buffer is unavailable")
+        self._mtp_target_hidden_states = self._mtp_aux_capture_buffer[
+            : self._mtp_aux_capture_rows
+        ]
+
+    def get_mtp_target_hidden_states(
+        self, num_tokens: int
+    ) -> Optional[torch.Tensor]:
+        hidden = self._mtp_target_hidden_states
+        if hidden is None:
+            return None
+        if num_tokens < 0:
+            return hidden
+        if num_tokens > hidden.shape[0]:
+            raise RuntimeError(
+                f"requested {num_tokens} MTP target rows from "
+                f"{hidden.shape[0]} captured rows"
+            )
+        return hidden[:num_tokens]
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         raise NotImplementedError("forward method must be implemented in subclass")

--- a/rtp_llm/models_py/model_desc/qwen3_dspark_model.py
+++ b/rtp_llm/models_py/model_desc/qwen3_dspark_model.py
@@ -1,0 +1,230 @@
+"""Qwen3 DSpark backbone on the shared DSpark proposer contract."""
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_loader.model_weight_info import ModelWeights
+from rtp_llm.models_py.model_desc.block_map import (
+    select_attention_inputs_for_layer,
+)
+from rtp_llm.models_py.model_desc.qwen3 import Qwen3Model
+from rtp_llm.models_py.modules import LinearFactory, RMSNorm
+from rtp_llm.models_py.modules.factory.attention.common import (
+    create_write_cache_store_impl,
+)
+from rtp_llm.models_py.speculative.dspark_proposer_mixin import DSparkProposerMixin
+from rtp_llm.ops import ParallelismConfig
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+from rtp_llm.utils.model_weight import W
+
+
+class _RopePositions:
+    def __init__(self, positions: torch.Tensor) -> None:
+        self.positions_d = positions
+
+
+class Qwen3DSparkModel(DSparkProposerMixin, Qwen3Model):
+    def __init__(
+        self,
+        config: ModelConfig,
+        parallelism_config: ParallelismConfig,
+        weights: ModelWeights,
+        max_generate_batch_size: int,
+        quant_config=None,
+        fmha_config=None,
+        py_hw_kernel_config=None,
+        device_resource_config=None,
+    ) -> None:
+        if quant_config is not None:
+            raise NotImplementedError("Qwen3 DSpark quantization is not supported")
+        super().__init__(
+            config,
+            parallelism_config,
+            weights,
+            max_generate_batch_size=max_generate_batch_size,
+            quant_config=quant_config,
+            fmha_config=fmha_config,
+            py_hw_kernel_config=py_hw_kernel_config,
+            device_resource_config=device_resource_config,
+        )
+        proposal_width = int(config.gen_num_per_cycle)
+        query_width = proposal_width + int(not config.dspark_sample_from_anchor)
+        self.init_dspark_proposer(
+            width=proposal_width,
+            query_width=query_width,
+            noise_token_id=config.dspark_noise_token_id,
+            aux_feature_dim=len(config.dspark_target_layer_ids)
+            * config.hidden_size,
+            hidden_dim=config.hidden_size,
+        )
+
+        self.attn_configs = config.getAttentionConfigs(
+            parallelism_config.get_attn_tp_size()
+        )
+        if self.attn_configs.is_causal:
+            raise ValueError("Qwen3 DSpark proposal attention must be non-causal")
+        self.fc = LinearFactory.create_linear_from_weights(
+            weights.global_weights, W.dspark_fc_w
+        )
+        self.hidden_norm = RMSNorm(
+            weights.get_global_weight(W.dspark_hidden_norm_gamma),
+            eps=config.layernorm_eps,
+        )
+
+        heads = self.attn_configs.head_num
+        kv_heads = self.attn_configs.kv_head_num
+        head_dim = self.attn_configs.size_per_head
+        q_cols = heads * head_dim
+        context_kv_weights = []
+        self.context_k_norms = nn.ModuleList()
+        for layer_weights in weights.weights[: self.layer_num]:
+            qkv = layer_weights[W.attn_qkv_w]
+            context_kv_weights.append(qkv[:, q_cols:])
+            self.context_k_norms.append(
+                RMSNorm(layer_weights[W.k_ln_gamma], eps=config.layernorm_eps)
+            )
+        self.context_kv_projection = LinearFactory.create_linear(
+            torch.cat(context_kv_weights, dim=1),
+            None,
+            None,
+            None,
+            py_hw_kernel_config,
+        )
+
+        from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb import (
+            MhaRotaryEmbeddingOp,
+        )
+
+        self.context_rope = MhaRotaryEmbeddingOp(self.attn_configs)
+
+    def cuda_graph_input_hidden_size(self) -> int:
+        return self._dspark_aux_feature_dim
+
+    def combine_hidden_states(self, features: torch.Tensor) -> torch.Tensor:
+        return self.fc(features)
+
+    def dspark_attention_inputs(self, inputs: PyModelInputs):
+        attention = select_attention_inputs_for_layer(inputs, self.kv_cache, 0)
+        if isinstance(attention, list):
+            if len(attention) != 1:
+                raise RuntimeError(
+                    "Qwen3 DSpark requires exactly one KV cache group per layer, "
+                    f"got {len(attention)}"
+                )
+            attention = attention[0]
+        return attention
+
+    def _block_table(self, inputs: PyModelInputs) -> torch.Tensor:
+        attention = self.dspark_attention_inputs(inputs)
+        table = attention.kv_cache_kernel_block_id_device
+        if table is None or table.numel() == 0:
+            table = attention.kv_cache_kernel_block_id.to(
+                device=self.embed_tokens.weight.device, non_blocking=True
+            )
+        return table[0] if table.dim() == 3 else table
+
+    def commit_feature_rows(
+        self,
+        main_x: torch.Tensor,
+        context_req_ids: torch.Tensor,
+        context_positions: torch.Tensor,
+        committed_ends: torch.Tensor,
+        inputs: PyModelInputs,
+        commit_ctx: Any = None,
+    ) -> None:
+        del committed_ends, commit_ctx
+        table = self._block_table(inputs)
+        page_size = self.attn_configs.kernel_tokens_per_block
+        positions = context_positions.long()
+        pages = table[context_req_ids.long(), positions // page_size].long()
+        slots = positions % page_size
+        hidden = self.hidden_norm(main_x)
+        head_dim = self.attn_configs.size_per_head
+        kv_heads = self.attn_configs.kv_head_num
+        dummy_q = hidden.new_zeros((hidden.shape[0], 1, head_dim))
+
+        all_kv = self.context_kv_projection(hidden).view(
+            -1, self.layer_num, 2, kv_heads, head_dim
+        )
+        for layer_idx in range(self.layer_num):
+            key, value = all_kv[:, layer_idx].unbind(1)
+            key = self.context_k_norms[layer_idx](key.reshape(-1, head_dim)).view(
+                -1, kv_heads, head_dim
+            )
+            self.context_rope._apply_rope(
+                dummy_q, key, _RopePositions(context_positions)
+            )
+            cache = self.kv_cache.get_layer_cache(layer_idx).kv_cache_base
+            cache[pages, 0, :, slots, :] = key.to(cache.dtype)
+            cache[pages, 1, :, slots, :] = value.to(cache.dtype)
+
+        writer = create_write_cache_store_impl(self.dspark_attention_inputs(inputs))
+        if writer is not None:
+            for layer_idx in range(self.layer_num):
+                layer_caches = self.kv_cache.get_layer_cache_groups(layer_idx)
+                if len(layer_caches) != 1:
+                    raise RuntimeError(
+                        "Qwen3 DSpark requires exactly one KV cache group per layer, "
+                        f"got {len(layer_caches)} for layer {layer_idx}"
+                    )
+                writer(layer_caches[0])
+
+    def forward_query_block(
+        self,
+        query_ids: torch.Tensor,
+        query_positions: torch.Tensor,
+        prefix_lengths: torch.Tensor,
+        active_requests: torch.Tensor,
+        inputs: PyModelInputs,
+        fmha_impl: Any,
+    ) -> torch.Tensor:
+        del query_ids, query_positions, prefix_lengths, active_requests
+        return super().forward(inputs, fmha_impl).hidden_states
+
+    def _forward_device(self) -> torch.device:
+        device = self.embed_tokens.weight.device
+        return device
+
+    @torch.inference_mode()
+    def forward_propose(
+        self, inputs: PyModelInputs, fmha_impl: Any = None
+    ) -> PyModelOutputs:
+        device = self._forward_device()
+        if self.kv_cache is None:
+            tokens = int(inputs.input_ids.numel())
+            batch = max(
+                (tokens + self._dspark_query_width - 1)
+                // self._dspark_query_width,
+                1,
+            )
+            return self.dspark_empty_outputs(batch, device)
+        return self.run_propose_step(inputs, fmha_impl, device)
+
+    @torch.inference_mode()
+    def forward_commit(
+        self, inputs: PyModelInputs, fmha_impl: Any = None
+    ) -> PyModelOutputs:
+        del fmha_impl
+        device = self._forward_device()
+        if self.kv_cache is None:
+            return PyModelOutputs(
+                torch.empty(
+                    (0, self.config.hidden_size),
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+            )
+        return self.run_commit_step(inputs, device)
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        del inputs, fmha_impl
+        raise RuntimeError(
+            "Qwen3DSparkModel requires a fixed forward_propose or "
+            "forward_commit entrypoint"
+        )
+
+
+__all__ = ["Qwen3DSparkModel"]

--- a/rtp_llm/models_py/model_desc/qwen3_dspark_model.py
+++ b/rtp_llm/models_py/model_desc/qwen3_dspark_model.py
@@ -6,17 +6,16 @@ import torch
 from torch import nn
 
 from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.device.device_type import is_hip
 from rtp_llm.model_loader.model_weight_info import ModelWeights
-from rtp_llm.models_py.model_desc.block_map import (
-    select_attention_inputs_for_layer,
-)
+from rtp_llm.models_py.model_desc.block_map import select_attention_inputs_for_layer
 from rtp_llm.models_py.model_desc.qwen3 import Qwen3Model
 from rtp_llm.models_py.modules import LinearFactory, RMSNorm
 from rtp_llm.models_py.modules.factory.attention.common import (
     create_write_cache_store_impl,
 )
 from rtp_llm.models_py.speculative.dspark_proposer_mixin import DSparkProposerMixin
-from rtp_llm.ops import ParallelismConfig
+from rtp_llm.ops import ParallelismConfig, check_rope_cache, get_rope_cache_once
 from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
 from rtp_llm.utils.model_weight import W
 
@@ -24,6 +23,146 @@ from rtp_llm.utils.model_weight import W
 class _RopePositions:
     def __init__(self, positions: torch.Tensor) -> None:
         self.positions_d = positions
+
+
+def _apply_non_interleaved_rope(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rope_dim: int,
+) -> None:
+    """Apply LLaMA/Qwen-style RoPE to the leading dimensions in-place."""
+    if query.numel() == 0:
+        return
+    if rope_dim <= 0 or rope_dim % 2 != 0:
+        raise ValueError(f"RoPE dimension must be positive and even, got {rope_dim}")
+    if rope_dim > query.size(-1) or rope_dim > key.size(-1):
+        raise ValueError(
+            f"RoPE dimension {rope_dim} exceeds Q/K head dimensions "
+            f"{query.size(-1)}/{key.size(-1)}"
+        )
+
+    positions = positions.narrow(0, 0, query.size(0)).long()
+    cos_sin = cos_sin_cache.index_select(0, positions)
+    half_dim = rope_dim // 2
+    cos = cos_sin[:, :half_dim].unsqueeze(1)
+    sin = cos_sin[:, half_dim:rope_dim].unsqueeze(1)
+
+    def rotate(tensor: torch.Tensor) -> None:
+        rope_input = tensor[..., :rope_dim].float()
+        first = rope_input[..., :half_dim]
+        second = rope_input[..., half_dim:]
+        rotated = torch.cat(
+            (first * cos - second * sin, second * cos + first * sin), dim=-1
+        )
+        tensor[..., :rope_dim].copy_(rotated)
+
+    rotate(query)
+    rotate(key)
+
+
+def _write_rocm_paged_kv_cache(
+    cache: torch.Tensor,
+    pages: torch.Tensor,
+    slots: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    vectorized_value: bool,
+) -> None:
+    """Write semantic K/V rows using the physical layout consumed by AITER."""
+    if cache.dim() != 5 or cache.size(1) != 2:
+        raise ValueError(
+            "Qwen3 DSpark ROCm context cache must be "
+            f"[blocks,2,heads,page,dim], got {tuple(cache.shape)}"
+        )
+
+    block_count, _, kv_heads, page_size, head_dim = cache.shape
+    del block_count
+    element_size = cache.element_size()
+    if element_size <= 0 or 16 % element_size:
+        raise ValueError(f"unsupported ROCm KV-cache element size: {element_size}")
+    vector_size = 16 // element_size
+    if head_dim % vector_size:
+        raise ValueError(
+            f"ROCm K head dimension {head_dim} must be divisible by {vector_size}"
+        )
+
+    key_rows = (
+        key.to(cache.dtype)
+        .contiguous()
+        .view(-1, kv_heads, head_dim // vector_size, vector_size)
+    )
+    # Reinterpret the contiguous backing storage before selecting K/V.  The
+    # cache[:, plane] slice is strided across blocks and cannot be viewed.
+    key_physical = cache.view(
+        cache.shape[0],
+        2,
+        kv_heads,
+        head_dim // vector_size,
+        page_size,
+        vector_size,
+    )[:, 0]
+    key_physical[pages, :, :, slots, :] = key_rows
+
+    value_rows = value.to(cache.dtype).contiguous()
+    if vectorized_value:
+        if page_size % vector_size:
+            raise ValueError(
+                f"ROCm V page size {page_size} must be divisible by {vector_size}"
+            )
+        value_physical = cache.view(
+            cache.shape[0],
+            2,
+            kv_heads,
+            page_size // vector_size,
+            head_dim,
+            vector_size,
+        )[:, 1]
+        value_physical[pages, :, slots // vector_size, :, slots % vector_size] = (
+            value_rows
+        )
+    else:
+        value_physical = cache.view(
+            cache.shape[0], 2, kv_heads, head_dim, page_size
+        )[:, 1]
+        value_physical[pages, :, :, slots] = value_rows
+
+
+class _TorchMhaRotaryEmbeddingOp:
+    """ROCm fallback for the FlashInfer-only DSpark context RoPE path."""
+
+    def __init__(self, attn_config) -> None:
+        self.rope_config = attn_config.rope_config
+        self.rope_dim = self.rope_config.dim
+        rope_cache = get_rope_cache_once(
+            self.rope_config,
+            attn_config.max_seq_len + attn_config.gen_num_per_cycle + 1,
+            # This API flag means "GPU cache"; torch::kCUDA maps to HIP in a
+            # ROCm PyTorch build.
+            is_cuda=True,
+            interleave=False,
+        )
+        if not check_rope_cache(self.rope_config, rope_cache):
+            raise RuntimeError(
+                "Qwen3 DSpark ROCm context RoPE requires a supported GPU cache"
+            )
+        self.cos_sin_cache = rope_cache.data
+
+    def _apply_rope(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        rope_params: Any,
+    ) -> None:
+        _apply_non_interleaved_rope(
+            query,
+            key,
+            self.cos_sin_cache,
+            rope_params.positions_d,
+            self.rope_dim,
+        )
 
 
 class Qwen3DSparkModel(DSparkProposerMixin, Qwen3Model):
@@ -56,8 +195,7 @@ class Qwen3DSparkModel(DSparkProposerMixin, Qwen3Model):
             width=proposal_width,
             query_width=query_width,
             noise_token_id=config.dspark_noise_token_id,
-            aux_feature_dim=len(config.dspark_target_layer_ids)
-            * config.hidden_size,
+            aux_feature_dim=len(config.dspark_target_layer_ids) * config.hidden_size,
             hidden_dim=config.hidden_size,
         )
 
@@ -94,11 +232,14 @@ class Qwen3DSparkModel(DSparkProposerMixin, Qwen3Model):
             py_hw_kernel_config,
         )
 
-        from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb import (
-            MhaRotaryEmbeddingOp,
-        )
+        if is_hip():
+            self.context_rope = _TorchMhaRotaryEmbeddingOp(self.attn_configs)
+        else:
+            from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb import (
+                MhaRotaryEmbeddingOp,
+            )
 
-        self.context_rope = MhaRotaryEmbeddingOp(self.attn_configs)
+            self.context_rope = MhaRotaryEmbeddingOp(self.attn_configs)
 
     def cuda_graph_input_hidden_size(self) -> int:
         return self._dspark_aux_feature_dim
@@ -158,8 +299,27 @@ class Qwen3DSparkModel(DSparkProposerMixin, Qwen3Model):
                 dummy_q, key, _RopePositions(context_positions)
             )
             cache = self.kv_cache.get_layer_cache(layer_idx).kv_cache_base
-            cache[pages, 0, :, slots, :] = key.to(cache.dtype)
-            cache[pages, 1, :, slots, :] = value.to(cache.dtype)
+            if is_hip():
+                is_fp8_cache = cache.dtype in (
+                    torch.float8_e4m3fnuz,
+                    torch.float8_e4m3fn,
+                )
+                vectorized_value = (
+                    self.fmha_config is None
+                    or self.fmha_config.use_asm_pa
+                    or is_fp8_cache
+                )
+                _write_rocm_paged_kv_cache(
+                    cache,
+                    pages,
+                    slots,
+                    key,
+                    value,
+                    vectorized_value=vectorized_value,
+                )
+            else:
+                cache[pages, 0, :, slots, :] = key.to(cache.dtype)
+                cache[pages, 1, :, slots, :] = value.to(cache.dtype)
 
         writer = create_write_cache_store_impl(self.dspark_attention_inputs(inputs))
         if writer is not None:
@@ -181,8 +341,47 @@ class Qwen3DSparkModel(DSparkProposerMixin, Qwen3Model):
         inputs: PyModelInputs,
         fmha_impl: Any,
     ) -> torch.Tensor:
-        del query_ids, query_positions, prefix_lengths, active_requests
-        return super().forward(inputs, fmha_impl).hidden_states
+        del query_ids, prefix_lengths, active_requests
+
+        # The target owns the engine input geometry, so an MRoPE target can
+        # publish three position ids per token into the shared attention input.
+        # This Qwen3 draft uses scalar RoPE. The FMHA implementation has already
+        # retained the shared tensor during prepare_fmha_impl(), therefore rebind
+        # is too late here: update the consumed prefix in-place for the duration
+        # of the draft layers, then restore it for the target verify path.
+        attention = self.dspark_attention_inputs(inputs)
+        position_ids = getattr(attention, "combo_position_ids", None)
+        restore_position_ids = None
+        position_slice = None
+        draft_positions = query_positions.reshape(-1)
+        if (
+            isinstance(position_ids, torch.Tensor)
+            and position_ids.numel() > 0
+            and draft_positions.numel() > 0
+        ):
+            if (
+                position_ids.dim() != 1
+                or position_ids.numel() < draft_positions.numel()
+            ):
+                raise RuntimeError(
+                    "Qwen3 DSpark position ids must be a flat buffer with at least "
+                    f"one entry per query token: got shape={tuple(position_ids.shape)}, "
+                    f"query_tokens={draft_positions.numel()}"
+                )
+            position_slice = position_ids.narrow(0, 0, draft_positions.numel())
+            restore_position_ids = position_slice.clone()
+            position_slice.copy_(
+                draft_positions.to(
+                    device=position_ids.device,
+                    dtype=position_ids.dtype,
+                )
+            )
+
+        try:
+            return super().forward(inputs, fmha_impl).hidden_states
+        finally:
+            if restore_position_ids is not None:
+                position_slice.copy_(restore_position_ids)
 
     def _forward_device(self) -> torch.device:
         device = self.embed_tokens.weight.device
@@ -196,8 +395,7 @@ class Qwen3DSparkModel(DSparkProposerMixin, Qwen3Model):
         if self.kv_cache is None:
             tokens = int(inputs.input_ids.numel())
             batch = max(
-                (tokens + self._dspark_query_width - 1)
-                // self._dspark_query_width,
+                (tokens + self._dspark_query_width - 1) // self._dspark_query_width,
                 1,
             )
             return self.dspark_empty_outputs(batch, device)

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -1750,6 +1750,9 @@ class Qwen3NextModel(GptModelBase):
             fmha_impl = self.prepare_fmha_impl(inputs)
 
         residual = torch.zeros_like(hidden_states)
+        capture_aux_hidden = bool(self._mtp_aux_capture_layer_ids)
+        if capture_aux_hidden:
+            self.begin_aux_hidden_capture(hidden_states, is_target_verify)
 
         for i, decoder_layer in enumerate(self.layers):
             layer_attention_inputs = select_attention_inputs_for_layer(
@@ -1768,8 +1771,15 @@ class Qwen3NextModel(GptModelBase):
                 attention_inputs=layer_attention_inputs,
                 attn_meta=attn_meta,
             )
+            if i in self._mtp_aux_capture_layer_id_set:
+                self.capture_aux_hidden(i, hidden_states, residual)
+        if capture_aux_hidden:
+            self.finish_aux_hidden_capture()
 
         hidden_states, residual = self.norm(hidden_states, residual)
+        if capture_aux_hidden:
+            assert self._mtp_target_hidden_states is not None
+            return PyModelOutputs(hidden_states, self._mtp_target_hidden_states)
         return PyModelOutputs(hidden_states)
 
 

--- a/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
+++ b/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
@@ -183,6 +183,68 @@ def _worker_graph_fused_rmsnorm(
         _teardown()
 
 
+def _worker_graph_recapture_with_rank_asymmetric_allocation(
+    rank, world_size, port, hidden_size=4096, num_tokens=8
+):
+    """Recapture when only one rank replaces its graph input allocation."""
+    try:
+        _setup(rank, world_size, port)
+        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import TrtllmDistEnv
+
+        dev = torch.device(f"cuda:{rank}")
+        env = TrtllmDistEnv(group=dist.group.WORLD, device_id=rank)
+        torch.manual_seed(42 + rank)
+        source = torch.randn(
+            num_tokens, hidden_size, dtype=torch.bfloat16, device=dev
+        )
+        stream = torch.cuda.Stream(device=dev)
+        stream.wait_stream(torch.cuda.current_stream(dev))
+
+        first_in = source.clone()
+        first_out = torch.empty_like(first_in)
+        first_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(stream), torch.cuda.graph(first_graph, stream=stream):
+            env.allreduce_op(first_in, first_out)
+        stream.synchronize()
+        env.consume_capture_if_needed()
+
+        # Rank 0 deliberately reuses the first graph's allocation while rank 1
+        # uses a new allocation. A local-data_ptr cache makes one rank report
+        # a hit and the other a miss; generation-based collective registration
+        # must instead keep both ranks in the same capture sequence.
+        second_in = first_in if rank == 0 else source.clone()
+        second_out = torch.empty_like(second_in)
+        second_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(stream), torch.cuda.graph(second_graph, stream=stream):
+            env.allreduce_op(second_in, second_out)
+        stream.synchronize()
+        env.consume_capture_if_needed()
+
+        second_replay = torch.roll(source, shifts=1, dims=-1)
+        second_ref = second_replay.float()
+        dist.all_reduce(second_ref)
+        second_ref = second_ref.to(second_replay.dtype)
+        with torch.cuda.stream(stream):
+            second_in.copy_(second_replay)
+            second_graph.replay()
+        stream.synchronize()
+        torch.testing.assert_close(second_out, second_ref, atol=2e-2, rtol=1e-2)
+
+        # The first graph keeps its own CommPtrs slot and remains valid after
+        # the asymmetric recapture registers the newer collective generation.
+        first_replay = torch.roll(source, shifts=2, dims=-1)
+        first_ref = first_replay.float()
+        dist.all_reduce(first_ref)
+        first_ref = first_ref.to(first_replay.dtype)
+        with torch.cuda.stream(stream):
+            first_in.copy_(first_replay)
+            first_graph.replay()
+        stream.synchronize()
+        torch.testing.assert_close(first_out, first_ref, atol=2e-2, rtol=1e-2)
+    finally:
+        _teardown()
+
+
 class TestTrtAllReduceGraphReplay(unittest.TestCase):
 
     def setUp(self):
@@ -225,6 +287,9 @@ class TestTrtAllReduceGraphReplay(unittest.TestCase):
                         num_tokens=num_tokens,
                         fp8_out=fp8_out,
                     )
+
+    def test_graph_recapture_with_rank_asymmetric_allocation(self):
+        _launch(_worker_graph_recapture_with_rank_asymmetric_allocation)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/dsv4/fp8/test/test_decode_topk_length.py
+++ b/rtp_llm/models_py/modules/dsv4/fp8/test/test_decode_topk_length.py
@@ -269,7 +269,6 @@ class DecodeTopkLengthCaptureFullWidthTest(unittest.TestCase):
         _update_topk_lengths_in_place(meta, start_pos, 2, full_width=True)
         self.assertEqual([int(x) for x in meta.swa_topk_length[:2]], [WINDOW, WINDOW])
 
-
 class DecodeTopkLengthParityTest(unittest.TestCase):
     """Eager build vs allocate+update produce identical length values."""
 

--- a/rtp_llm/models_py/modules/dsv4/test/test_dspark_cuda_graph_contract.py
+++ b/rtp_llm/models_py/modules/dsv4/test/test_dspark_cuda_graph_contract.py
@@ -32,6 +32,7 @@ class DSparkCudaGraphContractTest(unittest.TestCase):
         )
         model.kv_cache = None
         model._dspark_width = 3
+        model._dspark_query_width = 3
         model._dspark_hidden_dim = 8
         propose_inputs = PyModelInputs()
         propose_inputs.input_ids = torch.zeros(3, dtype=torch.int32)

--- a/rtp_llm/models_py/modules/dsv4/test/test_dspark_runtime_config.py
+++ b/rtp_llm/models_py/modules/dsv4/test/test_dspark_runtime_config.py
@@ -10,18 +10,18 @@ class DSparkRuntimeConfigTest(unittest.TestCase):
         sp_config = SimpleNamespace(
             gen_num_per_cycle=gamma,
             sp_dspark_mask_token_id=-1,
+            sp_dspark_sample_from_anchor=False,
         )
         target_config = SimpleNamespace(
             num_layers=43,
             capture_aux_hidden_layer_ids=None,
         )
-        # Deliberately has no dspark_block_size: proposal width must come only
-        # from sp_config.gen_num_per_cycle.
         draft_config = SimpleNamespace(
             dspark_noise_token_id=128799,
             dspark_target_layer_ids=[40, 41, 42],
             dspark_markov_rank=256,
             vocab_size=129280,
+            input_vocab_size=129280,
         )
         return sp_config, target_config, draft_config
 
@@ -33,7 +33,37 @@ class DSparkRuntimeConfigTest(unittest.TestCase):
         )
 
         self.assertEqual(sp_config.sp_dspark_mask_token_id, 128799)
+        self.assertTrue(sp_config.sp_dspark_sample_from_anchor)
         self.assertEqual(target_config.capture_aux_hidden_layer_ids, [40, 41, 42])
+
+    def test_noise_token_uses_input_vocabulary_for_reduced_draft_vocab(self):
+        sp_config, target_config, draft_config = self._configs(gamma=7)
+        draft_config.vocab_size = 20_000
+
+        ModelFactory._setup_dspark_configs(
+            sp_config, target_config, draft_config
+        )
+
+        self.assertEqual(sp_config.sp_dspark_mask_token_id, 128799)
+
+    def test_zero_input_vocabulary_falls_back_to_model_vocabulary(self):
+        sp_config, target_config, draft_config = self._configs(gamma=3)
+        draft_config.input_vocab_size = 0
+
+        ModelFactory._setup_dspark_configs(
+            sp_config, target_config, draft_config
+        )
+
+        self.assertEqual(sp_config.sp_dspark_mask_token_id, 128799)
+
+    def test_noise_token_outside_input_vocabulary_is_rejected(self):
+        sp_config, target_config, draft_config = self._configs(gamma=7)
+        draft_config.dspark_noise_token_id = draft_config.input_vocab_size
+
+        with self.assertRaisesRegex(ValueError, "input_vocab_size"):
+            ModelFactory._setup_dspark_configs(
+                sp_config, target_config, draft_config
+            )
 
     def test_gen_num_per_cycle_must_be_positive(self):
         sp_config, target_config, draft_config = self._configs(gamma=0)

--- a/rtp_llm/models_py/modules/factory/attention/__init__.py
+++ b/rtp_llm/models_py/modules/factory/attention/__init__.py
@@ -52,6 +52,9 @@ elif device_type == DeviceType.Cuda:
     from rtp_llm.models_py.modules.factory.attention.cuda_headwise_impl.headwise_fp8 import (
         HeadWiseFP8PrefillImpl,
     )
+    from rtp_llm.models_py.modules.factory.attention.cuda_impl.flash_attn_3 import (
+        FlashAttn3PagedShortGraphImpl,
+    )
     from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
         PyFlashinferDecodeImpl,
         PyFlashinferHybridPrefillImpl,
@@ -76,6 +79,7 @@ elif device_type == DeviceType.Cuda:
         [
             HeadWiseFP8PrefillImpl,
             HeadWisePrefillImpl,
+            FlashAttn3PagedShortGraphImpl,
             FlashInferTRTLLMSpecDecodeImpl,
             FlashInferTRTLLMPrefillImpl,
             FlashInferTRTLLMFMHAv2PrefillImpl,

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/flash_attn_3.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/flash_attn_3.py
@@ -1,0 +1,238 @@
+"""FlashAttention-3 paged attention for fixed-width short-query graphs.
+
+The generic CUDA-graph runtime owns graph bucketing and replay, while the
+existing fused RoPE/KV-cache operator owns position encoding and cache writes.
+FA3 only consumes the resulting query and the main paged KV cache.
+"""
+
+import copy
+from typing import Optional, Tuple
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention import common
+from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
+from rtp_llm.models_py.utils.arch import get_num_device_sms, is_sm90
+from rtp_llm.ops import AttentionConfigs, KvCacheDataType, ParallelismConfig
+from rtp_llm.ops.compute_ops import (
+    FusedRopeKVCachePrefillOpQOut,
+    LayerKVCache,
+    PyAttentionInputs,
+)
+
+try:
+    # CUDA 12.9 builds carry the FA3 dependency. CUDA 13 currently does not,
+    # so an unavailable binary remains a clean factory miss.
+    from flash_attn_interface import flash_attn_with_kvcache
+
+    _HAS_FLASH_ATTN_3 = True
+except (ImportError, OSError):
+    flash_attn_with_kvcache = None
+    _HAS_FLASH_ATTN_3 = False
+
+
+# A one-block limit covers speculative verify and hot-prefix suffix graphs
+# without turning large/chunked prefill into a fixed-shape graph workload.
+_MAX_QUERY_WIDTH = 64
+_MAX_SPLITS = 32
+_TARGET_CTA_PER_SM = 4
+_SINGLE_SPLIT_CTA_PER_SM = 3
+
+
+def _short_graph_num_splits(batch_size: int, head_num: int, sm_count: int) -> int:
+    """Choose FA3 split-K occupancy for a fixed-width short-query graph."""
+    if batch_size <= 0 or head_num <= 0 or sm_count <= 0:
+        raise ValueError("batch_size, head_num and sm_count must be positive")
+
+    active_ctas = batch_size * head_num
+    if active_ctas >= _SINGLE_SPLIT_CTA_PER_SM * sm_count:
+        return 1
+    target_ctas = _TARGET_CTA_PER_SM * sm_count
+    return max(
+        1,
+        min(_MAX_SPLITS, (target_ctas + active_ctas - 1) // active_ctas),
+    )
+
+
+def _fixed_width_active_prefix(
+    input_lengths: Optional[torch.Tensor],
+) -> Optional[Tuple[int, int]]:
+    """Return ``(graph_batch_size, query_width)`` for padded graph geometry."""
+    if input_lengths is None or input_lengths.dim() != 1 or input_lengths.numel() == 0:
+        return None
+
+    # Factory selection happens while graph objects are constructed, outside
+    # capture/replay. Replay continues to consume device-resident metadata.
+    lengths = [int(length) for length in input_lengths.detach().cpu().tolist()]
+    query_width = lengths[0]
+    if query_width <= 0:
+        return None
+
+    active_batch_size = 0
+    while (
+        active_batch_size < len(lengths) and lengths[active_batch_size] == query_width
+    ):
+        active_batch_size += 1
+
+    if active_batch_size == 0 or any(
+        length != 0 for length in lengths[active_batch_size:]
+    ):
+        return None
+    return active_batch_size, query_width
+
+
+def _rope_capture_inputs(attn_inputs: PyAttentionInputs) -> PyAttentionInputs:
+    """Retain graph-owned device length buffers in fused-RoPE parameters."""
+    rope_inputs = copy.copy(attn_inputs)
+    if (
+        attn_inputs.input_lengths_device is not None
+        and attn_inputs.input_lengths_device.numel() > 0
+    ):
+        rope_inputs.input_lengths = attn_inputs.input_lengths_device
+    if (
+        attn_inputs.prefix_lengths_device is not None
+        and attn_inputs.prefix_lengths_device.numel() > 0
+    ):
+        rope_inputs.prefix_lengths = attn_inputs.prefix_lengths_device
+    return rope_inputs
+
+
+class FlashAttn3PagedShortGraphImpl(FMHAImplBase):
+    """FA3 paged attention for uniform one-block CUDA graphs.
+
+    This implementation is phase- and model-agnostic. Any causal MHA/GQA
+    graph with a fixed query width and BF16/FP16 paged KV cache may select it.
+    """
+
+    cuda_graph_device_metadata_only = True
+
+    def __init__(
+        self,
+        attn_configs: AttentionConfigs,
+        attn_inputs: PyAttentionInputs,
+        parallelism_config: Optional[ParallelismConfig] = None,
+    ) -> None:
+        graph_geometry = _fixed_width_active_prefix(attn_inputs.input_lengths)
+        if graph_geometry is None:
+            raise ValueError("invalid fixed-width CUDA graph input geometry")
+
+        self.attn_configs = attn_configs
+        self.attn_inputs = attn_inputs
+        self.batch_size, self.query_width = graph_geometry
+        self.num_splits = _short_graph_num_splits(
+            self.batch_size,
+            attn_configs.head_num,
+            get_num_device_sms(),
+        )
+        self.softmax_scale = (
+            attn_configs.softmax_extra_scale
+            / attn_configs.q_scaling
+            * attn_configs.size_per_head**-0.5
+        )
+
+        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpQOut(attn_configs)
+        self.rope_params = self.rope_kvcache_impl.prepare(
+            _rope_capture_inputs(attn_inputs)
+        )
+        self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
+        self.cache_sequence_lengths = torch.empty(
+            self.batch_size, dtype=torch.int32, device="cuda"
+        )
+
+    @classmethod
+    def support(
+        cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
+    ) -> bool:
+        if not _HAS_FLASH_ATTN_3 or not is_sm90():
+            return False
+        if (
+            attn_configs.use_mla
+            or not attn_configs.need_rope_kv_cache
+            or attn_configs.kv_cache_dtype != KvCacheDataType.BASE
+            or attn_configs.dtype not in (torch.bfloat16, torch.float16)
+            or attn_configs.size_per_head not in (64, 96, 128, 192, 256)
+            or attn_configs.kernel_tokens_per_block <= 0
+        ):
+            return False
+        if not attn_inputs.is_prefill or not attn_inputs.is_cuda_graph:
+            return False
+        if (
+            attn_inputs.input_lengths is None
+            or attn_inputs.input_lengths.numel() == 0
+            or attn_inputs.prefix_lengths is None
+            or attn_inputs.prefix_lengths.numel() == 0
+            or attn_inputs.kv_cache_kernel_block_id_device is None
+            or attn_inputs.kv_cache_kernel_block_id_device.numel() == 0
+        ):
+            return False
+
+        graph_geometry = _fixed_width_active_prefix(attn_inputs.input_lengths)
+        if graph_geometry is None:
+            return False
+        graph_batch_size, query_width = graph_geometry
+        return (
+            1 < query_width <= _MAX_QUERY_WIDTH
+            and attn_inputs.prefix_lengths.numel() >= graph_batch_size
+            and attn_inputs.kv_cache_kernel_block_id_device.size(0) >= graph_batch_size
+        )
+
+    def forward(
+        self,
+        qkv: torch.Tensor,
+        kv_cache: Optional[LayerKVCache],
+        layer_idx: int = 0,
+    ) -> torch.Tensor:
+        assert flash_attn_with_kvcache is not None
+        assert kv_cache is not None
+
+        query = self.rope_kvcache_impl.forward(qkv, kv_cache, self.rope_params)
+        common.apply_write_cache_store(
+            self.write_cache_store_impl, self.attn_inputs, kv_cache
+        )
+
+        head_num = self.attn_configs.head_num
+        head_dim = self.attn_configs.size_per_head
+        query = query.view(self.batch_size, self.query_width, head_num, head_dim)
+
+        paged_kv_cache = kv_cache.kv_cache_base
+        if paged_kv_cache.dim() == 2:
+            paged_kv_cache = common.reshape_paged_kv_cache(
+                paged_kv_cache,
+                self.attn_configs.kv_head_num,
+                self.attn_configs.kernel_tokens_per_block,
+                head_dim,
+            )
+        key_cache = paged_kv_cache[:, 0].transpose(1, 2)
+        value_cache = paged_kv_cache[:, 1].transpose(1, 2)
+
+        prefix_lengths = self.attn_inputs.prefix_lengths_device
+        if prefix_lengths is None or prefix_lengths.numel() == 0:
+            prefix_lengths = self.attn_inputs.prefix_lengths
+        prefix_lengths = prefix_lengths[: self.batch_size]
+        input_lengths = self.attn_inputs.input_lengths_device
+        if input_lengths is None or input_lengths.numel() == 0:
+            input_lengths = self.attn_inputs.input_lengths
+        input_lengths = input_lengths[: self.batch_size]
+        torch.add(prefix_lengths, input_lengths, out=self.cache_sequence_lengths)
+
+        output = flash_attn_with_kvcache(
+            query,
+            key_cache,
+            value_cache,
+            cache_seqlens=self.cache_sequence_lengths,
+            page_table=self.attn_inputs.kv_cache_kernel_block_id_device[
+                : self.batch_size
+            ],
+            max_seqlen_q=self.query_width,
+            softmax_scale=self.softmax_scale,
+            causal=self.attn_configs.is_causal,
+            num_splits=self.num_splits,
+        )
+        return output.view(-1, head_num * head_dim)
+
+    def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs) -> None:
+        # Query width and launch geometry are fixed at capture; replay updates
+        # only the request's page table dependent fused-RoPE offset.
+        new_offset = self.rope_kvcache_impl.prepare_kv_cache_offset(attn_inputs)
+        if new_offset is not None:
+            common.copy_kv_cache_offset(self.rope_params.kv_cache_offset, new_offset)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -32,6 +32,8 @@ from rtp_llm.ops.compute_ops import (
 
 # Constants
 DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB = 128
+_FLASHINFER_WORKSPACE_ALIGNMENT = 256
+_FLASHINFER_ACCUMULATOR_BYTES = 4
 
 # FP8 KV cache uses a unit quantization scale: K/V are cast
 # directly to float8_e4m3fn and FA3 FP8 kernels run with scale_q/k/v = 1.0.
@@ -70,30 +72,124 @@ def quantize_to_fp8_if_needed(
     return output
 
 
-# Global workspace buffer pool
-_g_py_flashinfer_workspace_pool: list[torch.Tensor] = []
+# Global workspace buffer pool. CUDA graph instances keep their compact buffers
+# alive; the default 128 MiB buffer is reused as staging while each instance is
+# planned and right-sized.
+_g_py_flashinfer_workspace_pool: dict[
+    tuple[torch.device, int], list[torch.Tensor]
+] = {}
 _g_py_flashinfer_pool_lock = __import__("threading").Lock()
 
 
-def get_py_flashinfer_workspace_buffer(device: str = "cuda") -> torch.Tensor:
+def _round_workspace_size(size_bytes: int) -> int:
+    if size_bytes <= 0:
+        raise ValueError(f"workspace size must be positive, got {size_bytes}")
+    return (
+        (size_bytes + _FLASHINFER_WORKSPACE_ALIGNMENT - 1)
+        // _FLASHINFER_WORKSPACE_ALIGNMENT
+        * _FLASHINFER_WORKSPACE_ALIGNMENT
+    )
+
+
+def _workspace_device(device: str | torch.device) -> torch.device:
+    resolved = torch.device(device)
+    if resolved.type == "cuda" and resolved.index is None:
+        resolved = torch.device("cuda", torch.cuda.current_device())
+    return resolved
+
+
+def get_py_flashinfer_workspace_buffer(
+    device: str | torch.device = "cuda",
+    size_bytes: int = DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB * 1024 * 1024,
+) -> torch.Tensor:
     """Get a PyFlashInfer workspace buffer from the pool.
 
     This function manages workspace buffers to support multiple concurrent instances.
     """
+    resolved_device = _workspace_device(device)
+    rounded_size = _round_workspace_size(size_bytes)
+    key = (resolved_device, rounded_size)
     with _g_py_flashinfer_pool_lock:
-        if _g_py_flashinfer_workspace_pool:
-            return _g_py_flashinfer_workspace_pool.pop()
+        buffers = _g_py_flashinfer_workspace_pool.get(key)
+        if buffers:
+            return buffers.pop()
     return torch.zeros(
-        DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB * 1024 * 1024,
+        rounded_size,
         dtype=torch.uint8,
-        device=device,
+        device=resolved_device,
     )
 
 
 def release_py_flashinfer_workspace_buffer(buffer: torch.Tensor) -> None:
     """Release a PyFlashInfer workspace buffer back to the pool."""
+    key = (buffer.device, buffer.numel() * buffer.element_size())
     with _g_py_flashinfer_pool_lock:
-        _g_py_flashinfer_workspace_pool.append(buffer)
+        _g_py_flashinfer_workspace_pool.setdefault(key, []).append(buffer)
+
+
+def _planned_flashinfer_workspace_size(
+    wrapper: Any, num_qo_heads: int, head_dim_vo: int
+) -> Optional[int]:
+    """Return the float-workspace bytes required by a completed graph plan.
+
+    FlashInfer FA2 exposes its split-K allocation through ``PrefillPlanInfo``.
+    FA3 stores scheduling metadata in the integer workspace and does not consume
+    the float workspace. Unknown backends retain FlashInfer's recommended size.
+    """
+    backend = getattr(wrapper, "_backend", None)
+    plan_info = getattr(wrapper, "_plan_info", None)
+    # FA3 tensor-core decode is implemented through the SM90 batch-prefill
+    # planner as well, whose eight-field plan contains only integer-workspace
+    # offsets.  Do not generalize this to future/other FA3 wrappers: their
+    # workspace contract may differ.
+    if backend == "fa3" and plan_info is not None and len(plan_info) == 8:
+        return _FLASHINFER_WORKSPACE_ALIGNMENT
+    if backend != "fa2" or plan_info is None or len(plan_info) != 15:
+        return None
+
+    split_kv = bool(plan_info[14])
+    if not split_kv:
+        return _FLASHINFER_WORKSPACE_ALIGNMENT
+
+    padded_batch_size = int(plan_info[0])
+    cta_tile_q = int(plan_info[3])
+    value_offset = int(plan_info[10])
+    lse_offset = int(plan_info[11])
+    partial_rows = num_qo_heads * padded_batch_size * cta_tile_q
+    required_bytes = max(
+        value_offset
+        + partial_rows * head_dim_vo * _FLASHINFER_ACCUMULATOR_BYTES,
+        lse_offset + partial_rows * _FLASHINFER_ACCUMULATOR_BYTES,
+    )
+    return _round_workspace_size(required_bytes)
+
+
+def _compact_graph_workspace(
+    wrapper: Any,
+    workspace: torch.Tensor,
+    num_qo_heads: int,
+    head_dim_vo: int,
+) -> torch.Tensor:
+    """Replace a graph wrapper's staging workspace with its stable exact size."""
+    required_bytes = _planned_flashinfer_workspace_size(
+        wrapper, num_qo_heads, head_dim_vo
+    )
+    current_bytes = workspace.numel() * workspace.element_size()
+    if required_bytes is None or required_bytes >= current_bytes:
+        return workspace
+
+    # FlashInfer's plan() stages scheduler metadata with raw cudaMemcpyAsync
+    # from its pinned host workspace. reset_workspace_buffer() replaces that
+    # pinned tensor, so its stream work must finish before the old allocation
+    # can be released/reused. This runs once while constructing each graph and
+    # has no steady-state cost.
+    if workspace.is_cuda:
+        torch.cuda.current_stream(workspace.device).synchronize()
+
+    compact = get_py_flashinfer_workspace_buffer(workspace.device, required_bytes)
+    wrapper.reset_workspace_buffer(compact, wrapper._int_workspace_buffer)
+    release_py_flashinfer_workspace_buffer(workspace)
+    return compact
 
 
 def _host_i32(t):
@@ -161,6 +257,7 @@ class PyFlashinferPrefillPagedAttnOp(object):
         self.is_causal = attn_configs.is_causal
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         self.enable_cuda_graph = attn_inputs.is_cuda_graph
+        self._workspace_compacted = False
         self.prefill_cuda_graph_copy_params = None
         # Pre-allocated buffers for CUDA graph copy path (avoid per-forward allocation)
         self._aligned_q_buf = None
@@ -279,6 +376,19 @@ class PyFlashinferPrefillPagedAttnOp(object):
             )
             qo_indptr = self.qo_indptr
 
+        self._plan_prefill_wrapper(qo_indptr)
+        if self.enable_cuda_graph and not self._workspace_compacted:
+            self.g_workspace_buffer = _compact_graph_workspace(
+                self.prefill_wrapper,
+                self.g_workspace_buffer,
+                self.local_head_num,
+                self.head_dim_vo,
+            )
+            self._workspace_compacted = True
+            self._plan_prefill_wrapper(qo_indptr)
+        return self.fmha_params
+
+    def _plan_prefill_wrapper(self, qo_indptr: torch.Tensor) -> None:
         self.prefill_wrapper.plan(
             qo_indptr,
             self.fmha_params.decode_page_indptr_d,
@@ -293,7 +403,6 @@ class PyFlashinferPrefillPagedAttnOp(object):
             kv_data_type=self.kv_dtype,
             o_data_type=self.dtype,
         )
-        return self.fmha_params
 
     @staticmethod
     def support(attn_inputs: PyAttentionInputs) -> bool:
@@ -1029,6 +1138,7 @@ class PyFlashinferDecodeAttnOp(object):
             attn_q_dtype(attn_configs) if self.use_tensor_core else self.dtype
         )
         self.enable_cuda_graph = attn_inputs.is_cuda_graph
+        self._workspace_compacted = False
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
 
     def __del__(self):
@@ -1131,6 +1241,15 @@ class PyFlashinferDecodeAttnOp(object):
                 )
 
         self._plan_decode_wrapper(attn_inputs)
+        if self.enable_cuda_graph and not self._workspace_compacted:
+            self.g_workspace_buffer = _compact_graph_workspace(
+                self.decode_wrapper,
+                self.g_workspace_buffer,
+                self.local_head_num,
+                self.head_dim_vo,
+            )
+            self._workspace_compacted = True
+            self._plan_decode_wrapper(attn_inputs)
         return self.fmha_params
 
     def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/BUILD
@@ -113,6 +113,17 @@ py_test(
     },
 )
 
+py_test(
+    name = "test_flash_attn_3_graph_geometry",
+    srcs = ["test_flash_attn_3.py"],
+    main = "test_flash_attn_3.py",
+    deps = py_test_deps,
+    tags = ["H20"],
+    exec_properties = {
+        "gpu": "H20",
+    },
+)
+
 # FlashInfer TRT-LLM FMHA v2 tests
 py_test(
     name = "test_trtllm_fmha_v2_paged_prefill_sm90",

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flash_attn_3.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flash_attn_3.py
@@ -1,0 +1,173 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_impl import flash_attn_3
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.flash_attn_3 import (
+    _MAX_QUERY_WIDTH,
+    FlashAttn3PagedShortGraphImpl,
+    _fixed_width_active_prefix,
+    _rope_capture_inputs,
+    _short_graph_num_splits,
+)
+from rtp_llm.ops import KvCacheDataType, fused_rope_kvcache_op
+from rtp_llm.ops.fused_rope_kvcache_op import FusedRopeKVCachePrefillOpQOut
+
+
+class FlashAttn3SupportTest(unittest.TestCase):
+    def _make_inputs(self):
+        return SimpleNamespace(
+            is_prefill=True,
+            is_cuda_graph=True,
+            input_lengths=torch.tensor([8], dtype=torch.int32),
+            prefix_lengths=torch.tensor([0], dtype=torch.int32),
+            kv_cache_kernel_block_id_device=torch.ones((1, 1), dtype=torch.int32),
+        )
+
+    def _make_config(self, *, need_rope_kv_cache: bool):
+        return SimpleNamespace(
+            use_mla=False,
+            need_rope_kv_cache=need_rope_kv_cache,
+            kv_cache_dtype=KvCacheDataType.BASE,
+            dtype=torch.bfloat16,
+            size_per_head=128,
+            kernel_tokens_per_block=64,
+        )
+
+    def test_rejects_graphs_without_paged_kv_cache(self) -> None:
+        with (
+            mock.patch.object(flash_attn_3, "_HAS_FLASH_ATTN_3", True),
+            mock.patch.object(flash_attn_3, "is_sm90", return_value=True),
+        ):
+            self.assertFalse(
+                FlashAttn3PagedShortGraphImpl.support(
+                    self._make_config(need_rope_kv_cache=False), self._make_inputs()
+                )
+            )
+            self.assertTrue(
+                FlashAttn3PagedShortGraphImpl.support(
+                    self._make_config(need_rope_kv_cache=True), self._make_inputs()
+                )
+            )
+
+
+class FlashAttn3GraphGeometryTest(unittest.TestCase):
+    def test_one_cache_block_query_limit(self) -> None:
+        self.assertEqual(_MAX_QUERY_WIDTH, 64)
+
+    def test_unpadded_fixed_width(self) -> None:
+        self.assertEqual(
+            _fixed_width_active_prefix(torch.tensor([8, 8, 8], dtype=torch.int32)),
+            (3, 8),
+        )
+
+    def test_padded_fixed_width_active_prefix(self) -> None:
+        self.assertEqual(
+            _fixed_width_active_prefix(
+                torch.tensor([8, 8, 8, 0, 0, 0], dtype=torch.int32)
+            ),
+            (3, 8),
+        )
+
+    def test_single_active_row(self) -> None:
+        self.assertEqual(
+            _fixed_width_active_prefix(torch.tensor([8, 0, 0], dtype=torch.int32)),
+            (1, 8),
+        )
+
+    def test_rejects_non_prefix_activity(self) -> None:
+        self.assertIsNone(
+            _fixed_width_active_prefix(torch.tensor([8, 0, 8], dtype=torch.int32))
+        )
+
+    def test_rejects_mixed_positive_widths(self) -> None:
+        self.assertIsNone(
+            _fixed_width_active_prefix(torch.tensor([8, 7, 0], dtype=torch.int32))
+        )
+
+    def test_rejects_empty_or_inactive_geometry(self) -> None:
+        self.assertIsNone(_fixed_width_active_prefix(None))
+        self.assertIsNone(_fixed_width_active_prefix(torch.empty(0, dtype=torch.int32)))
+        self.assertIsNone(
+            _fixed_width_active_prefix(torch.tensor([0, 0], dtype=torch.int32))
+        )
+
+
+class FlashAttn3CudaGraphPrepareTest(unittest.TestCase):
+    def test_device_only_offset_helper_is_a_real_operator_contract(self) -> None:
+        impl = object.__new__(FusedRopeKVCachePrefillOpQOut)
+        block_ids = torch.tensor([[3, 7]], dtype=torch.int32)
+        attn_inputs = SimpleNamespace(kv_cache_kernel_block_id_device=block_ids)
+        fused_op = mock.Mock()
+        converted = torch.tensor([[9, 11]], dtype=torch.int32)
+        fused_op.convert_offset_to_block_array.return_value = converted
+
+        with mock.patch.object(
+            fused_rope_kvcache_op,
+            "_get_fused_rope_kvcache",
+            return_value=fused_op,
+        ):
+            result = impl.prepare_kv_cache_offset(attn_inputs)
+
+        self.assertIs(result, converted)
+        fused_op.convert_offset_to_block_array.assert_called_once_with(block_ids)
+
+    def test_rope_capture_retains_device_length_buffers(self) -> None:
+        host_input = torch.tensor([8], dtype=torch.int32)
+        host_prefix = torch.tensor([11], dtype=torch.int32)
+        device_input = torch.tensor([8], dtype=torch.int32, device="cuda")
+        device_prefix = torch.tensor([11], dtype=torch.int32, device="cuda")
+        inputs = SimpleNamespace(
+            input_lengths=host_input,
+            prefix_lengths=host_prefix,
+            input_lengths_device=device_input,
+            prefix_lengths_device=device_prefix,
+        )
+
+        rope_inputs = _rope_capture_inputs(inputs)
+
+        self.assertIs(rope_inputs.input_lengths, device_input)
+        self.assertIs(rope_inputs.prefix_lengths, device_prefix)
+        self.assertIs(inputs.input_lengths, host_input)
+        self.assertIs(inputs.prefix_lengths, host_prefix)
+
+    def test_replay_refreshes_only_kv_offset(self) -> None:
+        impl = object.__new__(FlashAttn3PagedShortGraphImpl)
+        impl.rope_kvcache_impl = mock.Mock()
+        impl.rope_kvcache_impl.prepare_kv_cache_offset.return_value = torch.tensor(
+            [7], dtype=torch.int32
+        )
+        impl.rope_params = mock.Mock()
+        impl.rope_params.kv_cache_offset = torch.zeros(1, dtype=torch.int32)
+        attn_inputs = mock.Mock()
+
+        impl.prepare_cuda_graph(attn_inputs)
+
+        impl.rope_kvcache_impl.prepare_kv_cache_offset.assert_called_once_with(
+            attn_inputs
+        )
+        impl.rope_kvcache_impl.prepare.assert_not_called()
+        self.assertEqual(impl.rope_params.kv_cache_offset.item(), 7)
+
+
+class FlashAttn3SplitSchedulerTest(unittest.TestCase):
+    def test_h20_qwen3_dspark_tp2_capture_buckets(self) -> None:
+        expected = {1: 32, 8: 4, 16: 2, 24: 1, 32: 1}
+        for batch_size, num_splits in expected.items():
+            with self.subTest(batch_size=batch_size):
+                self.assertEqual(
+                    _short_graph_num_splits(batch_size, 10, 78), num_splits
+                )
+
+    def test_caps_tiny_grids_and_rejects_invalid_geometry(self) -> None:
+        self.assertEqual(_short_graph_num_splits(1, 1, 120), 32)
+        for args in ((0, 1, 78), (1, 0, 78), (1, 1, 0)):
+            with self.subTest(args=args):
+                with self.assertRaises(ValueError):
+                    _short_graph_num_splits(*args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -2,12 +2,14 @@ import logging
 import math
 import sys
 import unittest
+from types import SimpleNamespace
 from typing import List
 
 import torch
 from attention_ref import compute_flashinfer_decode_reference
 from base_attention_test import BaseAttentionTest
 
+from rtp_llm.models_py.modules.factory.attention.cuda_impl import py_flashinfer_mha
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     PyFlashinferDecodeAttnOp,
 )
@@ -20,6 +22,63 @@ from rtp_llm.ops.compute_ops import (
 )
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+class TestPyFlashinferWorkspacePlanning(unittest.TestCase):
+    def test_fa2_graph_plan_uses_exact_split_k_workspace(self) -> None:
+        heads = 12
+        padded_batch_size = 80
+        cta_tile_q = 16
+        head_dim = 256
+        partial_rows = heads * padded_batch_size * cta_tile_q
+        value_offset = 256
+        value_bytes = partial_rows * head_dim * 4
+        lse_offset = value_offset + value_bytes
+
+        plan_info = [0] * 15
+        plan_info[0] = padded_batch_size
+        plan_info[3] = cta_tile_q
+        plan_info[10] = value_offset
+        plan_info[11] = lse_offset
+        plan_info[14] = 1
+        wrapper = SimpleNamespace(_backend="fa2", _plan_info=plan_info)
+
+        expected = py_flashinfer_mha._round_workspace_size(
+            lse_offset + partial_rows * 4
+        )
+        self.assertEqual(
+            py_flashinfer_mha._planned_flashinfer_workspace_size(
+                wrapper, heads, head_dim
+            ),
+            expected,
+        )
+
+    def test_fa3_graph_plan_needs_no_float_scratch(self) -> None:
+        wrapper = SimpleNamespace(_backend="fa3", _plan_info=[0] * 8)
+        self.assertEqual(
+            py_flashinfer_mha._planned_flashinfer_workspace_size(wrapper, 12, 256),
+            py_flashinfer_mha._FLASHINFER_WORKSPACE_ALIGNMENT,
+        )
+
+    def test_unknown_fa3_plan_keeps_flashinfer_default(self) -> None:
+        wrapper = SimpleNamespace(_backend="fa3", _plan_info=[0] * 9)
+        self.assertIsNone(
+            py_flashinfer_mha._planned_flashinfer_workspace_size(wrapper, 12, 256)
+        )
+
+    def test_unknown_backend_keeps_flashinfer_default(self) -> None:
+        wrapper = SimpleNamespace(_backend="future_backend", _plan_info=[])
+        self.assertIsNone(
+            py_flashinfer_mha._planned_flashinfer_workspace_size(wrapper, 12, 256)
+        )
+
+    def test_workspace_pool_is_size_aware(self) -> None:
+        first = py_flashinfer_mha.get_py_flashinfer_workspace_buffer("cpu", 513)
+        self.assertEqual(first.numel(), 768)
+        py_flashinfer_mha.release_py_flashinfer_workspace_buffer(first)
+        reused = py_flashinfer_mha.get_py_flashinfer_workspace_buffer("cpu", 513)
+        self.assertIs(reused, first)
+        py_flashinfer_mha.release_py_flashinfer_workspace_buffer(reused)
 
 
 class TestPyFlashinferDecodeAttnOp(BaseAttentionTest):

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -836,13 +836,25 @@ class AiterPrefillAttnOpPaged:
             buffer.shape != required_shape or buffer.device != self.graph_device
         ):
             raise ValueError("Aiter graph buffer changed; recapture required")
-        if self.seqlen_k_buf is None or self.seqlen_k_buf.shape[0] < batch_size:
+        if self.seqlen_k_buf is None:
             self.seqlen_k_buf = torch.empty(
                 max(1, batch_size), dtype=torch.int32, device=self.graph_device
             )
-        if self.kv_indptr_buf is None or self.kv_indptr_buf.shape[0] < batch_size + 1:
+        elif self.seqlen_k_buf.shape[0] < batch_size:
+            raise ValueError(
+                "Aiter paged-prefill CUDA graph replay exceeds the captured "
+                f"seqlen_k capacity: capture={self.seqlen_k_buf.shape[0]}, "
+                f"replay={batch_size}"
+            )
+        if self.kv_indptr_buf is None:
             self.kv_indptr_buf = torch.zeros(
                 max(1, batch_size + 1), dtype=torch.int32, device=self.graph_device
+            )
+        elif self.kv_indptr_buf.shape[0] < batch_size + 1:
+            raise ValueError(
+                "Aiter paged-prefill CUDA graph replay exceeds the captured "
+                f"kv_indptr capacity: capture={self.kv_indptr_buf.shape[0]}, "
+                f"replay={batch_size + 1}"
             )
         if self.kv_page_indices_buf is None:
             self.kv_page_indices_buf = torch.zeros(

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -1764,7 +1764,11 @@ class AiterPrefillImplPaged(FMHAImplBase):
         return "triton" if self._use_triton_paged_prefill(attn_inputs) else "batch"
 
     def support_cuda_graph(self) -> bool:
-        return self.backend == "triton"
+        # Both dispatched backends implement prepare_cuda_graph().  In
+        # particular, DSpARK COMMIT runs gamma + 1 query tokens (8 for the
+        # common 7-token proposal), which selects CK batch-prefill instead of
+        # the short-query Triton path.
+        return self.backend in ("triton", "batch")
 
     def _prepare_backend(self, backend: str) -> FMHAParams:
         if backend == "triton":

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -631,7 +631,7 @@ class AiterPrefillAttnOp:
             kv_page_indices,
             max_seqlen_q,
             max_seqlen_k,
-            causal=True,
+            causal=self.is_causal,
             block_table=block_table,
             seqlen_k=seqlen_k,
             q_descale=q_descale,

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -1306,6 +1306,60 @@ class TestAiterPrefillAttnOpTritonCudaGraphWorkspace(unittest.TestCase):
 
 
 @unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillAttnOp module")
+class TestAiterPrefillAttnOpPagedCudaGraphWorkspace(unittest.TestCase):
+    """Regression tests for fixed-address batch-prefill graph workspace."""
+
+    def test_repeated_prepare_keeps_captured_workspace_addresses(self):
+        from types import SimpleNamespace
+
+        cfg = _make_attn_configs(head_num=4, head_num_kv=2, head_dim=8)
+        cfg.kernel_tokens_per_block = 16
+        op = AiterPrefillAttnOpPaged(cfg)
+        device = torch.device("cuda")
+        block_table = torch.zeros(3, 4, dtype=torch.int32, device=device)
+        fmha_params = SimpleNamespace(
+            cu_seqlens_q=torch.tensor(
+                [0, 8, 16, 24], dtype=torch.int32, device=device
+            ),
+            cu_seqlens_k=torch.tensor(
+                [0, 40, 80, 120], dtype=torch.int32, device=device
+            ),
+            kv_cache_block_id_device=block_table,
+        )
+        attn_inputs = SimpleNamespace(
+            input_lengths_device=torch.full(
+                (3,), 8, dtype=torch.int32, device=device
+            ),
+            prefix_lengths_device=torch.full(
+                (3,), 32, dtype=torch.int32, device=device
+            ),
+            kv_cache_kernel_block_id_device=block_table,
+            kv_cache_block_id_device=block_table,
+        )
+
+        op.prepare_cuda_graph(fmha_params, attn_inputs)
+        captured_ptrs = {
+            "seqlen_k": op.seqlen_k_buf.data_ptr(),
+            "kv_indptr": op.kv_indptr_buf.data_ptr(),
+            "kv_page_indices": op.kv_page_indices_buf.data_ptr(),
+            "descale": op.descale_buf.data_ptr(),
+            "sanitized_block_table": op.sanitized_bt_buf.data_ptr(),
+        }
+
+        op.prepare_cuda_graph(fmha_params, attn_inputs)
+
+        replay_ptrs = {
+            "seqlen_k": op.seqlen_k_buf.data_ptr(),
+            "kv_indptr": op.kv_indptr_buf.data_ptr(),
+            "kv_page_indices": op.kv_page_indices_buf.data_ptr(),
+            "descale": op.descale_buf.data_ptr(),
+            "sanitized_block_table": op.sanitized_bt_buf.data_ptr(),
+        }
+        self.assertEqual(replay_ptrs, captured_ptrs)
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
 @unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
 @unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
 class TestAiterPrefillTritonCudaGraphNumerics(unittest.TestCase):

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -896,16 +896,17 @@ class TestAiterPrefillImplPagedCudaGraphDispatch(unittest.TestCase):
             observed_pad_query,
         )
 
-    def test_cuda_graph_supports_only_triton_backend(self):
-        for input_lengths, expected_backend in (([4, 1], "triton"), ([5, 1], "batch")):
+    def test_cuda_graph_supports_triton_and_batch_backends(self):
+        for input_lengths, expected_backend in (
+            ([4, 1], "triton"),
+            ([8, 8], "batch"),
+        ):
             with self.subTest(expected_backend=expected_backend):
                 impl, batch_impl, triton_impl, *_ = self._make_impl_with_mocked_prepare(
                     input_lengths, True
                 )
                 self.assertEqual(impl.backend, expected_backend)
-                self.assertEqual(
-                    impl.support_cuda_graph(), expected_backend == "triton"
-                )
+                self.assertTrue(impl.support_cuda_graph())
                 selected = triton_impl if expected_backend == "triton" else batch_impl
                 rejected = batch_impl if expected_backend == "triton" else triton_impl
                 selected.prepare.assert_called_once_with(impl.attn_inputs)

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -1774,8 +1774,7 @@ class TestCompactGatherReshape(unittest.TestCase):
             head_num=2, head_num_kv=1, head_dim=8, tokens_per_block=8
         )
         cfg.is_causal = False
-        op = AiterPrefillAttnOp(cfg, v1_kv_layout=True)
-        op.use_compact = False
+        op = AiterPrefillAttnOp(cfg)
         query = torch.zeros(2, 2, 8, dtype=torch.float16)
         cache = SimpleNamespace(
             kv_cache_base=torch.zeros(2, 2, 1, 8, 8, dtype=torch.float16)

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -1713,6 +1713,48 @@ class TestCompactGatherReshape(unittest.TestCase):
         self.assertTrue(op.linear_v)
         self.assertEqual(full_reshape.call_count, 1)
 
+    def test_paged_prefill_forwards_noncausal_semantics(self):
+        from types import SimpleNamespace
+
+        cfg = _make_attn_configs(
+            head_num=2, head_num_kv=1, head_dim=8, tokens_per_block=8
+        )
+        cfg.is_causal = False
+        op = AiterPrefillAttnOp(cfg, v1_kv_layout=True)
+        op.use_compact = False
+        query = torch.zeros(2, 2, 8, dtype=torch.float16)
+        cache = SimpleNamespace(
+            kv_cache_base=torch.zeros(2, 2, 1, 8, 8, dtype=torch.float16)
+        )
+        block_table = torch.tensor([[0]], dtype=torch.int32)
+        params = SimpleNamespace(
+            cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32),
+            prefill_seqlen_k_int32=torch.tensor([2], dtype=torch.int32),
+            max_seqlen_q=2,
+            max_seqlen_k=2,
+            token_q_num=2,
+            sanitized_block_table=block_table,
+        )
+        k_cache = torch.zeros(2, 1, 1, 8, 8, dtype=torch.float16)
+        v_cache = torch.zeros(2, 1, 1, 8, 8, dtype=torch.float16)
+        seen_causal = []
+
+        def fake_prefill(*args, **kwargs):
+            seen_causal.append(kwargs["causal"])
+            return torch.zeros_like(query)
+
+        prefill_func = (
+            "rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter."
+            "aiter.mha_batch_prefill_func"
+        )
+        with patch.object(
+            op, "_reshape_kv_cache_vectorized", return_value=(k_cache, v_cache)
+        ), patch(prefill_func, side_effect=fake_prefill):
+            output = op._forward_paged(query, cache, params)
+
+        self.assertEqual(tuple(output.shape), (2, 16))
+        self.assertEqual(seen_causal, [False])
+
     # ---- block table sanitization ------------------------------------------
 
     def test_sanitize_block_table_fills_padding_with_last_valid(self):

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
@@ -394,6 +394,7 @@ class LinearTest(TestCase):
             num_layers=1,
             vocab_size=32,
             layernorm_eps=1e-6,
+            capture_aux_hidden_layer_ids=(),
         )
         parallelism_config = SimpleNamespace()
         hw_kernel_config = HWKernelConfig()

--- a/rtp_llm/models_py/speculative/dspark_proposer_mixin.py
+++ b/rtp_llm/models_py/speculative/dspark_proposer_mixin.py
@@ -50,6 +50,21 @@ def optional_tensor(value: Any) -> Optional[torch.Tensor]:
     return value if value.numel() > 0 else None
 
 
+def device_metadata_tensor(attention_inputs: Any, name: str) -> Optional[torch.Tensor]:
+    """Prefer framework-owned device metadata over its host mirror.
+
+    CUDA Graph replay updates the ``*_device`` tensors in place. Falling back
+    to the host field keeps eager and unit-test callers compatible, while the
+    preferred path avoids introducing a host-to-device copy inside capture.
+    """
+    device_value = optional_tensor(
+        getattr(attention_inputs, f"{name}_device", None)
+    )
+    if device_value is not None:
+        return device_value
+    return optional_tensor(getattr(attention_inputs, name, None))
+
+
 def map_context_rows(
     starts: torch.Tensor,
     lengths: torch.Tensor,
@@ -104,6 +119,7 @@ class DSparkProposerMixin:
         self,
         *,
         width: int,
+        query_width: Optional[int] = None,
         noise_token_id: int,
         aux_feature_dim: int,
         hidden_dim: int,
@@ -122,6 +138,12 @@ class DSparkProposerMixin:
                 raise ValueError(f"DSpark {name} must be positive, got {value}")
 
         self._dspark_width = int(width)
+        self._dspark_query_width = int(width if query_width is None else query_width)
+        if self._dspark_query_width < self._dspark_width:
+            raise ValueError(
+                "DSpark query width cannot be smaller than proposal width: "
+                f"query={self._dspark_query_width}, proposal={self._dspark_width}"
+            )
         self._dspark_noise_token_id = int(noise_token_id)
         self._dspark_aux_feature_dim = int(aux_feature_dim)
         self._dspark_hidden_dim = int(hidden_dim)
@@ -185,8 +207,8 @@ class DSparkProposerMixin:
         raise NotImplementedError
 
     def compute_draft_hidden_states(self, hidden: torch.Tensor) -> torch.Tensor:
-        """Reduce and normalize backbone output to ``[B*width, dim]``."""
-        raise NotImplementedError
+        """Reduce backbone output to ``[B*width, dim]`` when needed."""
+        return hidden.contiguous()
 
     # ------------------------------------------------------------------
     # Shared per-round flow
@@ -196,7 +218,7 @@ class DSparkProposerMixin:
         self, batch_size: int, device: torch.device
     ) -> PyModelOutputs:
         """Zero-filled normalized hidden states with serving geometry."""
-        width = self._dspark_width
+        width = self._dspark_query_width
         return PyModelOutputs(
             torch.zeros(
                 (batch_size * width, self._dspark_hidden_dim),
@@ -257,16 +279,19 @@ class DSparkProposerMixin:
         features = hidden.reshape(-1, aux_dim).to(device=device)
         row_count = int(features.shape[0])
 
-        prefix = optional_tensor(
-            getattr(attention_inputs, "prefix_lengths_device", None)
+        prefix_lengths_source = device_metadata_tensor(
+            attention_inputs, "prefix_lengths"
         )
-        if prefix is None:
-            prefix = optional_tensor(getattr(attention_inputs, "prefix_lengths", None))
-        if prefix is None or int(prefix.numel()) < batch_size:
+        if (
+            prefix_lengths_source is None
+            or int(prefix_lengths_source.numel()) < batch_size
+        ):
             raise RuntimeError(
                 "DSpark commit requires prefix_lengths with one value per request"
             )
-        prefix_lengths = prefix[:batch_size].to(device=device, dtype=torch.long)
+        prefix_lengths = prefix_lengths_source[:batch_size].to(
+            device=device, dtype=torch.long
+        )
         lengths = lengths_source[:batch_size].to(device=device, dtype=torch.long)
         starts = lengths.cumsum(0) - lengths
 
@@ -319,38 +344,35 @@ class DSparkProposerMixin:
 
         The query block reads the committed feature KV written by
         :meth:`run_commit_step`; the call carries no feature input."""
-        width = self._dspark_width
+        width = self._dspark_query_width
 
         attention_inputs = primary_attention_inputs(
             inputs.attention_inputs, getattr(self, "kv_cache", None)
         )
-        input_lengths = optional_tensor(
-            getattr(attention_inputs, "input_lengths", None)
-        )
-        batch_size = int(input_lengths.numel()) if input_lengths is not None else 0
-        expected_tokens = batch_size * width
-        if int(inputs.input_ids.numel()) != expected_tokens:
+        token_count = int(inputs.input_ids.numel())
+        if token_count % width != 0:
             raise RuntimeError(
                 "DSpark input_ids must contain exactly B*gamma tokens: "
-                f"numel={inputs.input_ids.numel()}, batch={batch_size}, "
-                f"gamma={width}"
+                f"numel={token_count}, gamma={width}"
             )
+        batch_size = token_count // width
 
         # Read the CUDA-resident mirror: copying the pinned host field to the
         # device is a blocking H2D transfer, which CUDA rejects while the decode
         # graph is capturing.
-        prefix = optional_tensor(
-            getattr(attention_inputs, "prefix_lengths_device", None)
+        prefix_lengths_source = device_metadata_tensor(
+            attention_inputs, "prefix_lengths"
         )
-        if prefix is None:
-            prefix = optional_tensor(getattr(attention_inputs, "prefix_lengths", None))
-        if batch_size > 0 and (prefix is None or int(prefix.numel()) < batch_size):
+        if batch_size > 0 and (
+            prefix_lengths_source is None
+            or int(prefix_lengths_source.numel()) < batch_size
+        ):
             raise RuntimeError(
                 "DSpark requires prefix_lengths with one value per request"
             )
         prefix_lengths = (
-            prefix[:batch_size].to(device=device, dtype=torch.int32)
-            if prefix is not None
+            prefix_lengths_source[:batch_size].to(device=device, dtype=torch.int32)
+            if prefix_lengths_source is not None
             else torch.empty(0, dtype=torch.int32, device=device)
         )
 

--- a/rtp_llm/models_py/speculative/test/BUILD
+++ b/rtp_llm/models_py/speculative/test/BUILD
@@ -15,3 +15,14 @@ py_test(
     ],
     target_compatible_with = _DSV4_CUDA13_ONLY,
 )
+
+py_test(
+    name = "test_qwen3_dspark",
+    srcs = ["test_qwen3_dspark.py"],
+    deps = [
+        "//rtp_llm:async_model",
+        "//rtp_llm:models",
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    exec_properties = {"gpu": "A10"},
+)

--- a/rtp_llm/models_py/speculative/test/test_dspark_proposer.py
+++ b/rtp_llm/models_py/speculative/test/test_dspark_proposer.py
@@ -9,9 +9,10 @@ from rtp_llm.models_py.speculative.dspark_proposer_mixin import DSparkProposerMi
 class _TinyProposer(DSparkProposerMixin):
     """Smallest possible DSparkProposerMixin subclass."""
 
-    def __init__(self, *, width: int):
+    def __init__(self, *, width: int, query_width=None):
         self.init_dspark_proposer(
             width=width,
+            query_width=query_width,
             noise_token_id=1,
             aux_feature_dim=8,
             hidden_dim=4,
@@ -52,12 +53,17 @@ class ProposerContractTest(unittest.TestCase):
         self.assertEqual(tuple(outputs.hidden_states.shape), (6, 8))
         self.assertEqual(outputs.hidden_states.dtype, torch.bfloat16)
 
+    def test_query_width_may_exclude_anchor_from_predictions(self) -> None:
+        proposer = _TinyProposer(width=3, query_width=4)
+        outputs = proposer.dspark_empty_outputs(2, torch.device("cpu"))
+        self.assertEqual(tuple(outputs.hidden_states.shape), (8, 4))
+
     def test_hooks_require_subclass_implementation(self) -> None:
         proposer = DSparkProposerMixin()
         with self.assertRaises(NotImplementedError):
             proposer.combine_hidden_states(torch.zeros(1, 8))
-        with self.assertRaises(NotImplementedError):
-            proposer.compute_draft_hidden_states(torch.zeros(1, 3, 4, 8))
+        hidden = torch.zeros(1, 3, 4, 8)
+        self.assertIs(proposer.compute_draft_hidden_states(hidden), hidden)
         with self.assertRaises(NotImplementedError):
             proposer.commit_feature_rows(
                 torch.zeros(1, 8),

--- a/rtp_llm/models_py/speculative/test/test_qwen3_dspark.py
+++ b/rtp_llm/models_py/speculative/test/test_qwen3_dspark.py
@@ -1,0 +1,249 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from rtp_llm.model_factory import ModelFactory
+from rtp_llm.model_factory_register import ModelDict, ensure_model_registered
+from rtp_llm.models.qwen_3_dspark import (
+    Qwen3DSpark,
+    dspark_offset_d2t_to_absolute,
+)
+from rtp_llm.models_py.model_desc.qwen3_dspark_model import Qwen3DSparkModel
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.speculative.dspark_proposer_mixin import (
+    device_metadata_tensor,
+)
+
+
+class Qwen3DSparkRegistrationTest(unittest.TestCase):
+    def test_config_wires_shared_dspark_contract(self) -> None:
+        raw = {
+            "architectures": ["Qwen3DSparkForCausalLM"],
+            "hidden_size": 128,
+            "intermediate_size": 256,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "num_hidden_layers": 2,
+            "vocab_size": 1024,
+            "aux_hidden_state_layer_ids": [0, 1],
+            "mask_token_id": 1000,
+            "block_size": 8,
+            "markov_rank": 32,
+        }
+        with tempfile.TemporaryDirectory() as path:
+            Path(path, "config.json").write_text(json.dumps(raw))
+            config = Qwen3DSpark._create_config(path)
+
+        self.assertFalse(config.attn_config.is_causal)
+        self.assertFalse(config.dspark_sample_from_anchor)
+        self.assertEqual(config.dspark_noise_token_id, 1000)
+        self.assertEqual(config.dspark_target_layer_ids, [0, 1])
+        self.assertEqual(config.dspark_markov_rank, 32)
+        self.assertTrue(ensure_model_registered("qwen_3_dspark"))
+        self.assertEqual(
+            ModelDict.get_ft_model_type_by_config(raw), "qwen_3_dspark"
+        )
+
+    def test_speculators_config_normalizes_vocab_and_layer_contract(self) -> None:
+        raw = {
+            "architectures": ["DSparkDraftModel"],
+            "speculators_model_type": "dspark",
+            "transformer_layer_config": {
+                "hidden_size": 128,
+                "intermediate_size": 256,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "num_hidden_layers": 2,
+                "vocab_size": 1024,
+                "rope_parameters": {"rope_theta": 10_000_000},
+                "dtype": "bfloat16",
+            },
+            "draft_vocab_size": 1001,
+            "aux_hidden_state_layer_ids": [1, 2],
+            "mask_token_id": 1000,
+            "markov_rank": 32,
+        }
+        with tempfile.TemporaryDirectory() as path:
+            Path(path, "config.json").write_text(json.dumps(raw))
+            config = Qwen3DSpark._create_config(path)
+
+        self.assertEqual(config.input_vocab_size, 1024)
+        self.assertEqual(config.vocab_size, 1001)
+        self.assertEqual(config.dspark_target_layer_ids, [0, 1])
+        self.assertFalse(config.dspark_sample_from_anchor)
+        self.assertEqual(config.attn_config.rope_config.base, 10_000_000)
+        self.assertEqual(config.config_dtype, "bfloat16")
+
+    def test_speculators_noise_token_is_validated_in_input_vocab(self) -> None:
+        sp_config = SimpleNamespace(
+            gen_num_per_cycle=7,
+            sp_dspark_mask_token_id=-1,
+            sp_dspark_sample_from_anchor=False,
+        )
+        target_config = SimpleNamespace(
+            num_layers=48,
+            capture_aux_hidden_layer_ids=None,
+        )
+        draft_config = SimpleNamespace(
+            dspark_noise_token_id=248127,
+            dspark_target_layer_ids=[7, 15, 23, 31, 39],
+            dspark_markov_rank=256,
+            input_vocab_size=248320,
+            vocab_size=20000,
+            dspark_sample_from_anchor=False,
+            capture_aux_hidden_layer_ids=None,
+        )
+
+        ModelFactory._setup_dspark_configs(
+            sp_config, target_config, draft_config
+        )
+
+        self.assertEqual(sp_config.sp_dspark_mask_token_id, 248127)
+
+    def test_target_capture_layers_must_be_unique_and_ordered(self) -> None:
+        sp_config = SimpleNamespace(
+            gen_num_per_cycle=7,
+            sp_dspark_mask_token_id=-1,
+            sp_dspark_sample_from_anchor=False,
+        )
+        target_config = SimpleNamespace(
+            num_layers=48,
+            capture_aux_hidden_layer_ids=None,
+        )
+        draft_config = SimpleNamespace(
+            dspark_noise_token_id=248127,
+            dspark_target_layer_ids=[15, 7, 15],
+            dspark_markov_rank=256,
+            input_vocab_size=248320,
+            vocab_size=20000,
+            dspark_sample_from_anchor=False,
+            capture_aux_hidden_layer_ids=None,
+        )
+
+        with self.assertRaisesRegex(ValueError, "unique and ordered"):
+            ModelFactory._setup_dspark_configs(
+                sp_config, target_config, draft_config
+            )
+
+    @staticmethod
+    def _capture_harness(layer_ids: tuple[int, ...]) -> SimpleNamespace:
+        return SimpleNamespace(
+            _mtp_aux_capture_layer_ids=layer_ids,
+            _mtp_aux_capture_layer_id_set=frozenset(layer_ids),
+            _mtp_target_hidden_states=None,
+            _mtp_target_graph_buffer=None,
+            _mtp_target_prompt_buffer=None,
+            _mtp_aux_capture_buffer=None,
+            _mtp_aux_capture_rows=0,
+            _mtp_aux_capture_index=0,
+        )
+
+    def test_aux_capture_materializes_fused_residual_boundary(self) -> None:
+        capture = self._capture_harness((1,))
+        hidden = torch.tensor([[1.0, 2.0]])
+        residual = torch.tensor([[10.0, 20.0]])
+
+        GptModelBase.begin_aux_hidden_capture(capture, hidden, False)
+        GptModelBase.capture_aux_hidden(capture, 0, hidden, residual)
+        GptModelBase.capture_aux_hidden(capture, 1, hidden, residual)
+        GptModelBase.finish_aux_hidden_capture(capture)
+
+        torch.testing.assert_close(
+            capture._mtp_target_hidden_states, torch.tensor([[11.0, 22.0]])
+        )
+
+    def test_target_graph_capture_reuses_fixed_address(self) -> None:
+        capture = self._capture_harness((0, 1))
+        hidden = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        residual = torch.tensor([[10.0, 20.0], [30.0, 40.0]])
+
+        GptModelBase.begin_aux_hidden_capture(capture, hidden, True)
+        GptModelBase.capture_aux_hidden(capture, 0, hidden)
+        GptModelBase.capture_aux_hidden(capture, 1, hidden, residual)
+        GptModelBase.finish_aux_hidden_capture(capture)
+        graph_ptr = capture._mtp_target_graph_buffer.data_ptr()
+
+        GptModelBase.begin_aux_hidden_capture(capture, hidden[:1], True)
+        GptModelBase.capture_aux_hidden(capture, 0, hidden[:1])
+        GptModelBase.capture_aux_hidden(capture, 1, hidden[:1], residual[:1])
+        GptModelBase.finish_aux_hidden_capture(capture)
+        self.assertEqual(capture._mtp_target_graph_buffer.data_ptr(), graph_ptr)
+        self.assertEqual(tuple(capture._mtp_target_hidden_states.shape), (1, 4))
+
+        prompt_hidden = hidden.repeat(4, 1)
+        GptModelBase.begin_aux_hidden_capture(capture, prompt_hidden, False)
+        GptModelBase.capture_aux_hidden(capture, 0, prompt_hidden)
+        GptModelBase.capture_aux_hidden(capture, 1, prompt_hidden)
+        GptModelBase.finish_aux_hidden_capture(capture)
+        self.assertEqual(capture._mtp_target_graph_buffer.data_ptr(), graph_ptr)
+        self.assertNotEqual(capture._mtp_target_prompt_buffer.data_ptr(), graph_ptr)
+
+    def test_speculators_d2t_offsets_are_normalized_to_absolute_ids(self) -> None:
+        offsets = torch.tensor([1, 1, 2, -1], dtype=torch.int64)
+        absolute = dspark_offset_d2t_to_absolute([offsets])
+        self.assertEqual(absolute.tolist(), [1, 2, 4, 2])
+
+    def test_commit_uses_kernel_block_ids_not_physical_cache_ids(self) -> None:
+        kernel_ids = torch.tensor([[3, 4]], dtype=torch.int32)
+        physical_ids = torch.tensor([[3003, 3004]], dtype=torch.int32)
+        attention = SimpleNamespace(
+            kv_cache_kernel_block_id_device=kernel_ids,
+            kv_cache_kernel_block_id=torch.tensor([[5, 6]], dtype=torch.int32),
+            kv_cache_block_id_device=physical_ids,
+            kv_cache_block_id=torch.tensor([[5005, 5006]], dtype=torch.int32),
+        )
+        model = SimpleNamespace(
+            embed_tokens=SimpleNamespace(weight=torch.empty(0)), kv_cache=None
+        )
+        model.dspark_attention_inputs = lambda inputs: inputs.attention_inputs
+
+        selected = Qwen3DSparkModel._block_table(
+            model, SimpleNamespace(attention_inputs=attention)
+        )
+
+        self.assertIs(selected, kernel_ids)
+
+    def test_hybrid_tagged_inputs_select_draft_layer_group(self) -> None:
+        full = SimpleNamespace()
+        linear = SimpleNamespace()
+        layer_cache = SimpleNamespace(tag="full")
+        model = SimpleNamespace(
+            kv_cache=SimpleNamespace(
+                get_layer_cache_groups=lambda layer_idx: [layer_cache]
+            )
+        )
+        inputs = SimpleNamespace(attention_inputs={"linear0": linear, "full": full})
+
+        selected = Qwen3DSparkModel.dspark_attention_inputs(model, inputs)
+
+        self.assertIs(selected, full)
+
+    def test_cuda_graph_metadata_prefers_device_mirror(self) -> None:
+        host = torch.tensor([11, 12], dtype=torch.int32)
+        device_mirror = torch.tensor([21, 22], dtype=torch.int32)
+        attention = SimpleNamespace(
+            prefix_lengths=host,
+            prefix_lengths_device=device_mirror,
+        )
+
+        selected = device_metadata_tensor(attention, "prefix_lengths")
+
+        self.assertIs(selected, device_mirror)
+
+    def test_metadata_falls_back_for_eager_callers(self) -> None:
+        host = torch.tensor([11, 12], dtype=torch.int32)
+        attention = SimpleNamespace(
+            input_lengths=host,
+            input_lengths_device=torch.empty(0, dtype=torch.int32),
+        )
+
+        selected = device_metadata_tensor(attention, "input_lengths")
+
+        self.assertIs(selected, host)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/speculative/test/test_qwen3_dspark.py
+++ b/rtp_llm/models_py/speculative/test/test_qwen3_dspark.py
@@ -3,23 +3,138 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
 from rtp_llm.model_factory import ModelFactory
 from rtp_llm.model_factory_register import ModelDict, ensure_model_registered
-from rtp_llm.models.qwen_3_dspark import (
-    Qwen3DSpark,
-    dspark_offset_d2t_to_absolute,
-)
-from rtp_llm.models_py.model_desc.qwen3_dspark_model import Qwen3DSparkModel
+from rtp_llm.models.qwen_3_dspark import Qwen3DSpark, dspark_offset_d2t_to_absolute
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
-from rtp_llm.models_py.speculative.dspark_proposer_mixin import (
-    device_metadata_tensor,
+from rtp_llm.models_py.model_desc.qwen3 import Qwen3Model
+from rtp_llm.models_py.model_desc.qwen3_dspark_model import (
+    Qwen3DSparkModel,
+    _apply_non_interleaved_rope,
+    _write_rocm_paged_kv_cache,
 )
+from rtp_llm.models_py.speculative.dspark_proposer_mixin import device_metadata_tensor
+from rtp_llm.ops.compute_ops import PyAttentionInputs
 
 
 class Qwen3DSparkRegistrationTest(unittest.TestCase):
+    def test_torch_rope_matches_qwen_reference_and_preserves_tail(self) -> None:
+        positions = torch.tensor([0, 1, 7], dtype=torch.int32)
+        rope_dim = 4
+        head_dim = 6
+        inv_freq = 1.0 / (10_000.0 ** (torch.arange(0, rope_dim, 2).float() / rope_dim))
+        freqs = torch.outer(torch.arange(8).float(), inv_freq)
+        cache = torch.cat((freqs.cos(), freqs.sin()), dim=-1)
+        query = torch.arange(3 * 2 * head_dim, dtype=torch.float32).view(3, 2, head_dim)
+        key = (query[:, :1] + 0.5).clone()
+        expected_query = query.clone()
+        expected_key = key.clone()
+
+        def reference(tensor: torch.Tensor) -> None:
+            selected = cache[positions.long()]
+            cos = selected[:, : rope_dim // 2].unsqueeze(1)
+            sin = selected[:, rope_dim // 2 :].unsqueeze(1)
+            first = tensor[..., : rope_dim // 2].clone()
+            second = tensor[..., rope_dim // 2 : rope_dim].clone()
+            tensor[..., :rope_dim] = torch.cat(
+                (first * cos - second * sin, second * cos + first * sin), dim=-1
+            )
+
+        reference(expected_query)
+        reference(expected_key)
+        query_tail = query[..., rope_dim:].clone()
+        key_tail = key[..., rope_dim:].clone()
+
+        _apply_non_interleaved_rope(query, key, cache, positions, rope_dim)
+
+        torch.testing.assert_close(query, expected_query)
+        torch.testing.assert_close(key, expected_key)
+        torch.testing.assert_close(query[..., rope_dim:], query_tail)
+        torch.testing.assert_close(key[..., rope_dim:], key_tail)
+
+    def test_rocm_nonasm_context_cache_uses_aiter_physical_layout(self) -> None:
+        block_count, kv_heads, page_size, head_dim = 3, 2, 16, 16
+        cache = torch.zeros(
+            block_count,
+            2,
+            kv_heads,
+            page_size,
+            head_dim,
+            dtype=torch.bfloat16,
+        )
+        pages = torch.tensor([2, 0, 1], dtype=torch.long)
+        slots = torch.tensor([3, 9, 15], dtype=torch.long)
+        key = torch.arange(3 * kv_heads * head_dim, dtype=torch.bfloat16).view(
+            3, kv_heads, head_dim
+        )
+        value = key + 1000
+
+        _write_rocm_paged_kv_cache(
+            cache,
+            pages,
+            slots,
+            key,
+            value,
+            vectorized_value=False,
+        )
+
+        vector_size = 16 // cache.element_size()
+        key_physical = cache.view(
+            block_count,
+            2,
+            kv_heads,
+            head_dim // vector_size,
+            page_size,
+            vector_size,
+        )[:, 0]
+        value_physical = cache.view(
+            block_count, 2, kv_heads, head_dim, page_size
+        )[:, 1]
+        actual_key = key_physical[pages, :, :, slots, :].reshape_as(key)
+        actual_value = value_physical[pages, :, :, slots]
+        torch.testing.assert_close(actual_key, key)
+        torch.testing.assert_close(actual_value, value)
+
+    def test_draft_forward_uses_scalar_positions_then_restores_target_mrope(
+        self,
+    ) -> None:
+        model = Qwen3DSparkModel.__new__(Qwen3DSparkModel)
+        torch.nn.Module.__init__(model)
+        model.kv_cache = None
+
+        query_positions = torch.arange(6196, 6204, dtype=torch.long).view(1, 8)
+        target_mrope = query_positions.repeat_interleave(3).to(torch.int32)
+        original_target_mrope = target_mrope.clone()
+        attention = PyAttentionInputs()
+        attention.combo_position_ids = target_mrope
+        inputs = SimpleNamespace(attention_inputs=attention)
+        observed = []
+
+        def fake_qwen_forward(_model, forwarded_inputs, _fmha_impl):
+            observed.append(
+                forwarded_inputs.attention_inputs.combo_position_ids[:8].clone()
+            )
+            return SimpleNamespace(hidden_states=torch.ones(8, 4))
+
+        with patch.object(Qwen3Model, "forward", new=fake_qwen_forward):
+            hidden = model.forward_query_block(
+                torch.zeros(1, 8, dtype=torch.int32),
+                query_positions,
+                torch.tensor([6196], dtype=torch.int32),
+                torch.tensor([True]),
+                inputs,
+                fmha_impl=object(),
+            )
+
+        self.assertEqual(tuple(hidden.shape), (8, 4))
+        self.assertEqual(len(observed), 1)
+        torch.testing.assert_close(observed[0], query_positions.reshape(-1).int())
+        torch.testing.assert_close(target_mrope, original_target_mrope)
+
     def test_config_wires_shared_dspark_contract(self) -> None:
         raw = {
             "architectures": ["Qwen3DSparkForCausalLM"],
@@ -44,9 +159,7 @@ class Qwen3DSparkRegistrationTest(unittest.TestCase):
         self.assertEqual(config.dspark_target_layer_ids, [0, 1])
         self.assertEqual(config.dspark_markov_rank, 32)
         self.assertTrue(ensure_model_registered("qwen_3_dspark"))
-        self.assertEqual(
-            ModelDict.get_ft_model_type_by_config(raw), "qwen_3_dspark"
-        )
+        self.assertEqual(ModelDict.get_ft_model_type_by_config(raw), "qwen_3_dspark")
 
     def test_speculators_config_normalizes_vocab_and_layer_contract(self) -> None:
         raw = {
@@ -98,9 +211,7 @@ class Qwen3DSparkRegistrationTest(unittest.TestCase):
             capture_aux_hidden_layer_ids=None,
         )
 
-        ModelFactory._setup_dspark_configs(
-            sp_config, target_config, draft_config
-        )
+        ModelFactory._setup_dspark_configs(sp_config, target_config, draft_config)
 
         self.assertEqual(sp_config.sp_dspark_mask_token_id, 248127)
 
@@ -125,9 +236,7 @@ class Qwen3DSparkRegistrationTest(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, "unique and ordered"):
-            ModelFactory._setup_dspark_configs(
-                sp_config, target_config, draft_config
-            )
+            ModelFactory._setup_dspark_configs(sp_config, target_config, draft_config)
 
     @staticmethod
     def _capture_harness(layer_ids: tuple[int, ...]) -> SimpleNamespace:
@@ -244,6 +353,7 @@ class Qwen3DSparkRegistrationTest(unittest.TestCase):
         selected = device_metadata_tensor(attention, "input_lengths")
 
         self.assertIs(selected, host)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rtp_llm/models_py/triton_kernels/causal_conv1d/causal_conv1d.py
+++ b/rtp_llm/models_py/triton_kernels/causal_conv1d/causal_conv1d.py
@@ -702,6 +702,12 @@ def _causal_conv1d_update_kernel(
     #     return
 
     sequence_length = tl.load(sequence_lengths_ptr + idx_seq).to(tl.int32)
+    # CUDA graph replay rounds a live batch up to the next captured bucket and
+    # marks the extra rows with sequence_length == 0.  Do not derive a page
+    # offset for those rows: cal_block_idx(sequence_length - 1, ...) would be
+    # negative and read before the row's block-map storage.
+    if sequence_length <= 0:
+        return
     read_block_offset = cal_block_idx(sequence_length - 1, SEQ_SIZE_PER_BLOCK)
     read_block_id = tl.load(
         block_map_ptr + idx_seq * stride_block_map + read_block_offset

--- a/rtp_llm/models_py/triton_kernels/causal_conv1d/test/test_casual_conv1d_decode.py
+++ b/rtp_llm/models_py/triton_kernels/causal_conv1d/test/test_casual_conv1d_decode.py
@@ -70,6 +70,67 @@ def causal_conv1d_update_ref(
 
 
 class TestCausalConv1dUpdate(unittest.TestCase):
+    def test_cuda_graph_padding_row_does_not_touch_cache(self):
+        device = "cuda"
+        dtype = torch.bfloat16
+        valid_batch = 3
+        graph_batch = 4
+        seqlen = 8
+        dim = 256
+        width = 4
+        seq_size_per_block = 64
+        sequence_lengths = [130, 193, 257]
+
+        torch.manual_seed(17)
+        block_map = torch.zeros(
+            graph_batch, 16, dtype=torch.int32, device=device
+        )
+        next_block = 1
+        for row, sequence_length in enumerate(sequence_lengths):
+            block_count = math.ceil(sequence_length / seq_size_per_block) + seqlen
+            block_map[row, :block_count] = torch.arange(
+                next_block,
+                next_block + block_count,
+                dtype=torch.int32,
+                device=device,
+            )
+            next_block += block_count
+
+        x = torch.randn(graph_batch, dim, seqlen, dtype=dtype, device=device)
+        weight = torch.randn(dim, width, dtype=torch.float32, device=device)
+        cache_seed = torch.randn(
+            next_block, dim, width - 1, dtype=dtype, device=device
+        )
+        valid_cache = cache_seed.clone()
+        padded_cache = cache_seed.clone()
+
+        valid_out = causal_conv1d_update(
+            x[:valid_batch],
+            valid_cache,
+            weight,
+            activation="silu",
+            block_map=block_map[:valid_batch],
+            sequence_lengths=torch.tensor(
+                sequence_lengths, dtype=torch.int32, device=device
+            ),
+            seq_size_per_block=seq_size_per_block,
+        )
+        padded_out = causal_conv1d_update(
+            x,
+            padded_cache,
+            weight,
+            activation="silu",
+            block_map=block_map,
+            sequence_lengths=torch.tensor(
+                sequence_lengths + [0], dtype=torch.int32, device=device
+            ),
+            seq_size_per_block=seq_size_per_block,
+        )
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(padded_out[:valid_batch], valid_out)
+        torch.testing.assert_close(padded_cache, valid_cache)
+
     def test_causal_conv1d_update(self):
         itype = torch.bfloat16
         device = "cuda"

--- a/rtp_llm/models_py/triton_kernels/fla/fused_recurrent.py
+++ b/rtp_llm/models_py/triton_kernels/fla/fused_recurrent.py
@@ -87,6 +87,11 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
 
     if IS_CONTINUOUS_BATCHING:
         sequence_length = tl.load(sequence_lengths + i_n).to(tl.int64)
+        # Rounded-up CUDA graph buckets use zero-length tail rows.  They own no
+        # cache page, so reject them before calculating or loading a block-map
+        # offset.  This mirrors the variable-length T <= 0 contract below.
+        if sequence_length <= 0:
+            return
     else:
         # not used
         sequence_length = 0

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_decode.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_decode.py
@@ -187,6 +187,98 @@ def test_fused_recurrent_narrow_block_map_view():
     assert_close("narrow cache", contiguous_cache, narrow_cache, 0.0)
 
 
+def test_fused_recurrent_cuda_graph_padding_row_does_not_touch_cache():
+    device = "cuda"
+    dtype = torch.bfloat16
+    valid_batch = 3
+    graph_batch = 4
+    seqlen = 8
+    heads = 2
+    value_heads = 2
+    dim = 32
+    seq_size_per_block = 64
+    sequence_lengths = [130, 193, 257]
+
+    torch.manual_seed(23)
+    q = torch.randn(graph_batch, seqlen, heads, dim, dtype=dtype, device=device)
+    k = torch.randn_like(q)
+    v = torch.randn(
+        graph_batch, seqlen, value_heads, dim, dtype=dtype, device=device
+    )
+    beta = torch.rand(
+        graph_batch, seqlen, value_heads, dtype=dtype, device=device
+    )
+    g = F.logsigmoid(
+        torch.rand(
+            graph_batch,
+            seqlen,
+            value_heads,
+            dtype=torch.float32,
+            device=device,
+        )
+    )
+
+    block_map = torch.zeros(
+        graph_batch, 16, dtype=torch.int32, device=device
+    )
+    next_block = 1
+    for row, sequence_length in enumerate(sequence_lengths):
+        block_count = math.ceil(sequence_length / seq_size_per_block) + seqlen
+        block_map[row, :block_count] = torch.arange(
+            next_block,
+            next_block + block_count,
+            dtype=torch.int32,
+            device=device,
+        )
+        next_block += block_count
+
+    cache_seed = torch.randn(
+        next_block,
+        value_heads,
+        dim,
+        dim,
+        dtype=torch.float32,
+        device=device,
+    )
+    valid_cache = cache_seed.clone()
+    padded_cache = cache_seed.clone()
+
+    valid_out, _ = fused_recurrent_gated_delta_rule(
+        q=q[:valid_batch],
+        k=k[:valid_batch],
+        v=v[:valid_batch],
+        beta=beta[:valid_batch],
+        g=g[:valid_batch],
+        initial_state=valid_cache,
+        block_map=block_map[:valid_batch],
+        sequence_lengths=torch.tensor(
+            sequence_lengths, dtype=torch.int32, device=device
+        ),
+        seq_size_per_block=seq_size_per_block,
+        use_qk_l2norm_in_kernel=True,
+        inplace_final_state=True,
+    )
+    padded_out, _ = fused_recurrent_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        initial_state=padded_cache,
+        block_map=block_map,
+        sequence_lengths=torch.tensor(
+            sequence_lengths + [0], dtype=torch.int32, device=device
+        ),
+        seq_size_per_block=seq_size_per_block,
+        use_qk_l2norm_in_kernel=True,
+        inplace_final_state=True,
+    )
+    torch.cuda.synchronize()
+
+    assert_close("padding output", valid_out, padded_out[:valid_batch], 0.0)
+    assert_close("padding cache", valid_cache, padded_cache, 0.0)
+
+
 if __name__ == "__main__":
     H = 16
     HV = 32
@@ -200,3 +292,4 @@ if __name__ == "__main__":
                 bs, seq, H, HV, D, scale, gate_logit_normalizer, torch.bfloat16
             )
     test_fused_recurrent_narrow_block_map_view()
+    test_fused_recurrent_cuda_graph_padding_row_does_not_touch_cache()

--- a/rtp_llm/ops/fused_rope_kvcache_op.py
+++ b/rtp_llm/ops/fused_rope_kvcache_op.py
@@ -43,16 +43,22 @@ class FusedRopeKVCachePrefillOpBase:
     def __init__(self, attn_configs: AttentionConfigs) -> None:
         self.attn_configs = attn_configs
 
+    def prepare_kv_cache_offset(
+        self, attn_inputs: PyAttentionInputs
+    ) -> Optional[torch.Tensor]:
+        """Build the device KV-offset table without preparing host scalars.
+
+        CUDA-graph replay only needs to refresh the page-table-derived offset.
+        Re-running ``prepare`` would also read length maxima back to the host,
+        although the captured RoPE launch geometry is unchanged.
+        """
+        block_ids = attn_inputs.kv_cache_kernel_block_id_device
+        if block_ids is None or block_ids.numel() == 0:
+            return None
+        return _get_fused_rope_kvcache().convert_offset_to_block_array(block_ids)
+
     def prepare(self, attn_inputs: PyAttentionInputs) -> FusedRopeAttnParams:
-        if (
-            attn_inputs.kv_cache_kernel_block_id_device is not None
-            and attn_inputs.kv_cache_kernel_block_id_device.numel() > 0
-        ):
-            kv_cache_offset = _get_fused_rope_kvcache().convert_offset_to_block_array(
-                attn_inputs.kv_cache_kernel_block_id_device
-            )
-        else:
-            kv_cache_offset = None
+        kv_cache_offset = self.prepare_kv_cache_offset(attn_inputs)
         kv_cache_offset_h = None  # not used
 
         # CP remaps explicit position IDs alongside the local token shard. Keep

--- a/rtp_llm/ops/librtp_compute_ops/__init__.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/__init__.pyi
@@ -390,6 +390,16 @@ class PyModelOutputs:
         Initialize with hidden states tensor
         """
 
+    @typing.overload
+    def __init__(
+        self,
+        hidden_states: torch.Tensor,
+        mtp_target_hidden_states: torch.Tensor,
+    ) -> None:
+        """
+        Initialize with hidden states and speculative target features
+        """
+
     @property
     def hidden_states(self) -> torch.Tensor:
         """
@@ -398,6 +408,15 @@ class PyModelOutputs:
 
     @hidden_states.setter
     def hidden_states(self, arg0: torch.Tensor) -> None: ...
+
+    @property
+    def mtp_target_hidden_states(self) -> torch.Tensor | None:
+        """
+        Optional target features consumed by speculative decoding
+        """
+
+    @mtp_target_hidden_states.setter
+    def mtp_target_hidden_states(self, arg0: torch.Tensor | None) -> None: ...
 
 class PyMultimodalInputs:
     def __init__(self) -> None: ...

--- a/rtp_llm/server/server_args/kv_cache_group_args.py
+++ b/rtp_llm/server/server_args/kv_cache_group_args.py
@@ -151,9 +151,12 @@ def init_kv_cache_group_args(parser, kv_cache_config):
         env_name="SSM_STATE_DTYPE",
         bind_to=(kv_cache_config, "ssm_state_dtype"),
         type=str,
-        choices=["bf16", "fp32"],
-        default="bf16",
-        help="线性注意力 SSM state 的数据类型。默认 bf16，可选 fp32 和 bf16。",
+        choices=["auto", "bf16", "fp32"],
+        default="auto",
+        help=(
+            "线性注意力 SSM state 的数据类型。默认 auto，优先采用模型配置；"
+            "模型未声明或 remote cache 需要连续共享池时使用 bf16，也可显式指定 fp32 或 bf16。"
+        ),
     )
     kv_cache_group.add_argument(
         "--test_block_num",

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -16,6 +16,14 @@ py_test(
     ],
 )
 
+py_test(
+    name = "comparison_utils_test",
+    srcs = [
+        "comparison_utils.py",
+        "comparison_utils_test.py",
+    ],
+)
+
 exports_files([
     "entry.py",
     "data/prompt_candidates.json",

--- a/rtp_llm/test/smoke/comparison_utils.py
+++ b/rtp_llm/test/smoke/comparison_utils.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+
+def integer_within_tolerance(
+    expected: int, actual: Optional[int], tolerance: int
+) -> bool:
+    if tolerance < 0:
+        raise ValueError("integer comparison tolerance must be non-negative")
+    return actual is not None and abs(actual - expected) <= tolerance

--- a/rtp_llm/test/smoke/comparison_utils_test.py
+++ b/rtp_llm/test/smoke/comparison_utils_test.py
@@ -1,0 +1,22 @@
+import unittest
+
+from comparison_utils import integer_within_tolerance
+
+
+class IntegerWithinToleranceTest(unittest.TestCase):
+    def test_accepts_exact_and_boundary_values(self):
+        self.assertTrue(integer_within_tolerance(44, 44, 1))
+        self.assertTrue(integer_within_tolerance(44, 43, 1))
+        self.assertTrue(integer_within_tolerance(44, 45, 1))
+
+    def test_rejects_missing_or_out_of_range_values(self):
+        self.assertFalse(integer_within_tolerance(44, None, 1))
+        self.assertFalse(integer_within_tolerance(44, 46, 1))
+
+    def test_rejects_negative_tolerance(self):
+        with self.assertRaisesRegex(ValueError, "must be non-negative"):
+            integer_within_tolerance(44, 44, -1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.json
+++ b/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.json
@@ -165,6 +165,7 @@
                 "finished": true,
                 "aux_info": {
                     "iter_count": 44,
+                    "iter_count_tolerance": 2,
                     "output_len": 50,
                     "input_len": 58
                 }

--- a/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.query_7.json
+++ b/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.query_7.json
@@ -24,6 +24,7 @@
     "output_len": 50,
     "step_output_len": 50,
     "iter_count": 44,
+    "iter_count_tolerance": 2,
     "cum_log_probs": [],
     "beam_responses": [],
     "pd_sep": false,

--- a/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_moe_vl_fp8.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_moe_vl_fp8.json
@@ -33,7 +33,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "The user wants a description of the provided image.\n\n1.  **Identify the main subjects:** A woman and a dog.\n2.  **Identify the setting:** A sandy beach with the ocean in the background. The lighting suggests late afternoon or sunset (golden hour).\n3.  **Describe the action:** The woman is sitting on the sand. The dog is sitting opposite her. They are interacting, specifically doing a \"high five\" or \"shake\" trick. The",
+                            "content": "The user wants a description of the provided image.\n\n1.  **Identify the main subjects:** A woman and a dog.\n2.  **Identify the setting:** A sandy beach with the ocean in the background. The lighting suggests late afternoon or sunset (golden hour).\n3.  **Describe the action:** The dog is sitting and giving its paw to the woman. The woman is holding the paw. They are looking at each other and smiling.\n4.  **",
                             "partial": false
                         },
                         "finish_reason": "length"
@@ -44,6 +44,7 @@
                     "total_tokens": 2873,
                     "completion_tokens": 100,
                     "prompt_tokens_details": {
+                        "cached_tokens": 2048,
                         "image_tokens": 2752
                     }
                 }

--- a/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_nvfp4_py_dp2_ll_cg_sm100_arm.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_nvfp4_py_dp2_ll_cg_sm100_arm.json
@@ -1,16 +1,12 @@
 {
     "_comment": [
-        "The two queries below legitimately expect different completions: query 0 runs at",
-        "batch 1 and emits an empty <think> block, query 1 runs at batch 3 and emits a",
-        "reasoning trace. Both values are the observed GB200 output, captured from the",
-        "smoke_actual artifact of run 65789165 (case next_moe_nvfp4_deepep_ll_cudagraph_dp2_sm100).",
-        "The divergence is batch-size dependence of this configuration, not a mis-recorded",
-        "golden: --use_deepep_low_latency 1 with --dp_size 2 routes experts per batch, and",
-        "--decode_capture_config '1,2,3,4' captures a separate CUDA graph per batch size, so",
-        "batch 1 and batch 3 take different kernels and can diverge on the first sampled token",
-        "even at top_k=1. The TP2 sibling (q_r_35b_nvfp4_py_tp2_cg_sm100_arm.json) has no",
-        "DeepEP dispatch and stays identical across both batch sizes.",
-        "To reproduce: run the case twice, once with only query 0 and once with only query 1."
+        "Regenerated from the smoke_actual artifacts of runs 71439644 and 71441736, case",
+        "next_moe_nvfp4_deepep_ll_cudagraph_dp2_sm100. Both runs produced the same responses",
+        "after SSM_STATE_DTYPE defaulted to auto and preserved this checkpoint's",
+        "mamba_ssm_dtype=float32 instead of overriding it with BF16.",
+        "With the model-declared FP32 recurrent state, both batch 1 and batch 3 emit the",
+        "same completion. This DP2 configuration still has a separate golden from its TP2",
+        "sibling because it uses DeepEP low-latency expert dispatch."
     ],
     "model_type": "qwen35_moe",
     "model_path": "/mnt/nas1/smoke/Qwen3.5-35B-A3B-NVFP4-reshard",
@@ -45,13 +41,13 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\n<think>\nOkay, the user asked me to introduce myself. Let me start by recalling my identity"
+                        "response": "\n\n<think>\n\n</think>\n\nHello! I'm **Qwen3.5**, the latest large language"
                     },
                     {
-                        "response": "\n\n<think>\nOkay, the user asked me to introduce myself. Let me start by recalling my identity"
+                        "response": "\n\n<think>\n\n</think>\n\nHello! I'm **Qwen3.5**, the latest large language"
                     },
                     {
-                        "response": "\n\n<think>\nOkay, the user asked me to introduce myself. Let me start by recalling my identity"
+                        "response": "\n\n<think>\n\n</think>\n\nHello! I'm **Qwen3.5**, the latest large language"
                     }
                 ]
             }

--- a/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_nvfp4_py_tp2_cg_sm100_arm.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/q_r_35b_nvfp4_py_tp2_cg_sm100_arm.json
@@ -1,13 +1,12 @@
 {
     "_comment": [
-        "Regenerated from the smoke_actual artifact of run 65789165, case",
-        "next_moe_nvfp4_cudagraph_tp2_sm100. Goldens were matched to files by case name, so",
-        "this file and its DP2 sibling (q_r_35b_nvfp4_py_dp2_ll_cg_sm100_arm.json) are not",
-        "interchanged even though their expected text differs.",
-        "Unlike the DP2 sibling, this configuration is batch-invariant: TP2 has no DeepEP",
-        "dispatch, so batch 1 and batch 3 take the same expert routing and all four slots",
-        "expect identical output. See the DP2 file's _comment for why that one legitimately",
-        "diverges across batch sizes."
+        "Regenerated from the smoke_actual artifacts of runs 71439644 and 71441736, case",
+        "next_moe_nvfp4_cudagraph_tp2_sm100. Both runs produced the same responses after",
+        "SSM_STATE_DTYPE defaulted to auto and preserved this checkpoint's",
+        "mamba_ssm_dtype=float32 instead of overriding it with BF16.",
+        "This TP2 configuration remains batch-invariant: batch 1 and batch 3 all produce",
+        "the same completion. The DP2 sibling uses DeepEP low-latency expert dispatch and",
+        "therefore retains a separate, configuration-specific golden."
     ],
     "model_type": "qwen35_moe",
     "model_path": "/mnt/nas1/smoke/Qwen3.5-35B-A3B-NVFP4-reshard",
@@ -23,7 +22,7 @@
                 }
             },
             "result": {
-                "response": "\n\n<think>\n\n</think>\n\nHello! I'm **Qwen3.5**, the latest large language",
+                "response": "\n\n<think>\nOkay, the user asked me to introduce myself. Let me start by recalling my identity",
                 "finished": true
             }
         },
@@ -42,13 +41,13 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\n<think>\n\n</think>\n\nHello! I'm **Qwen3.5**, the latest large language"
+                        "response": "\n\n<think>\nOkay, the user asked me to introduce myself. Let me start by recalling my identity"
                     },
                     {
-                        "response": "\n\n<think>\n\n</think>\n\nHello! I'm **Qwen3.5**, the latest large language"
+                        "response": "\n\n<think>\nOkay, the user asked me to introduce myself. Let me start by recalling my identity"
                     },
                     {
-                        "response": "\n\n<think>\n\n</think>\n\nHello! I'm **Qwen3.5**, the latest large language"
+                        "response": "\n\n<think>\nOkay, the user asked me to introduce myself. Let me start by recalling my identity"
                     }
                 ]
             }

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_tp2_load_quant.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_tp2_load_quant.json
@@ -22,7 +22,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate).\n    *   **Goal:** The questions should be thought-provoking,",
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** The questions should be thought-prov",
                             "partial": false
                         },
                         "finish_reason": "length"

--- a/rtp_llm/test/smoke/data/model/qwen3_next/dash_basic.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/dash_basic.json
@@ -15,7 +15,7 @@
                 "request_id": "smoke_dash_basic"
             },
             "result": {
-                "response": "\n\nThis is a simple example of a web application built with the\n[Fl",
+                "response": "\n\nThis is a simple example of a web application using the\n[Flask",
                 "finish_reason": 1,
                 "prompt_token_num": 4,
                 "prompt_cached_token_num": 0
@@ -34,7 +34,7 @@
                 "request_id": "smoke_dash_return_input_ids"
             },
             "result": {
-                "response": "\n\n\nThis PR adds a check to the",
+                "response": "\n\n\nThis PR adds a check to ensure",
                 "finish_reason": 1,
                 "prompt_token_ids": [
                     40860,
@@ -82,7 +82,7 @@
                 "request_id": "smoke_dash_cancel_after_first_response"
             },
             "result": {
-                "response": "",
+                "response": "\n",
                 "cancelled": true
             }
         }

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_cuda_graph.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_cuda_graph.json
@@ -22,7 +22,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate).\n    *   **Goal:** The questions should be thought-provoking,",
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** The questions should be thought-prov",
                             "partial": false
                         },
                         "finish_reason": "length"

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2.json
@@ -22,7 +22,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** The questions should be thought-prov",
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate).\n    *   **Goal:** The questions should be thought-provoking,",
                             "partial": false
                         },
                         "finish_reason": "length"

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
@@ -48,7 +48,7 @@
                 "debug_info": null,
                 "aux_info": {
                     "cost_time": 3143.197,
-                    "iter_count": 25,
+                    "iter_count": 27,
                     "prefix_len": 0,
                     "input_len": 18,
                     "output_len": 100,
@@ -169,7 +169,7 @@
                 "_prompt_source": "chat-template wrapping $prompt:l2"
             },
             "result": {
-                "response": "<think>\nHere's a thinking process that leads to the suggested revisions:\n\n1.  **An",
+                "response": "<think>\n\n</think>\n\n这是一份经过深度润色和逻辑重构的文本。我提供了两个版本",
                 "response_alternatives": null,
                 "hidden_states": null,
                 "logits": null,
@@ -193,7 +193,7 @@
                     "decode_memory_reuse_len": 0,
                     "output_len": 20,
                     "step_output_len": 20,
-                    "iter_count": 6,
+                    "iter_count": 7,
                     "cum_log_probs": [],
                     "beam_responses": [],
                     "pd_sep": false,

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_cudagraph.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_cudagraph.json
@@ -23,7 +23,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate).\n    *   **Goal:** The questions should be thought-provoking,",
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** The questions should be thought-prov",
                             "partial": false
                         },
                         "finish_reason": "length"

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_pd.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_pd.json
@@ -18,7 +18,7 @@
                 "_prompt_source": "chat-template wrapping $prompt:l2"
             },
             "result": {
-                "response": "<think>\n\n</think>\n\n这是一份经过深度润色和逻辑重构的文本。我提供了两个版本",
+                "response": "<think>\nHere's a thinking process that leads to the suggested revisions:\n\n1.  **An",
                 "response_alternatives": null,
                 "hidden_states": null,
                 "logits": null,
@@ -42,7 +42,7 @@
                     "decode_memory_reuse_len": 0,
                     "output_len": 20,
                     "step_output_len": 19,
-                    "iter_count": 7,
+                    "iter_count": 6,
                     "cum_log_probs": [],
                     "beam_responses": [],
                     "pd_sep": true,
@@ -66,7 +66,7 @@
                 "_prompt_source": "chat-template wrapping $prompt:l2"
             },
             "result": {
-                "response": "<think>\n\n</think>\n\n这是一份经过深度润色和逻辑重构的文本。我提供了两个版本",
+                "response": "<think>\nHere's a thinking process that leads to the suggested revisions:\n\n1.  **An",
                 "response_alternatives": null,
                 "hidden_states": null,
                 "logits": null,
@@ -90,7 +90,7 @@
                     "decode_memory_reuse_len": 0,
                     "output_len": 20,
                     "step_output_len": 19,
-                    "iter_count": 7,
+                    "iter_count": 6,
                     "cum_log_probs": [],
                     "beam_responses": [],
                     "pd_sep": true,
@@ -114,7 +114,7 @@
                 "_prompt_source": "chat-template wrapping $prompt:l2"
             },
             "result": {
-                "response": "<think>\n\n</think>\n\n这是一份经过深度润色和逻辑重构的文本。我提供了两个版本",
+                "response": "<think>\nHere's a thinking process that leads to the suggested revisions:\n\n1.  **An",
                 "response_alternatives": null,
                 "hidden_states": null,
                 "logits": null,
@@ -138,7 +138,7 @@
                     "decode_memory_reuse_len": 0,
                     "output_len": 20,
                     "step_output_len": 19,
-                    "iter_count": 7,
+                    "iter_count": 6,
                     "cum_log_probs": [],
                     "beam_responses": [],
                     "pd_sep": true,

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_reuse_cache.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_reuse_cache.json
@@ -19,7 +19,56 @@
                 "_prompt_source": "chat-template wrapping $prompt:l2"
             },
             "result": {
-                "response": "<think>\nHere's a thinking process that leads to the suggested revisions:\n\n1.  **An",
+                "response": "<think>\n\n</think>\n\n这是一份经过深度润色和逻辑重构的文本。我提供了两个版本",
+                "response_alternatives": null,
+                "hidden_states": null,
+                "logits": null,
+                "loss": null,
+                "input_ids": null,
+                "output_ids": null,
+                "aux_info": {
+                    "input_len": 465,
+                    "prefix_len": 0,
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "output_len": 20,
+                    "step_output_len": 20,
+                    "iter_count": 7,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "pd_sep": false,
+                    "softmax_probs": []
+                }
+            }
+        },
+        {
+            "query": {
+                "top_p": 0,
+                "yield_generator": false,
+                "generate_config": {
+                    "top_p": 0,
+                    "max_new_tokens": 20,
+                    "top_k": 1,
+                    "temperature": 0,
+                    "random_seed": 42
+                },
+                "top_k": 1,
+                "temperature": 0,
+                "prompt": "<|im_start|>user\n润色一下，使其更通顺，更有逻辑，更有专业性：In addition, the Doushantuo phosphorites are characterized by their rich microfossils and a certain amount of organic matter, which suggest that microbial degradation of organic matter could have been a crucial factor in facilitating the precipitation of phosphate in Zhangcunping phosphorites. However, it is important to note that the δ13Ccarb values of lower phosphorites (ca. -2.47‰) are lighter than those of upper phosphorites (ca. -0.71‰). This difference may be attributed the potential variation in the organic matter degradation process.\nOrganic matter degradation in marine sediments is mediated by a series of microbial redox reactions that decrease in energy yield, ranging from oxic respiration, denitrification, Mn reduction, Fe reduction, sulfate reduction, and methanogenesis (Jarvis et al., 1994; Pufahl and Groat, 2017). The lower phosphorites were formed in an anoxic water column where oxygen in overlying water was limited. In this scenario, bacteria-driven breakdown of organic matter is very efficient especially in the presence of microbial sulfate reduction (Arning et al., 2009; Hiatt et al., 2015). The presence of pyrite framboids in lower phosphorites is indicative of an authigenic microbial origin and suggests the presence of sulfate, which fuels sulfate reduction (Hiatt et al., 2015; Hiatt et al., 2020). The increased supply of sulfate from oxidative weathering into the Ediacaran ocean (Laakso et al., 2020) likely fueled the microbial sulfate reduction and, thus organic matter degradation (Chen et al., 2022). Pyrite precipitates in the zone of sulfate reduction when ferrous Fe from Fe(oxyhydr)oxides dissolution combines with bacterially reduced sulfide (Pufahl, 2010). In addition, the observation of sulfur bacteria in Zhangcunping lower phosphorites supports our view (Bailey et al., 2013).<|im_end|>\n<|im_start|>assistant\n",
+                "_prompt_source": "chat-template wrapping $prompt:l2"
+            },
+            "result": {
+                "response": "<think>\n\n</think>\n\n这是一份经过深度润色和逻辑重构的文本。我提供了两个版本",
                 "response_alternatives": null,
                 "hidden_states": null,
                 "logits": null,
@@ -68,56 +117,7 @@
                 "_prompt_source": "chat-template wrapping $prompt:l2"
             },
             "result": {
-                "response": "<think>\nHere's a thinking process that leads to the suggested revisions:\n\n1.  **An",
-                "response_alternatives": null,
-                "hidden_states": null,
-                "logits": null,
-                "loss": null,
-                "input_ids": null,
-                "output_ids": null,
-                "aux_info": {
-                    "input_len": 465,
-                    "prefix_len": 0,
-                    "reuse_len": 0,
-                    "local_reuse_len": 0,
-                    "remote_reuse_len": 0,
-                    "memory_reuse_len": 0,
-                    "prefill_total_reuse_len": 0,
-                    "prefill_local_reuse_len": 0,
-                    "prefill_remote_reuse_len": 0,
-                    "prefill_memory_reuse_len": 0,
-                    "decode_total_reuse_len": 0,
-                    "decode_local_reuse_len": 0,
-                    "decode_remote_reuse_len": 0,
-                    "decode_memory_reuse_len": 0,
-                    "output_len": 20,
-                    "step_output_len": 20,
-                    "iter_count": 6,
-                    "cum_log_probs": [],
-                    "beam_responses": [],
-                    "pd_sep": false,
-                    "softmax_probs": []
-                }
-            }
-        },
-        {
-            "query": {
-                "top_p": 0,
-                "yield_generator": false,
-                "generate_config": {
-                    "top_p": 0,
-                    "max_new_tokens": 20,
-                    "top_k": 1,
-                    "temperature": 0,
-                    "random_seed": 42
-                },
-                "top_k": 1,
-                "temperature": 0,
-                "prompt": "<|im_start|>user\n润色一下，使其更通顺，更有逻辑，更有专业性：In addition, the Doushantuo phosphorites are characterized by their rich microfossils and a certain amount of organic matter, which suggest that microbial degradation of organic matter could have been a crucial factor in facilitating the precipitation of phosphate in Zhangcunping phosphorites. However, it is important to note that the δ13Ccarb values of lower phosphorites (ca. -2.47‰) are lighter than those of upper phosphorites (ca. -0.71‰). This difference may be attributed the potential variation in the organic matter degradation process.\nOrganic matter degradation in marine sediments is mediated by a series of microbial redox reactions that decrease in energy yield, ranging from oxic respiration, denitrification, Mn reduction, Fe reduction, sulfate reduction, and methanogenesis (Jarvis et al., 1994; Pufahl and Groat, 2017). The lower phosphorites were formed in an anoxic water column where oxygen in overlying water was limited. In this scenario, bacteria-driven breakdown of organic matter is very efficient especially in the presence of microbial sulfate reduction (Arning et al., 2009; Hiatt et al., 2015). The presence of pyrite framboids in lower phosphorites is indicative of an authigenic microbial origin and suggests the presence of sulfate, which fuels sulfate reduction (Hiatt et al., 2015; Hiatt et al., 2020). The increased supply of sulfate from oxidative weathering into the Ediacaran ocean (Laakso et al., 2020) likely fueled the microbial sulfate reduction and, thus organic matter degradation (Chen et al., 2022). Pyrite precipitates in the zone of sulfate reduction when ferrous Fe from Fe(oxyhydr)oxides dissolution combines with bacterially reduced sulfide (Pufahl, 2010). In addition, the observation of sulfur bacteria in Zhangcunping lower phosphorites supports our view (Bailey et al., 2013).<|im_end|>\n<|im_start|>assistant\n",
-                "_prompt_source": "chat-template wrapping $prompt:l2"
-            },
-            "result": {
-                "response": "<think>\nHere's a thinking process that leads to the suggested revisions:\n\n1.  **An",
+                "response": "<think>\n\n</think>\n\n这是一份经过深度润色和逻辑重构的文本。我提供了两个版本",
                 "response_alternatives": null,
                 "hidden_states": null,
                 "logits": null,

--- a/rtp_llm/test/smoke/normal_comparer.py
+++ b/rtp_llm/test/smoke/normal_comparer.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from pydantic import BaseModel, ValidationError
 from smoke.base_comparer import BaseComparer
+from smoke.comparison_utils import integer_within_tolerance
 from smoke.common_def import ABS_PATH, REL_PATH, QueryStatus, SmokeException
 from smoke.utils import create_temporary_copy, save_hidden_states, save_logits
 
@@ -65,6 +66,7 @@ class AuxInfo(BaseModel):
     output_len: Optional[int] = None
     step_output_len: Optional[int] = None
     iter_count: Optional[int] = None
+    iter_count_tolerance: Optional[int] = None
     cum_log_probs: Optional[Union[List[float], List[None]]] = None
     beam_responses: Optional[List[str]] = None
     pd_sep: Optional[bool] = None
@@ -387,7 +389,6 @@ class NormalComparer(BaseComparer):
             "reuse_len",
             "output_len",
             "step_output_len",
-            "iter_count",
             "pd_sep",
             "local_reuse_len",
             "remote_reuse_len",
@@ -404,6 +405,27 @@ class NormalComparer(BaseComparer):
             expect_val = getattr(expect_aux, field)
             actual_val = getattr(actual_aux, field)
             check_equal(field, expect_val, actual_val)
+
+        if expect_aux.iter_count is not None:
+            tolerance = expect_aux.iter_count_tolerance or 0
+            actual_iter_count = actual_aux.iter_count
+            try:
+                iter_count_matches = integer_within_tolerance(
+                    expect_aux.iter_count, actual_iter_count, tolerance
+                )
+            except ValueError as error:
+                diffs.append(
+                    f"{prefix}aux_info.iter_count_tolerance: {error}"
+                )
+            else:
+                if not iter_count_matches:
+                    lower = expect_aux.iter_count - tolerance
+                    upper = expect_aux.iter_count + tolerance
+                    diffs.append(
+                        f"{prefix}aux_info.iter_count:\n"
+                        f"    expect: {expect_aux.iter_count} (allowed range: [{lower}, {upper}])\n"
+                        f"    actual:  {repr(actual_iter_count)}"
+                    )
 
         check_equal(
             "beam_responses", expect_aux.beam_responses, actual_aux.beam_responses

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -454,6 +454,9 @@ def h20_oss_suites():
             ),
             smoke_test(
                 name="eagle_mtp_cudagraph_concurrent",
+                # H20 concurrent runs have produced 44 through 46 iterations for
+                # query 7 with identical output tokens. Keep a bounded ±2
+                # assertion so a collapse toward output_len=50 still fails.
                 task_info="data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.json",
                 smoke_args="--max_seq_len 16384 --ft_disable_custom_ar 1 --eplb_mode NONE --redundant_expert 0 --act_type FP16 --concurrency_limit 16 --frontend_server_count 1 --warm_up 0 --reserver_runtime_mem_mb 42000 --seq_size_per_block 64 --enable_xqa 1 --sp_type eagle --gen_num_per_cycle 4 --sp_model_type qwen_2-mtp --sp_checkpoint_path /mnt/nas1/mtp_reg/qwen2_14b_draft/ --sp_act_type FP16 --decode_capture_config '1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16' --prefill_capture_config '80:1' --enable_cuda_graph 1 --tp_size 2",
                 envs=["NCCL_DISABLE_ABORT=1", "NCCL_DEBUG=INFO", "LOG_LEVEL=INFO"],

--- a/rtp_llm/utils/model_weight.py
+++ b/rtp_llm/utils/model_weight.py
@@ -1480,13 +1480,16 @@ class W:
 
     # DSV4 DSpARK-only globals.  The three decoder stages continue to use
     # the regular v4_* per-layer tags with ``mtp.{i}`` checkpoint prefixes.
-    # These tensors form the target-feature combiner and the sequential
-    # Markov correction head around that shared V4 backbone.
+    # These tensors form the target-feature combiner around that shared V4 backbone.
     v4_dspark_main_norm = "v4.dspark.main_norm.weight"
     v4_dspark_main_proj_w = "v4.dspark.main_proj.weight"
     v4_dspark_main_proj_s = "v4.dspark.main_proj.scale"
-    v4_dspark_markov_w1 = "v4.dspark.markov_w1.weight"
-    v4_dspark_markov_w2 = "v4.dspark.markov_w2.weight"
+
+    # Model-agnostic DSpARK globals.
+    dspark_fc_w = "dspark_fc.weight"
+    dspark_hidden_norm_gamma = "dspark_hidden_norm.gamma"
+    dspark_markov_w1 = "dspark_markov_w1.weight"
+    dspark_markov_w2 = "dspark_markov_w2.weight"
 
     gpt_style_tp_strategy: Dict[str, Any] = {
         embedding: sp_neg1,
@@ -1673,8 +1676,10 @@ class W:
         v4_dspark_main_norm: sp_id,
         v4_dspark_main_proj_w: sp_id,
         v4_dspark_main_proj_s: sp_id,
-        v4_dspark_markov_w1: sp_id,
-        v4_dspark_markov_w2: sp_id,
+        dspark_fc_w: sp_id,
+        dspark_hidden_norm_gamma: sp_id,
+        dspark_markov_w1: sp_id,
+        dspark_markov_w2: sp_id,
     }
 
     weights_list = [


### PR DESCRIPTION
## Summary

- integrate the DFlash DSpARK runtime on the latest `main`
- add Qwen3 DSpARK execution support on ROCm
- make raw device-backed KV cache allocation work on ROCm/RDMA paths
- complete HIP graph padded-verify preparation and keep AITER graph workspace addresses stable
- honor per-model swizzle configuration and keep graph-captured Python modules alive
- retain the high-concurrency P/D admission hardening

## Branch and history safety

- immutable source branch: `feature/dflash-dspark-rocm` at `d765b110b126b3f0f946174484130eafd13d9d95`
- rebase target: `main` at `3df00496a58a129bf010dc28439a26b4df06af5d`
- the source branch was not rebased, amended, or force-pushed
- the pre-merge DSpARK history converged through `f661d6eb8`; its resulting content is represented here as one integration-base commit, followed by the eight post-merge commits rebased onto current main
- `d765b110b` is not replayed as a redundant helper: current main's generalized `buildGroupLoadPlan` implementation and `TailGroupReserveSlotsDoNotStarveTheLoad` / compact-state tests already cover that cache-key alignment fix

## Conflict resolution notes

The rebase preserves current-main lifecycle, telemetry, warmup, graph-shape, and host/device metadata behavior while applying the DSpARK/ROCm deltas. In particular:

- stream shutdown keeps main's terminal-error attribution and uses the bounded `finishOrCancel` path
- symmetric-memory initialization honors `FT_DISABLE_CUSTOM_AR` without restoring the unsafe rank-local catch-all fallback
- DSpARK commit keeps the host batch-size probe and uses device mirrors for graph-captured tensor math
- AITER graph buffers fail fast on shape/capacity changes instead of reallocating captured workspaces
- per-model swizzle overrides are combined with the shape guard for linear-attention BA weights

## Relationship to existing work

This is a combined ROCm superset integration and overlaps with #1249. It does not modify or close #1249, and keeps the original ROCm feature branch available as the full historical source. The earlier DSpARK stack also references #1107.

## Validation

Completed before opening this draft:

- [x] latest remote `main` is an ancestor of this branch
- [x] `git diff --check`
- [x] conflict-marker and forbidden-artifact scan
- [x] source branch SHA revalidated before and after push

Pending on the MI308 development host, in an isolated paired worktree and ROCm container:

- [ ] targeted DSpARK / MTP / cache / swizzle / AITER unit tests
- [ ] Model RPC and `th_transformer` builds
- [ ] graph-off and graph-on DSpARK smoke tests, including padded capture batches
- [ ] acceptance-rate and crash/assertion regression checks
